### PR TITLE
Fix handling of certificate

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -531,6 +531,7 @@ ADB.prototype.checkApkKeystoreMatch = function (keytool, md5re, keystoreHash,
   var zip = new AdmZip(apk);
   var rsa = /^META-INF\/.*\.[rR][sS][aA]$/;
   var entries = zip.getEntries();
+  var numEntries = entries.length;
   var responded = false;
   var examined = 0;
 
@@ -543,7 +544,7 @@ ADB.prototype.checkApkKeystoreMatch = function (keytool, md5re, keystoreHash,
       } else if (matched) {
         responded = true;
         return cb(null, true);
-      } else if (examined === entries.length) {
+      } else if (examined === numEntries) {
         responded = true;
         return cb(null, false);
       }
@@ -558,11 +559,7 @@ ADB.prototype.checkApkKeystoreMatch = function (keytool, md5re, keystoreHash,
     logger.debug(' keystore MD5: ' + keystoreHash);
     var matchesKeystore = entryHash && entryHash === keystoreHash;
     logger.debug('Matches keystore? ' + matchesKeystore);
-    if (matchesKeystore) {
-      onExamine(null, true);
-    } else {
-      onExamine(null, false);
-    }
+    onExamine(null, matchesKeystore);
   };
 
   while (entries.length > 0) {


### PR DESCRIPTION
Keep the original length of the entries, since we're popping elements off. Otherwise signing fails.
