### PR TITLE
Add support for a 'waitDuration' option in startApp

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1144,7 +1144,11 @@ ADB.prototype.startApp = function (startAppOptions, cb) {
       }
 
       if (startAppOptions.waitActivity) {
-        this.waitForActivity(startAppOptions.waitPkg, startAppOptions.waitActivity, cb);
+        if (startAppOptions.hasOwnProperty("waitDuration")) {
+          this.waitForActivity(startAppOptions.waitPkg, startAppOptions.waitActivity, startAppOptions.waitDuration, cb);
+        } else {
+          this.waitForActivity(startAppOptions.waitPkg, startAppOptions.waitActivity, cb);
+        }
       } else {
         cb();
       }


### PR DESCRIPTION
This might be required for https://github.com/appium/appium/issues/780.
