### PR TITLE
Adding way to find build-tools more dynamically instead of whiltelisting

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -20,7 +20,8 @@ var spawn = require('child_process').spawn
   , temp = require('temp')
   , mv = require('mv')
   , helperJarPath = path.resolve(__dirname, '../jars')
-  , logger = require('./logger');
+  , logger = require('./logger')
+  , getDirectories = helpers.getDirectories;
 
 var ADB = function (opts) {
   if (!opts) {
@@ -79,19 +80,10 @@ ADB.prototype.checkSdkBinaryPresent = function (binary, cb) {
   if (this.sdkRoot) {
     var binaryLocs = [ path.resolve(this.sdkRoot, "platform-tools", binaryName)
         , path.resolve(this.sdkRoot, "tools", binaryName) ];
-
-    // put supported build tool dir names here
-    var supportedBuildToolDirs = [ '17.0.0'
-        , '18.0.1'
-        , '19.0.0'
-        , '19.0.1'
-        , '19.1.0'
-        , '20.0.0'
-        , 'android-4.2.2'
-        , 'android-4.3'
-        , 'android-4.4' ];
+    // getting all valid directories in build tool which can contain binary.
+    var buildToolDirs = getDirectories(path.resolve(this.sdkRoot, "build-tools"));
     // add the possible paths for supported build tools
-    _.each(supportedBuildToolDirs, function (versionDir) {
+    _.each(buildToolDirs, function (versionDir) {
         binaryLocs.push(path.resolve(this.sdkRoot, "build-tools", versionDir, binaryName));
       }.bind(this));
 
@@ -104,7 +96,7 @@ ADB.prototype.checkSdkBinaryPresent = function (binary, cb) {
                    "or supported build-tools under \"" + this.sdkRoot + "\"; " +
                    "do you have android SDK or build-tools installed into this " +
                    "location? Supported build tools are: " +
-                   supportedBuildToolDirs.join(', ')));
+                   buildToolDirs.join(', ')));
       return;
     }
     logger.debug("Using " + binary + " from " + binaryLoc);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -94,3 +94,14 @@ exports.getAndroidPlatform = function () {
   return res;
 };
 
+exports.getDirectories = function (rootPath) {
+  var files = fs.readdirSync(rootPath);
+  var dirs = [];
+  _.each(files, function (file) {
+      var pathString = path.resolve(rootPath, file);
+      if (fs.lstatSync(pathString).isDirectory()) dirs.push(file);
+  }.bind(this));
+  // It is not a clean way to sort it, but in this case would work fine because we have numerics and alphanumeric
+  // will return some thing like this ["17.0.0", "18.0.1", "19.0.0", "19.0.1", "19.1.0", "20.0.0", "android-4.2.2", "android-4.3", "android-4.4"]
+  return dirs.sort();
+};


### PR DESCRIPTION
- Added method to get valid directories in build-tools which might have binaries we are looking for
- Sorted so that we use binary from latest version
- [fix for #2985](https://github.com/appium/appium/issues/2985)
- Can use for also finding platforms which i can take up as other issue
