### PR TITLE
Correct Regex for deviceNotFoundError

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -180,7 +180,7 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
       return stdout;
     } catch (e) {
       let protocolFaultError = new RegExp("protocol fault \\(no status\\)", "i").test(e);
-      let deviceNotFoundError = new RegExp("error: device not found", "i").test(e);
+      let deviceNotFoundError = new RegExp("error: device ('.+' )?not found", "i").test(e);
       if (protocolFaultError || deviceNotFoundError) {
         log.info(`error sending command, reconnecting device and retrying: ${cmd}`);
         await sleep(1000);


### PR DESCRIPTION
The exact error is `error: device '3801b560347ac200' not found`. So I change the Regex to match with that error.