### PR TITLE
Undo unzip selection

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -47,21 +47,6 @@ async function getAndroidPlatformAndPath () {
   return null;
 }
 
-async function getUnzipProgram () {
-  log.debug('Locating unzip program');
-  let unzipExe = 'gunzip';
-  try {
-    // make sure we have an unzip program
-    await fs.which(unzipExe);
-  } catch (err) {
-    if (err.message.indexOf('not found') !== -1) {
-      unzipExe = 'unzip';
-    }
-  }
-  log.debug(`Using '${unzipExe}'`);
-  return unzipExe;
-}
-
 async function unzipFile (zipPath) {
   log.debug(`Unzipping ${zipPath}`);
   try {
@@ -71,8 +56,7 @@ async function unzipFile (zipPath) {
       zip.extractAllTo(path.dirname(zipPath), true);
       log.debug("Unzip successful");
     } else {
-      let unzipExe = await getUnzipProgram();
-      await exec(unzipExe, ['-o', zipPath], {cwd: path.dirname(zipPath)});
+      await exec('unzip', ['-o', zipPath], {cwd: path.dirname(zipPath)});
       log.debug("Unzip successful");
     }
   } catch (e) {
@@ -89,9 +73,8 @@ async function assertZipArchive (zipPath) {
       throw new Error(`Zip archive not present at ${zipPath}`);
     }
   } else {
-    let unzipExe = await getUnzipProgram();
     let execOpts = {cwd: path.dirname(zipPath)};
-    await exec(unzipExe, ['-tq', zipPath], execOpts);
+    await exec('unzip', ['-tq', zipPath], execOpts);
   }
 }
 


### PR DESCRIPTION
Turns out that `gunzip` works entirely differently than `unzip`. Decided to just require `unzip` on the system.