### PR TITLE
Make isSoftKeyboardPresent correctly detect keyboards with no UI

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1492,7 +1492,7 @@ ADB.prototype.isSoftKeyboardPresent = function (cb) {
   var cmd = "dumpsys input_method";
   this.shell(cmd, function (err, stdout) {
     if (err) return cb(err);
-    var keyBoardShown = /mInputShown=\w+/gi.exec(stdout);
+    var keyBoardShown = /mIsInputViewShown=\w+/gi.exec(stdout);
     if (keyBoardShown && keyBoardShown[0]) {
       if (keyBoardShown[0].split('=')[1] === 'true') {
         cb(null, true);


### PR DESCRIPTION
Currently, `isSoftKeyboardPresent` detects the presence of a keyboard by looking for `mInputShown=true` in the output of `dumpsys input_method`. However, this flag is `true` even in cases where there is no keyboard UI displayed, such as when using a hardware keyboard or the Appium UnicodeIME.

I looked at `dumpsys input_method` output for the following situations:
- [Software keyboard + stock IME](https://gist.github.com/amake/5daa9d869702acc38162) (safe to go back)
- [Software keyboard + UnicodeIME](https://gist.github.com/amake/038d8a661e3c2a56553f) (not safe)
- [Hardware keyboard + stock IME](https://gist.github.com/amake/6a12b97bf6f277f60883) (not safe)
- [Hardware keyboard + UnicodeIME](https://gist.github.com/amake/6a8f2b22e71a69c1b0dd) (not safe)

It appears that `mIsInputViewShown` is the correct flag to look at to determine if it is safe to use the back button. This flag is present back to at least API level 17 (I didn't check before that).

This patch switches the current implementation to use this flag instead. This would at least partially address these issues:
appium/appium#3884
appium/appium#3903
