### PR TITLE
Changed logging messages related to ANDROID_HOME

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -79,13 +79,13 @@ ADB.prototype.checkSdkBinaryPresent = function (binary, cb) {
   }
   if (this.sdkRoot) {
     var binaryLocs = [ path.resolve(this.sdkRoot, "platform-tools", binaryName)
-        , path.resolve(this.sdkRoot, "tools", binaryName) ];
-    // getting all valid directories in build tool which can contain binary.
+      , path.resolve(this.sdkRoot, "tools", binaryName) ];
+    // get subpaths for currently installed build tool directories
     var buildToolDirs = getDirectories(path.resolve(this.sdkRoot, "build-tools"));
-    // add the possible paths for supported build tools
+
     _.each(buildToolDirs, function (versionDir) {
-        binaryLocs.push(path.resolve(this.sdkRoot, "build-tools", versionDir, binaryName));
-      }.bind(this));
+      binaryLocs.push(path.resolve(this.sdkRoot, "build-tools", versionDir, binaryName));
+    }.bind(this));
 
     _.each(binaryLocs, function (loc) {
       if (fs.existsSync(loc)) binaryLoc = loc;
@@ -94,9 +94,7 @@ ADB.prototype.checkSdkBinaryPresent = function (binary, cb) {
     if (binaryLoc === null) {
       cb(new Error("Could not find " + binary + " in tools, platform-tools, " +
                    "or supported build-tools under \"" + this.sdkRoot + "\"; " +
-                   "do you have android SDK or build-tools installed into this " +
-                   "location? Supported build tools are: " +
-                   buildToolDirs.join(', ')));
+                   "do you have the Android SDK installed at this location?"));
       return;
     }
     logger.debug("Using " + binary + " from " + binaryLoc);
@@ -104,15 +102,16 @@ ADB.prototype.checkSdkBinaryPresent = function (binary, cb) {
     this.binaries[binary] = binaryLoc;
     cb(null, binaryLoc);
   } else {
+    logger.warn("The ANDROID_HOME environment variable is not set to the Android SDK root directory path. " +
+                "ANDROID_HOME is required for compatibility with SDK 23+. Checking along PATH for " + binary + ".");
     exec(cmd + " " + binary, { maxBuffer: 524288 }, function (err, stdout) {
       if (stdout) {
         logger.debug("Using " + binary + " from " + stdout);
         this.binaries[binary] = '"' + stdout.trim() + '"';
         cb(null, this.binaries[binary]);
       } else {
-        cb(new Error("Could not find " + binary + "; do you have the Android " +
-                     "SDK installed and the tools + platform-tools folders " +
-                     "added to your PATH?"));
+        cb(new Error("Could not find " + binary + ". Please set the ANDROID_HOME " +
+                     "environment variable with the Android SDK root directory path."));
       }
     }.bind(this));
   }


### PR DESCRIPTION
This is just string changes and an additional log to better explain potential problems to users.

Currently we support 2 ways  of searching for binaries: one with ANDROID_HOME and one without.  Since we already document ANDROID_HOME as required for setup, we should reduce our complexity and remove the non-A_H code.  I'll create a ticket so we can discuss with the team.
