### PR TITLE
Change stop app to false on app launch

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1100,7 +1100,7 @@ ADB.prototype.startApp = function (startAppOptions, cb) {
       waitActivity: false,
       optionalIntentArguments: false,
       retry: true,
-      stopApp: true
+      stopApp: false
   });
   // preventing null waitpkg
   startAppOptions.waitPkg = startAppOptions.waitPkg || startAppOptions.pkg;


### PR DESCRIPTION
This is to enable tests from a suite, to run continuously without loosing context
