### PR TITLE
Fixed problem running instrumentation with spaces in path to ADB

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1171,12 +1171,12 @@ ADB.prototype.androidCoverage = function (instrumentClass, waitPkg, waitActivity
    '-w',
    'com.example.Pkg/com.example.Pkg.instrumentation.MyInstrumentation' ]
    */
-  var args = this.adbCmd.split(' ').concat(('shell am instrument -e coverage true -w ' + instrumentClass).split(' '));
-  logger.debug("Collecting coverage data with: " + args.join(' '));
-  var adbPath = args.shift().replace(/\"/g, ''); // spawn fails on '"'
+  var command = /"(.+?)"/.exec(this.adbCmd)[1]; // spawn() on Windows accepts only executable path as a first argument
+  var args = ('-s ' + this.curDeviceId + ' shell am instrument -e coverage true -w ' + instrumentClass).split(' ');
+  logger.debug("Collecting coverage data with: " + command + " " + args.join(' '));
 
   var alreadyReturned = false;
-  this.instrumentProc = spawn(adbPath, args); // am instrument runs for the life of the app process.
+  this.instrumentProc = spawn(command, args); // am instrument runs for the life of the app process.
   this.instrumentProc.on('error', function (err) {
     logger.error(err);
     if (!alreadyReturned) {
@@ -1184,7 +1184,12 @@ ADB.prototype.androidCoverage = function (instrumentClass, waitPkg, waitActivity
       return cb(err);
     }
   });
-
+  this.instrumentProc.stderr.on('data', function (data) {
+    if (!alreadyReturned) {
+      alreadyReturned = true;
+      return cb(new Error("Failed to run instrumentation: " + new Buffer(data).toString('utf8')));
+    }
+  });
   this.waitForActivity(waitPkg, waitActivity, function (err) {
     if (!alreadyReturned) {
       alreadyReturned = true;


### PR DESCRIPTION
Fixed problem running instrumentation on Windows if path to ADB contains spaces (e.g. C:\Program Files).
Added instrumentation process error message output on spawn.
