### PR TITLE
Fix some issues in Android 2.3 (API10)

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1082,38 +1082,41 @@ ADB.prototype.startApp = function (startAppOptions, cb) {
   // preventing null waitpkg
   startAppOptions.waitPkg = startAppOptions.waitPkg || startAppOptions.pkg;
   startAppOptions.optionalIntentArguments = startAppOptions.optionalIntentArguments ? " " + startAppOptions.optionalIntentArguments : "";
-  var stop = startAppOptions.stopApp ? "-S" : "";
-  var cmd = "am start " + stop +
-            " -a " + startAppOptions.action +
-            " -c " + startAppOptions.category +
-            " -f " + startAppOptions.flags +
-            " -n " + startAppOptions.pkg + "/" + startAppOptions.activity + startAppOptions.optionalIntentArguments;
-  this.shell(cmd, function (err, stdout) {
+  this.getApiLevel(function (err, apiLevel) {
     if (err) return cb(err);
-    if (stdout.indexOf("Error: Activity class") !== -1 &&
-        stdout.indexOf("does not exist") !== -1) {
-      if (!startAppOptions.activity) {
-        return cb(new Error("Parameter 'appActivity' is required for launching application"));
+    var stop = startAppOptions.stopApp && apiLevel >= 15 ? "-S" : "";
+    var cmd = "am start " + stop +
+              " -a " + startAppOptions.action +
+              " -c " + startAppOptions.category +
+              " -f " + startAppOptions.flags +
+              " -n " + startAppOptions.pkg + "/" + startAppOptions.activity + startAppOptions.optionalIntentArguments;
+    this.shell(cmd, function (err, stdout) {
+      if (err) return cb(err);
+      if (stdout.indexOf("Error: Activity class") !== -1 &&
+          stdout.indexOf("does not exist") !== -1) {
+        if (!startAppOptions.activity) {
+          return cb(new Error("Parameter 'appActivity' is required for launching application"));
+        }
+        if (startAppOptions.retry && startAppOptions.activity[0] !== ".") {
+          logger.debug("We tried to start an activity that doesn't exist, " +
+                       "retrying with . prepended to activity");
+          startAppOptions.activity = "." + startAppOptions.activity;
+          startAppOptions.retry = false;
+          return this.startApp(startAppOptions, cb);
+        } else {
+          var msg = "Activity used to start app doesn't exist or cannot be " +
+                    "launched! Make sure it exists and is a launchable activity";
+          logger.error(msg);
+          return cb(new Error(msg));
+        }
       }
-      if (startAppOptions.retry && startAppOptions.activity[0] !== ".") {
-        logger.debug("We tried to start an activity that doesn't exist, " +
-                    "retrying with . prepended to activity");
-        startAppOptions.activity = "." + startAppOptions.activity;
-        startAppOptions.retry = false;
-        return this.startApp(startAppOptions, cb);
-      } else {
-        var msg = "Activity used to start app doesn't exist or cannot be " +
-                  "launched! Make sure it exists and is a launchable activity";
-        logger.error(msg);
-        return cb(new Error(msg));
-      }
-    }
 
-    if (startAppOptions.waitActivity) {
-      this.waitForActivity(startAppOptions.waitPkg, startAppOptions.waitActivity, cb);
-    } else {
-      cb();
-    }
+      if (startAppOptions.waitActivity) {
+        this.waitForActivity(startAppOptions.waitPkg, startAppOptions.waitActivity, cb);
+      } else {
+        cb();
+      }
+    }.bind(this));
   }.bind(this));
 };
 


### PR DESCRIPTION
- Fix activity parsing regex in API10
  With API >= 15 the actual regex works fine, but in API10 mFocusedApp contains HistoryRecord instead of ActivityRecord, the focused app is not found and Appium fails with 'Error: io.appium.android.apis/.ApiDemos never started. Current: undefined/undefined'
  I have already added a new test in Appium to test regex in API10: https://github.com/appium/appium/pull/3200
- Fix app detection on the device in API10
  In API 10, the app is never found on the device and it's always reinstalled. The option '-3' in 'pm list packages' to show only third party packages exists for API15 and above, but not in API10.
- Fix unlock screen in API10
  It isn't possible to unlock the screen in API10. The unlock app starts with '-S' option, that only exists for API15 and above.
