### PR TITLE
Fix parsing of adb and args

### DIFF
--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -25,8 +25,15 @@ util.inherits(Logcat, EventEmitter);
 Logcat.prototype.startCapture = function (cb) {
   this.onLogcatStart = cb;
   logger.debug("Starting logcat capture");
-  var args = this.adbCmd.split(' ').concat(['logcat']);
-  var adbCmd = args.shift();
+
+  // get the adb command separate from the arguments to it
+  var cmd = "adb";
+  if (this.adbCmd.indexOf('adb.exe') !== -1) {
+    cmd = "adb.exe";
+  }
+  var adbCmd = this.adbCmd.substring(0, this.adbCmd.indexOf(cmd) + cmd.length);
+  var args = this.adbCmd.substring(this.adbCmd.indexOf(cmd) + cmd.length).split(' ');
+
   this.proc = spawn(adbCmd, args);
   this.proc.stdout.setEncoding('utf8');
   this.proc.stderr.setEncoding('utf8');


### PR DESCRIPTION
Rather than splitting the `adb` command on spaces, take the first part (the actual command) as everything up to an including `adb` or `adb.exe`, and parse the rest on spaces. This way there can be a space in the path to `adb`.

Fixes appium/appium#3673
