### PR TITLE
Update getRunningAVD to allow launching Android Emulator

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -285,9 +285,6 @@ systemCallMethods.getRunningAVD = async function (avdName) {
   try {
     log.debug(`Trying to find ${avdName} emulator`);
     let emulators = await this.getConnectedEmulators();
-    if (emulators.length < 1) {
-      throw new Error("No emulators connected");
-    }
     for (let emulator of emulators) {
       this.setEmulatorPort(emulator.port);
       let runningAVDName = await this.sendTelnetCommand("avd name");

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -339,7 +339,7 @@ systemCallMethods.killAllEmulators = async function () {
   }
 };
 
-systemCallMethods.launchAVD = async function (avdName, avdArgs, language, locale,
+systemCallMethods.launchAVD = async function (avdName, avdArgs, language, country,
   avdLaunchTimeout = 60000, avdReadyTimeout = 60000, retryTimes = 1) {
   log.debug(`Launching Emulator with AVD ${avdName}, launchTimeout` +
             `${avdLaunchTimeout} ms and readyTimeout ${avdReadyTimeout} ms`);
@@ -352,9 +352,21 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, locale
     log.debug(`Setting Android Device Language to ${language}`);
     launchArgs.push("-prop", `persist.sys.language=${language.toLowerCase()}`);
   }
+  if (typeof country === "string") {
+    log.debug(`Setting Android Device Country to ${country}`);
+    launchArgs.push("-prop", `persist.sys.country=${country.toUpperCase()}`);
+  }
+  let locale;
+  if (typeof language === "string" && typeof country === "string") {
+    locale = language.toLowerCase() + "-" + country.toUpperCase();
+  } else if (typeof language === "string") {
+    locale = language.toLowerCase();
+  } else if (typeof country === "string") {
+    locale = country;
+  }
   if (typeof locale === "string") {
-    log.debug(`Setting Android Device Country to ${locale}`);
-    launchArgs.push("-prop", `persist.sys.country=${locale.toUpperCase()}`);
+    log.debug(`Setting Android Device Locale to ${locale}`);
+    launchArgs.push("-prop", `persist.sys.locale=${locale}`);
   }
   if (typeof avdArgs === "string") {
     avdArgs = avdArgs.split(" ");


### PR DESCRIPTION
To fix https://github.com/appium/appium/issues/6233, getRunningAVD method should return null when no avd is connected, instead of throwing an exception.
I have also added locale property in launchAVD method to launch API23 emulators with proper language settings.