### PR TITLE
Retry restarting adb

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -942,17 +942,25 @@ ADB.prototype.waitForDevice = function (cb) {
     }.bind(this));
   }.bind(this);
 
-  doWait(function (err) {
+  var tries = 0;
+  var waitCb = function (err) {
     if (err) {
+      var lastCb = cb;
+      if (tries < 3) {
+        tries++;
+        logger.debug("Retrying restartAdb");
+        lastCb = waitCb.bind(this);
+      }
       this.restartAdb(function () {
         this.getConnectedDevices(function () {
-          doWait(cb);
+          doWait(lastCb);
         });
       }.bind(this));
     } else {
       cb(null);
     }
-  }.bind(this));
+  };
+  doWait(waitCb.bind(this));
 };
 
 ADB.prototype.restartAdb = function (cb) {


### PR DESCRIPTION
When "wait-for-device" or "echo 'ready'" fails, retry. This bypasses a periodic protocol error when calling these.
