### PR TITLE
handle remoteAdbHost and remoteAdbPort from desired capabilities

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -39,6 +39,12 @@ var ADB = function (opts) {
   this.keyPassword = opts.keyPassword;
   this.adb = "adb";
   this.tmpDir = opts.tmpDir;
+  if (opts.remoteAdbHost) {
+    this.adb += " -H " + opts.remoteAdbHost;
+  }
+  if (opts.remoteAdbPort) {
+    this.adb += " -P " + opts.remoteAdbPort;
+  }
   this.adbCmd = this.adb;
   this.curDeviceId = null;
   this.emulatorPort = null;


### PR DESCRIPTION
Use remoteAdbHost and remoteAdbPort into desired capabilities variables to set the remote adb server address.

split from as #2250 in submodule adb
