### PR TITLE
Add additional logging to app signing

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -23,6 +23,7 @@ apkSigningMethods.signWithDefaultCert = async function (apk) {
 };
 
 apkSigningMethods.signWithCustomCert = async function (apk) {
+  log.debug(`Signing '${apk}' with custom cert`);
   const java = getJavaForOs();
   let javaHome = getJavaHome();
   let jarsigner = path.resolve(javaHome, 'bin', 'jarsigner');
@@ -93,12 +94,13 @@ apkSigningMethods.checkApkCert = async function (apk, pkg) {
 };
 
 apkSigningMethods.checkCustomApkCert = async function (apk, pkg) {
+  log.debug(`Checking custom app cert for ${apk}`);
   let h = "a-fA-F0-9";
-  let md5Str = ['.*MD5.*((?:[', h, ']{2}:){15}[', h, ']{2})'].join('');
+  let md5Str = [`.*MD5.*((?:[${h}]{2}:){15}[${h}]{2})`];
   let md5 = new RegExp(md5Str, 'mi');
   let javaHome = getJavaHome();
   let keytool = path.resolve(javaHome, 'bin', 'keytool');
-  keytool = system.isWindows() ? keytool + '.exe' : keytool;
+  keytool = system.isWindows() ? `${keytool}.exe` : keytool;
   let keystoreHash = await this.getKeystoreMd5(keytool, md5);
   return await this.checkApkKeystoreMatch(keytool, md5, keystoreHash, pkg, apk);
 };


### PR DESCRIPTION
The logs get a little sketchy when an app is being signed.