### PR TITLE
Refactoring startApp to add callback as a parameter and removing redundant varaibles

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1060,46 +1060,38 @@ ADB.prototype.killProcessByPID = function (pid, cb) {
   this.shell("kill " + pid, cb);
 };
 
-ADB.prototype.startApp = function (startAppOptions) {
-  var pkg = startAppOptions.pkg;
-  var activity = startAppOptions.activity;
-  var action = startAppOptions.action;
-  var category = startAppOptions.category;
-  var flags = startAppOptions.flags;
-  // preventing null wait package
-  var waitPkg = startAppOptions.waitPkg || pkg;
-  var waitActivity = startAppOptions.waitActivity || false;
-  var optionalIntentArguments = startAppOptions.optionalIntentArguments ? " " + startAppOptions.optionalIntentArguments : "";
-  var retry = startAppOptions.retry;
-  var stopApp = startAppOptions.stopApp;
-  var cb = startAppOptions.cb;
-
-  if (typeof retry === "undefined") {
-      retry = true;
-  }
-  if (typeof stopApp === "undefined") {
-      stopApp = true;
-  }
-
-  var stop = stopApp ? "-S" : "";
+ADB.prototype.startApp = function (startAppOptions, cb) {
+  startAppOptions = _.clone(startAppOptions);
+  // initializing defaults
+  _.defaults(startAppOptions, {
+      waitPkg: startAppOptions.pkg,
+      waitActivity: false,
+      optionalIntentArguments: false,
+      retry: true,
+      stopApp: true
+  });
+  // preventing null waitpkg
+  startAppOptions.waitPkg = startAppOptions.waitPkg || startAppOptions.pkg;
+  startAppOptions.optionalIntentArguments = startAppOptions.optionalIntentArguments ? " " + startAppOptions.optionalIntentArguments : "";
+  var stop = startAppOptions.stopApp ? "-S" : "";
   var cmd = "am start " + stop +
-            " -a " + action +
-            " -c " + category +
-            " -f " + flags +
-            " -n " + pkg + "/" + activity + optionalIntentArguments;
+            " -a " + startAppOptions.action +
+            " -c " + startAppOptions.category +
+            " -f " + startAppOptions.flags +
+            " -n " + startAppOptions.pkg + "/" + startAppOptions.activity + startAppOptions.optionalIntentArguments;
   this.shell(cmd, function (err, stdout) {
     if (err) return cb(err);
     if (stdout.indexOf("Error: Activity class") !== -1 &&
         stdout.indexOf("does not exist") !== -1) {
-      if (!activity) {
+      if (!startAppOptions.activity) {
         return cb(new Error("Parameter 'appActivity' is required for launching application"));
       }
-      if (retry && activity[0] !== ".") {
+      if (startAppOptions.retry && startAppOptions.activity[0] !== ".") {
         logger.info("We tried to start an activity that doesn't exist, " +
                     "retrying with . prepended to activity");
-        startAppOptions.activity = "." + activity;
+        startAppOptions.activity = "." + startAppOptions.activity;
         startAppOptions.retry = false;
-        return this.startApp(startAppOptions);
+        return this.startApp(startAppOptions, cb);
       } else {
         var msg = "Activity used to start app doesn't exist or cannot be " +
                   "launched! Make sure it exists and is a launchable activity";
@@ -1108,8 +1100,8 @@ ADB.prototype.startApp = function (startAppOptions) {
       }
     }
 
-    if (waitActivity) {
-      this.waitForActivity(waitPkg, waitActivity, cb);
+    if (startAppOptions.waitActivity) {
+      this.waitForActivity(startAppOptions.waitPkg, startAppOptions.waitActivity, cb);
     } else {
       cb();
     }


### PR DESCRIPTION
-Refactoring startApp to add callback as a parameter and removing redundant varaibles.
-Related to [#2026](https://github.com/appium/appium/issues/2026)
