### PR TITLE
Added build tools 19.1.0 and 20.0.0 support.

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -85,6 +85,8 @@ ADB.prototype.checkSdkBinaryPresent = function (binary, cb) {
         , '18.0.1'
         , '19.0.0'
         , '19.0.1'
+        , '19.1.0'
+        , '20.0.0'
         , 'android-4.2.2'
         , 'android-4.3'
         , 'android-4.4' ];


### PR DESCRIPTION
Appium could not find zipalign binary using latest build tools and platform tools.
