### PR TITLE
Add missing IME method

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1565,6 +1565,14 @@ ADB.prototype.availableIMEs = function (cb) {
   });
 };
 
+ADB.prototype.defaultIME = function (cb) {
+  var cmd = 'settings get secure default_input_method';
+  this.shell(cmd, function (err, engine) {
+    if (err) return cb(err);
+    cb(null, engine.trim());
+  });
+};
+
 ADB.prototype.enableIME = function (imeId, cb) {
   var cmd = 'ime enable ' + imeId;
   this.shell(cmd, cb);


### PR DESCRIPTION
On looking through the spec, I realize I missed a [method to find the currently active input method](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/ime/active_engine).
