### PR TITLE
Replacing win-spawn with child_process spawn

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var spawn = require('win-spawn')
+var spawn = require('child_process').spawn
   , exec = require('child_process').exec
   , path = require('path')
   , fs = require('fs')

--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var spawn = require('win-spawn')
+var spawn = require('child_process').spawn
   , through = require('through')
   , EventEmitter = require('events').EventEmitter
   , util = require('util')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/appium/appium-adb",
   "dependencies": {
-    "win-spawn": "~2.0.0",
     "async": "~0.9.0",
     "ncp": "~0.5.1",
     "underscore": "~1.6.0",


### PR DESCRIPTION
-Related to [Process leak issue #2446](https://github.com/appium/appium/issues/2446) in windows 
-Tested on windows, now spawn works on windows for all exe commands.
-Now there should be no process leak in windows
