### PR TITLE
Fix handling of retry

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -162,7 +162,7 @@ ADB.prototype.exec = function (cmd, opts, cb) {
         if (protocolFaultError || deviceNotFoundError) {
           logger.info("error sending command, reconnecting device and retrying: " + cmd);
           return setTimeout(function () {
-            this.adb.getDevicesWithRetry(function (err, devices) {
+            this.getDevicesWithRetry(function (err, devices) {
               if (err) return _cb(new Error("Reconnect failed, devices are: " + devices));
               _cb(new Error(stderr)); // we've reconnected, so get back into the retry loop
             });
@@ -172,8 +172,8 @@ ADB.prototype.exec = function (cmd, opts, cb) {
       } else {
         cb(null, stdout, stderr); // shortcut retry and respond with success
       }
-    });
-  }, function (err) {
+    }.bind(this));
+  }.bind(this), function (err) {
     if (err) return cb(err); // if we retry too many times, we'll get the error here, the success case is handled in the retry loop
   });
 };


### PR DESCRIPTION
Inner function doesn't have `this` object. And `this.adb` in this file is the string representation of the path to the executable.
