### PR TITLE
Make sure telnet works for newer versions of Android SDK

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -231,6 +231,7 @@ methods.sendTelnetCommand = async function (command) {
         dataStream += data;
         if (readyRegex.test(data)) {
           res = dataStream.replace(readyRegex, "").trim();
+          res = _.last(res.trim().split('\n'));
           log.debug(`Telnet command got response: ${res}`);
           conn.write("quit\n");
         }


### PR DESCRIPTION
On more recent Android SDK versions the telnet response can have additional lines. This is not what we want. So split and take the last line.