### PR TITLE
Fix sdk binary names in windows

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -24,8 +24,15 @@ systemCallMethods.getSdkBinaryPath = async function (binaryName) {
   }
 };
 
-systemCallMethods.getCommandForOS = function (binaryName) {
+systemCallMethods.getCommandForOS = function () {
   let cmd = "which";
+  if (system.isWindows()) {
+    cmd = "where";
+  }
+  return cmd;
+};
+
+systemCallMethods.getBinaryNameForOS = function (binaryName) {
   if (system.isWindows()) {
     if (binaryName === "android") {
       binaryName += ".bat";
@@ -34,13 +41,13 @@ systemCallMethods.getCommandForOS = function (binaryName) {
         binaryName += ".exe";
       }
     }
-    cmd = "where";
   }
-  return cmd;
+  return binaryName;
 };
 
 systemCallMethods.getBinaryFromSdkRoot = async function (binaryName) {
   let binaryLoc = null;
+  binaryName = this.getBinaryNameForOS(binaryName);
   let binaryLocs = [path.resolve(this.sdkRoot, "platform-tools", binaryName),
                     path.resolve(this.sdkRoot, "tools", binaryName)];
   // get subpaths for currently installed build tool directories
@@ -67,7 +74,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function (binaryName) {
 
 systemCallMethods.getBinaryFromPath = async function (binaryName) {
   let binaryLoc = null;
-  let cmd = this.getCommandForOS(binaryName);
+  let cmd = this.getCommandForOS();
   try {
     let {stdout} = await exec(cmd, [binaryName]);
     log.info(`Using ${binaryName} from ${stdout}`);

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -52,6 +52,9 @@ describe('signing', () => {
   describe('signWithCustomCert', withMocks({teen_process, helpers}, (mocks) => {
     it('should call exec with correct args', async () => {
       let jarsigner = path.resolve(java_home, 'bin', 'jarsigner');
+      if (appiumSupport.system.isWindows()) {
+        jarsigner = jarsigner + '.exe';
+      }
       adb.useKeystore = true;
       mocks.helpers.expects("getJavaHome")
         .returns(java_home);


### PR DESCRIPTION
In Windows, Appium 1.5 doesn't find adb comand:
```  
[ADB]Checking whether adb is present
[MJSONWP] Encountered internal error running command: Error: Could not find adb in tools, platform-tools, or supported build-tools under D:\android-sdk do you have the Android SDK installed at this location?
    at ADB.callee$0$0$ (lib/tools/system-calls.js:59:11)
```
The complete binary name should be adb.exe.
