### PR TITLE
Use multiple possible activities

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -154,21 +154,21 @@ function buildStartCmd (startAppOptions, apiLevel) {
 
 // turns pkg.activity.name to .activity.name
 // also turns activity.name to .activity.name
-function getActivityRelativeName (pkgName, activityRelativeName) {
-  let relativeName = activityRelativeName;
+function getPossibleActivityNames (pkgName, activityName) {
+  let names = [activityName];
   // need to beware of namespaces with overlapping chars:
   //   com.foo.bar
   //   com.foo.barx
-  if (activityRelativeName.indexOf(pkgName + ".") === 0) {
-    relativeName = activityRelativeName.substring(pkgName.length);
+  if (activityName.indexOf(`${pkgName}.`) === 0) {
+    names.push(activityName.substring(pkgName.length));
   }
-  if (relativeName[0] !== '.') {
-    relativeName = `.${relativeName}`;
+  if (activityName[0] !== '.') {
+    names.push(`.${activityName}`);
   }
-  return relativeName;
+  return names;
 }
 
 export { getDirectories, getAndroidPlatformAndPath, unzipFile, assertZipArchive,
          getIMEListFromOutput, getJavaForOs, isShowingLockscreen, isCurrentFocusOnKeyguard,
-         isScreenOnFully, buildStartCmd, getActivityRelativeName, getJavaHome,
+         isScreenOnFully, buildStartCmd, getPossibleActivityNames, getJavaHome,
          rootDir, androidPlatforms };

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -1,4 +1,4 @@
-import { buildStartCmd, getActivityRelativeName } from '../helpers.js';
+import { buildStartCmd, getPossibleActivityNames } from '../helpers.js';
 import { exec } from 'teen_process';
 import log from '../logger.js';
 import path from 'path';
@@ -114,21 +114,24 @@ apkUtilsMethods.waitForActivityOrNot = async function (pkg, activity, not,
   if (!pkg || !activity) {
     throw new Error("Package and activity required.");
   }
-  log.debug(`Waiting for pkg: ${pkg} and activity: ${activity}` +
+  log.debug(`Waiting for pkg: '${pkg}' and activity: '${activity}'` +
             `${not ? ' not' : ''} to be focused`);
   let endAt = Date.now() + waitMs;
-  let activityRelativeName = getActivityRelativeName(pkg, activity);
+  let possibleActivityNames = getPossibleActivityNames(pkg, activity);
+  log.debug(`Possible activities, to be checked: ${possibleActivityNames.join(', ')}`);
   while (Date.now() < endAt) {
     let {appPackage, appActivity} = await this.getFocusedPackageAndActivity();
-    let foundAct = ((appPackage === pkg) && (activityRelativeName === appActivity));
+    log.debug(`Found package: '${appPackage}' and activity: '${appActivity}'`);
+    let foundAct = ((appPackage === pkg) &&
+                    (_.findIndex(possibleActivityNames, possibleActivity => possibleActivity === appActivity) !== -1));
     if ((!not && foundAct) || (not && !foundAct)) {
       return;
     }
+    log.debug('Incorrect package and activity. Retrying.');
     // cool down so we're not overloading device with requests
     await sleep(750);
   }
-  log.errorAndThrow(`${pkg}/${activityRelativeName} never ` +
-                    `${not ? 'stopped' : 'started'}`);
+  log.errorAndThrow(`${pkg}/${activity} never ${not ? 'stopped' : 'started'}`);
 };
 
 apkUtilsMethods.waitForActivity = async function (pkg, act, waitMs = 20000) {

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -1,4 +1,4 @@
-import { getActivityRelativeName, getDirectories, getAndroidPlatformAndPath } from '../../lib/helpers';
+import { getPossibleActivityNames, getDirectories, getAndroidPlatformAndPath } from '../../lib/helpers';
 import { withMocks } from 'appium-test-support';
 import { fs } from 'appium-support';
 import path from 'path';
@@ -8,19 +8,23 @@ import chai from 'chai';
 const should = chai.should;
 
 describe('helpers', () => {
-  describe('getActivityRelativeName', () => {
+  describe('getPossibleActivityNames', () => {
     it('should correctly remove pkg from pkg.activity.name', () => {
-      getActivityRelativeName('pkg', 'pkg.activity.name')
-        .should.equal('.activity.name');
+      getPossibleActivityNames('pkg', 'pkg.activity.name')
+        .should.include('.activity.name');
     });
     it('should return .act.name when act.name is passed', () => {
-      getActivityRelativeName('pkg', 'act.name')
-        .should.equal('.act.name');
+      getPossibleActivityNames('pkg', 'act.name')
+        .should.include('.act.name');
     });
     it('should not amend a valid activity name', () => {
-      getActivityRelativeName('pkg', '.activity.name')
-        .should.equal('.activity.name');
+      getPossibleActivityNames('pkg', '.activity.name')
+        .should.include('.activity.name');
     });
+    it('should handle case where application id is different from package name', () => {
+       getPossibleActivityNames('com.ga.aaa.android.bbb.activities.local', 'com.ga.aaa.android.bbb.activity.FirstLaunchActivity')
+         .should.include('com.ga.aaa.android.bbb.activity.FirstLaunchActivity');
+     });
   });
 
   describe('getDirectories', withMocks({fs}, (mocks) => {


### PR DESCRIPTION
Instead of trying to guess if the activity needs to be made relative, use a list of possible activity names to check if it has started.

Also improve logging so we have more visibility into what is going on.

See https://github.com/appium/appium/issues/5936