### PR TITLE
Pass -v threadtime to adb logcat

### DIFF
--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -25,7 +25,7 @@ util.inherits(Logcat, EventEmitter);
 Logcat.prototype.startCapture = function (cb) {
   this.onLogcatStart = cb;
   logger.debug("Starting logcat capture");
-  this.proc = spawn(this.adb.path, this.adb.defaultArgs.concat(['logcat']));
+  this.proc = spawn(this.adb.path, this.adb.defaultArgs.concat(['logcat', '-v threadtime']));
   this.proc.stdout.setEncoding('utf8');
   this.proc.stderr.setEncoding('utf8');
   this.proc.on('error', function (err) {


### PR DESCRIPTION
It'd be super useful if the logs contained timestamps. This PR adds them.