### PR TITLE
Only use last line of telnet output

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -231,6 +231,7 @@ methods.sendTelnetCommand = async function (command) {
         dataStream += data;
         if (readyRegex.test(data)) {
           res = dataStream.replace(readyRegex, "").trim();
+          res = _.last(res.trim().split('\n'));
           log.debug(`Telnet command got response: ${res}`);
           conn.write("quit\n");
         }

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -589,6 +589,30 @@ describe('adb commands', () => {
       mocks.adb.verify();
       mocks.net.verify();
     });
+    it('should return the last line of the output only', async () => {
+      const port = 54321;
+      let conn = new events.EventEmitter();
+      let commands = [];
+      let expected = "desired_command_output";
+      conn.write = function (command) {
+        commands.push(command);
+      };
+      mocks.adb.expects("getEmulatorPort")
+        .once().withExactArgs()
+        .returns(port);
+      mocks.net.expects("createConnection")
+        .once().withExactArgs(port, 'localhost')
+        .returns(conn);
+      let p = adb.sendTelnetCommand('avd name');
+      setTimeout(function () {
+        conn.emit('connect');
+        conn.emit('data','OK');
+        conn.emit('data','OK\nunwanted_echo_output\n' + expected);
+        conn.emit('close');
+      }, 0);
+      let actual = await p;
+      (actual).should.equal(expected);
+    });
   }));
   it('isValidClass should correctly validate class names', () => {
     adb.isValidClass('some.package/some.package.Activity').index.should.equal(0);


### PR DESCRIPTION
The android emulator started echoing command input over Telnet in Android SDK Tools 25.1.1. This fixes #150 and avoids processing echoed command input from telnet.