### PR TITLE
Changed adb start cmd line construction to be more flexible.

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1081,6 +1081,30 @@ ADB.prototype.killProcessByPID = function (pid, cb) {
   this.shell("kill " + pid, cb);
 };
 
+var _buildStartCmd = function (startAppOptions, apiLevel) {
+  var cmd = "am start ";
+
+  cmd += startAppOptions.stopApp && apiLevel >= 15 ? "-S" : "";
+
+  if (startAppOptions.action) {
+    cmd += " -a " + startAppOptions.action;
+  }
+
+  if (startAppOptions.category) {
+    cmd += " -c " + startAppOptions.category;
+  }
+
+  if (startAppOptions.flags) {
+    cmd += " -f " + startAppOptions.flags;
+  }
+
+  if (startAppOptions.pkg) {
+    cmd += " -n " + startAppOptions.pkg + "/" + startAppOptions.activity + startAppOptions.optionalIntentArguments;
+  }
+
+  return cmd;
+};
+
 ADB.prototype.startApp = function (startAppOptions, cb) {
   startAppOptions = _.clone(startAppOptions);
   // initializing defaults
@@ -1096,12 +1120,9 @@ ADB.prototype.startApp = function (startAppOptions, cb) {
   startAppOptions.optionalIntentArguments = startAppOptions.optionalIntentArguments ? " " + startAppOptions.optionalIntentArguments : "";
   this.getApiLevel(function (err, apiLevel) {
     if (err) return cb(err);
-    var stop = startAppOptions.stopApp && apiLevel >= 15 ? "-S" : "";
-    var cmd = "am start " + stop +
-              " -a " + startAppOptions.action +
-              " -c " + startAppOptions.category +
-              " -f " + startAppOptions.flags +
-              " -n " + startAppOptions.pkg + "/" + startAppOptions.activity + startAppOptions.optionalIntentArguments;
+
+    var cmd = _buildStartCmd(startAppOptions, apiLevel);
+
     this.shell(cmd, function (err, stdout) {
       if (err) return cb(err);
       if (stdout.indexOf("Error: Activity class") !== -1 &&


### PR DESCRIPTION
This is related to appium/appium issue #2969.  I made a small change to make cmd line construction more flexible to allow for launching arbitrary apps that have fewer args.
