### PR TITLE
Make isSoftKeyboardPresent handle UI-less keyboards

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1492,16 +1492,17 @@ ADB.prototype.isSoftKeyboardPresent = function (cb) {
   var cmd = "dumpsys input_method";
   this.shell(cmd, function (err, stdout) {
     if (err) return cb(err);
-    var keyBoardShown = /mIsInputViewShown=\w+/gi.exec(stdout);
-    if (keyBoardShown && keyBoardShown[0]) {
-      if (keyBoardShown[0].split('=')[1] === 'true') {
-        cb(null, true);
-      } else {
-        cb(null, false);
+    var isKeyboardShown = false;
+    var canCloseKeyboard = false;
+    var inputShownMatch = /mInputShown=\w+/gi.exec(stdout);
+    if (inputShownMatch && inputShownMatch[0]) {
+      isKeyboardShown = inputShownMatch[0].split('=')[1] === 'true';
+      var isInputViewShownMatch = /mIsInputViewShown=\w+/gi.exec(stdout);
+      if (isInputViewShownMatch && isInputViewShownMatch[0]) {
+        canCloseKeyboard = isInputViewShownMatch[0].split('=')[1] === 'true';
       }
-    } else {
-      cb(null, false);
     }
+    cb(null, isKeyboardShown, canCloseKeyboard);
   });
 };
 


### PR DESCRIPTION
Currently `isSoftKeyboardPresent` will simply return `true` when an IME is present, whether or not the IME has a closeable UI. This is problematic because some kinds of keyboards (hardware keyboards, Appium UnicodeIME) are detected as "present" but have no UI to hide, thus leading `hideKeyboard` in `android-controller.js` to perform a back-button press when it's not safe to do so.

With the current behavior it is an error to attempt `hideKeyboard` when no keyboard is present at all. To retain this behavior, `isSoftKeyboardPresent` must return two pieces of information: whether or not a keyboard is present, and whether or not the keyboard is closeable.
