### PR TITLE
Replacing startApp parameters with options object

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1060,11 +1060,27 @@ ADB.prototype.killProcessByPID = function (pid, cb) {
   this.shell("kill " + pid, cb);
 };
 
-ADB.prototype.startApp = function (pkg, activity, action, category, flags, waitPkg, waitActivity, optionalIntentArguments, retry, stopApp,  cb) {
+ADB.prototype.startApp = function (startAppOptions) {
+  var pkg = startAppOptions.pkg;
+  var activity = startAppOptions.activity;
+  var action = startAppOptions.action;
+  var category = startAppOptions.category;
+  var flags = startAppOptions.flags;
+  // preventing null wait package
+  var waitPkg = startAppOptions.waitPkg || pkg;
+  var waitActivity = startAppOptions.waitActivity || false;
+  var optionalIntentArguments = startAppOptions.optionalIntentArguments ? " " + startAppOptions.optionalIntentArguments : "";
+  var retry = startAppOptions.retry;
+  var stopApp = startAppOptions.stopApp;
+  var cb = startAppOptions.cb;
 
-  // Prevent null wait package.
-  waitPkg = waitPkg || pkg;
-  optionalIntentArguments = optionalIntentArguments ? " " + optionalIntentArguments : "";
+  if (typeof retry === "undefined") {
+      retry = true;
+  }
+  if (typeof stopApp === "undefined") {
+      stopApp = true;
+  }
+
   var stop = stopApp ? "-S" : "";
   var cmd = "am start " + stop +
             " -a " + action +
@@ -1081,9 +1097,9 @@ ADB.prototype.startApp = function (pkg, activity, action, category, flags, waitP
       if (retry && activity[0] !== ".") {
         logger.info("We tried to start an activity that doesn't exist, " +
                     "retrying with . prepended to activity");
-        activity = "." + activity;
-        retry = false;
-        return this.startApp(pkg, activity, action, category, flags, waitPkg, waitActivity, optionalIntentArguments, retry, stopApp,  cb);
+        startAppOptions.activity = "." + activity;
+        startAppOptions.retry = false;
+        return this.startApp(startAppOptions);
       } else {
         var msg = "Activity used to start app doesn't exist or cannot be " +
                   "launched! Make sure it exists and is a launchable activity";


### PR DESCRIPTION
- Replacing startApp parameters with object, because of too many arguments and also neat way of handling optional parameters.
- In anticipation of (Issue 2026) [https://github.com/appium/appium/issues/2026]
