### PR TITLE
lock() fix

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -110,8 +110,16 @@ methods.keyevent = async function (keycode) {
 };
 
 methods.lock = async function () {
-  log.debug("Pressing the KEYCODE_POWER button to lock screen");
-  await this.keyevent(26);
+  let locked = await this.isScreenLocked();
+  if (!locked) {
+    log.debug("Pressing the KEYCODE_POWER button to lock screen");
+    await this.keyevent(26);
+    // we need to wait for the animation to complete before
+    // the screen is actually considered 'locked'
+    await sleep(500);
+  } else {
+    log.debug("Screen is already locked. Doing nothing.");
+  }
 };
 
 methods.back = async function () {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { fs } from 'appium-support';
 import net from 'net';
 import Logcat from '../logcat';
-import { sleep } from 'asyncbox';
+import { sleep, retryInterval } from 'asyncbox';
 import { SubProcess } from 'teen_process';
 
 
@@ -111,12 +111,18 @@ methods.keyevent = async function (keycode) {
 
 methods.lock = async function () {
   let locked = await this.isScreenLocked();
+  locked = await this.isScreenLocked();
   if (!locked) {
     log.debug("Pressing the KEYCODE_POWER button to lock screen");
     await this.keyevent(26);
-    // we need to wait for the animation to complete before
-    // the screen is actually considered 'locked'
-    await sleep(500);
+
+    // wait for the screen to lock
+    await retryInterval(10, 500, async () => {
+      locked = await this.isScreenLocked();
+      if (!locked) {
+        log.errorAndThrow("Waiting for screen to lock.");
+      }
+    });
   } else {
     log.debug("Screen is already locked. Doing nothing.");
   }

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -4,6 +4,7 @@ import ADB from '../..';
 import net from 'net';
 import events from 'events';
 import Logcat from '../../lib/logcat.js';
+import log from '../../lib/logger.js';
 import * as teen_process from 'teen_process';
 import { withMocks } from 'appium-test-support';
 
@@ -102,13 +103,15 @@ describe('adb commands', () => {
         mocks.adb.verify();
       });
     }));
-    describe('lock', withMocks({adb}, (mocks) => {
-      it('should call isScreenLocked and keyevent with correct args', async () => {
+    describe('lock', withMocks({adb, log}, (mocks) => {
+      it('should call isScreenLocked, keyevent and errorAndThrow', async () => {
         mocks.adb.expects("isScreenLocked")
-          .once().returns(false);
+          .atLeast(2).returns(false);
         mocks.adb.expects("keyevent")
           .once().withExactArgs(26)
           .returns("");
+        mocks.log.expects("errorAndThrow")
+          .once().returns("");
         await adb.lock();
         mocks.adb.verify();
       });

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -103,7 +103,9 @@ describe('adb commands', () => {
       });
     }));
     describe('lock', withMocks({adb}, (mocks) => {
-      it('should call keyevent with correct args', async () => {
+      it('should call isScreenLocked and keyevent with correct args', async () => {
+        mocks.adb.expects("isScreenLocked")
+          .once().returns(false);
         mocks.adb.expects("keyevent")
           .once().withExactArgs(26)
           .returns("");


### PR DESCRIPTION
Fixes issue with calling `lock()` in quick succession. Also adding a 500ms delay because ADB doesn't recognize the lock until the animation is complete.