### PR TITLE
Adding method to check if apk has internet permission

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1626,4 +1626,20 @@ ADB.prototype.setIME = function (imeId, cb) {
   this.shell(cmd, cb);
 };
 
+ADB.prototype.hasInternetPermissionFromManifest = function (localApk, cb) {
+  this.checkAaptPresent(function (err) {
+    if (err) return cb(err);
+    var badging = [this.binaries.aapt, 'dump', 'badging', localApk].join(' ');
+    logger.debug("hasInternetPermissionFromManifest: " + badging);
+    exec(badging, { maxBuffer: 524288 }, function (err, stdout, stderr) {
+      if (err || stderr) {
+        logger.warn(stderr);
+        return cb(new Error("hasInternetPermissionFromManifest failed. " + err));
+      }
+      var hasInternetPermission = new RegExp("uses-permission:'android.permission.INTERNET'").test(stdout);
+      cb(null, hasInternetPermission);
+    });
+  }.bind(this));
+};
+
 module.exports = ADB;


### PR DESCRIPTION
- Method to check if internet permission is present
- It will be used when selendroid it is started as it is requirement for selendroid to work
- [#3146](https://github.com/appium/appium/issues/3146)
