### PR TITLE
Catch java.lang.SecurityException in activity launch

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1142,6 +1142,10 @@ ADB.prototype.startApp = function (startAppOptions, cb) {
           logger.error(msg);
           return cb(new Error(msg));
         }
+      } else if (stdout.indexOf("java.lang.SecurityException") !== -1) {
+        // if the app is disabled on a real device it will throw a security exception
+        logger.error("Permission to start activity denied.");
+        return cb(new Error("Permission to start activity denied."));
       }
 
       if (startAppOptions.waitActivity) {


### PR DESCRIPTION
When there are insufficient permissions for an activity to be launched on a real device (the only such condition I have found being the app is disabled) `adb` "throws" a `java.lang.SecurityException`. This addition deals with that case.

I have, however, been struggling with a way to test this. Without a rooted device, `adb` won't allow you to disable and enable apps. And on the emulator a disabled app is not seen by the launcher, so it comes out the same as if there were no such activity (a case we already handle).

Fixes appium/appium#3675.
