### PR TITLE
Adding isSoftKeyboardPresent method

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1463,6 +1463,23 @@ ADB.prototype.isScreenLocked = function (cb) {
   });
 };
 
+ADB.prototype.isSoftKeyboardPresent = function (cb) {
+  var cmd = "dumpsys input_method";
+  this.shell(cmd, function (err, stdout) {
+    if (err) return cb(err);
+    var keyBoardShown = /mInputShown=\w+/gi.exec(stdout);
+    if (keyBoardShown && keyBoardShown[0]) {
+      if (keyBoardShown[0].split('=')[1] === 'true') {
+        cb(null, true);
+      } else {
+        cb(null, false);
+      }
+    } else {
+      cb(null, false);
+    }
+  });
+};
+
 ADB.prototype.sendTelnetCommand = function (command, cb) {
   logger.info("Sending telnet command to device: " + command);
   this.getEmulatorPort(function (err, port) {


### PR DESCRIPTION
related to Issue  #2021 in appium to hide keyboard only when it is present on the screen
