### PR TITLE
Add method to create a subprocess of adb

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -205,6 +205,13 @@ systemCallMethods.shell = async function (cmd, opts = {}) {
   return await this.adbExec(execCmd, opts);
 };
 
+systemCallMethods.createSubProcess = function (args = []) {
+  // add the default arguments
+  args = this.executable.defaultArgs.concat(args);
+  log.debug(`Creating ADB subprocess with args: ${args.join(', ')}`);
+  return new SubProcess(this.getAdbPath(), args);
+};
+
 systemCallMethods.getAdbServerPort = function () {
   return process.env.ANDROID_ADB_SERVER_PORT || 5037;
 };

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -85,6 +85,11 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     adb.setEmulatorPort(5554);
     adb.emulatorPort.should.equal(5554);
   });
+  describe('createSubProcess', () => {
+    it('should return an instance of SubProcess', () => {
+      adb.createSubProcess([]).should.be.an.instanceof(teen_process.SubProcess);
+    });
+  });
 }));
 
 describe('System calls',  withMocks({adb, B}, (mocks) => {


### PR DESCRIPTION
`appium-uiautomator` pulls stuff from adb and then creates a `SubProcess`. This is wrong. So add a method to create one in the context of the adb instance.