### PR TITLE
corrected jar path

### DIFF
--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -4,7 +4,7 @@ import { getAndroidPlatformAndPath, unzipFile, assertZipArchive } from '../helpe
 import { system, fs } from 'appium-support';
 import path from 'path';
 
-const helperJarPath = path.resolve(__dirname, '../jars');
+const helperJarPath = path.resolve(__dirname, '..', '..', '..', 'jars');
 let manifestMethods = {};
 
 // android:process= may be defined in AndroidManifest.xml


### PR DESCRIPTION
Resolves https://github.com/appium/appium/issues/6102

- Windows was unable to launch Selendroid Server
- Both OSX and Windows were using the same APK
- The APK, however, produced different package names
- Further inspection of each APK showed differences in the AndroidManifest.xml file
- Windows wasn't inserting the modified AndroidManifest.xml because it couldn't find the move_manifest.jar file

CC @imurchie 