### PR TITLE
isRealDevice()

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -48,6 +48,20 @@ methods.isValidClass = function (classString) {
   return new RegExp(/^[a-zA-Z0-9\./_]+$/).exec(classString);
 };
 
+methods.isRealDevice = async function () {
+  // Emulator should return 'EMULATOR' for ro.setupwizard.mode
+  // or contain 'generic' in ro.product.device
+  let setupWizardMode = await this.shell(['getprop', 'ro.setupwizard.mode']);  
+  if (/EMULATOR/.exec(setupWizardMode)) {
+    return false;
+  }
+  let productDevice = await this.shell(['getprop', 'ro.product.device']);
+  if (/generic/.exec(productDevice)) {
+    return false;
+  }
+  return true;
+};
+
 methods.forceStop = async function (pkg) {
   return this.shell(['am', 'force-stop', pkg]);
 };


### PR DESCRIPTION
For emulator sessions, `getprop ro.setupwizard.mode` usually returns 'EMULATOR', but sometimes this isn't the case. Fallback to check for 'generic' (as in generic_x86) in `ro.product.device`.

Example output:
https://gist.github.com/scottdixon/99f263431bcbaba100a0
And:
https://gist.github.com/tetsu-koba/1073308

@moizjv @sebv - I know you guys recently worked on this. Would love your input.
