### PR TITLE
fixed setWifiState and setDataState for API>19

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -277,8 +277,7 @@ methods.isWifiOn = async function () {
  * on: true (to turn on) or false (to turn off)
  */
 methods.setWifiState = async function (on) {
-  await this.shell(['am', 'start', '-n', 'io.appium.settings/.Settings', '-e',
-                    'wifi', on ? 'on' : 'off']);
+  await this.shell(['settings', 'put', 'global', 'wifi_on', on ? 1 : 0]);
 };
 
 methods.isDataOn = async function () {
@@ -290,8 +289,7 @@ methods.isDataOn = async function () {
  * on: true (to turn on) or false (to turn off)
  */
 methods.setDataState = async function (on) {
-  await this.shell(['am', 'start', '-n', 'io.appium.settings/.Settings', '-e',
-                    'data', on ? 'on' : 'off']);
+  await this.shell(['settings', 'put', 'global', 'mobile_data', on ? 1 : 0]);
 };
 
 /*

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -322,8 +322,7 @@ describe('adb commands', () => {
     describe('setWifiState', withMocks({adb}, (mocks) => {
       it('should call shell with correct args', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'start', '-n', 'io.appium.settings/.Settings', '-e',
-                                 'wifi', 'on'])
+          .once().withExactArgs(['settings', 'put', 'global', 'wifi_on', 1])
           .returns("");
         await adb.setWifiState(true);
         mocks.adb.verify();
@@ -348,8 +347,7 @@ describe('adb commands', () => {
     describe('setDataState', withMocks({adb}, (mocks) => {
       it('should call shell with correct args', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'start', '-n', 'io.appium.settings/.Settings', '-e',
-                                 'data', 'on'])
+          .once().withExactArgs(["settings", "put", "global", "mobile_data", 1])
           .returns("");
         await adb.setDataState(true);
         mocks.adb.verify();


### PR DESCRIPTION
This will resolve appium/appium#5256 and this will continue in appium/appium-android-driver#148.

Apologies for confusion.Have raised it here.

@imurchie @jlipps @TikhomirovSergey Please review. This fixes the API to work on all the Android API till API Level 23 (Tested from 19 to 23)