### PR TITLE
Fix activity name parsing #3758

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1287,14 +1287,12 @@ ADB.prototype.waitForActivityOrNot = function (pkg, activity, not,
   var intMs = 750
     , endAt = Date.now() + waitMs;
 
-  if (activity.indexOf(pkg) === 0) {
-    activity = activity.substring(pkg.length);
-  }
+  var activityRelativeName = helpers.getActivityRelativeName(pkg, activity);
 
   var checkForActivity = function (foundPackage, foundActivity) {
     var foundAct = false;
     if (foundPackage === pkg) {
-      _.each(activity.split(','), function (act) {
+      _.each(activityRelativeName.split(','), function (act) {
         act = act.trim();
         if (act === foundActivity || "." + act === foundActivity) {
           foundAct = true;
@@ -1315,7 +1313,7 @@ ADB.prototype.waitForActivityOrNot = function (pkg, activity, not,
         setTimeout(wait, intMs);
       } else {
         var verb = not ? "stopped" : "started";
-        var msg = pkg + "/" + activity + " never " + verb + ". Current: " +
+        var msg = pkg + "/" + activityRelativeName + " never " + verb + ". Current: " +
                   foundPackage + "/" + foundActivity;
         logger.error(msg);
         cb(new Error(msg));

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -133,3 +133,15 @@ exports.isScreenOnFully = function (dumpsys) {
     (m && m.length > 0 && m[0].split('=')[1] === 'true') || false;
 };
 
+exports.getActivityRelativeName = function (pkgName, activityRelativeName) {
+  var relativeName = activityRelativeName;
+
+  // need to beware of namespaces with overlapping chars:
+  //   com.foo.bar
+  //   com.foo.barx
+  if (activityRelativeName.indexOf(pkgName + ".") === 0) {
+    relativeName = activityRelativeName.substring(pkgName.length);
+  }
+
+  return relativeName;
+};

--- a/test/unit/helpers-specs.js
+++ b/test/unit/helpers-specs.js
@@ -40,5 +40,9 @@ describe('helpers', function () {
     helpers.isScreenOnFully(dumpsys).should.equal(true);
   });
 
+  it('getActivityRelativeName should handle package and activity names with overlapping, but unmatching namespaces', function () {
+    var pkg = "com.test.myapp";
+    helpers.getActivityRelativeName(pkg, "com.test.myapp35.Activity").should.eql("com.test.myapp35.Activity");
+    helpers.getActivityRelativeName(pkg, "com.test.myapp.Activity").should.eql(".Activity");
+  });
 });
-


### PR DESCRIPTION
Fixed Appium [issue 3758](https://github.com/appium/appium/issues/3758).  Code failed to account for cases where package and activity namespaces overlap but do not match, eg "com.foo.bar/com.foo.barf.WuTang".
