### PR TITLE
add JAVA_HOME env variable check 

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -497,6 +497,8 @@ ADB.prototype.checkCustomApkCert = function (apk, pkg, cb) {
   var h = "a-fA-F0-9";
   var md5Str = ['.*MD5.*((?:[', h, ']{2}:){15}[', h, ']{2})'].join('');
   var md5 = new RegExp(md5Str, 'mi');
+  if (!process.env.JAVA_HOME || !fs.exists(process.env.JAVA_HOME))
+      return cb(new Error("JAVA_HOME is not set: " + process.env.JAVA_HOME));
   var keytool = path.resolve(process.env.JAVA_HOME, 'bin', 'keytool');
   keytool = isWindows ? '"' + keytool + '.exe"' : '"' + keytool + '"';
 


### PR DESCRIPTION
add JAVA_HOME env variable check before running path.resolve with process.env.JAVA_HOME and return a more meaningful error message.
