### PR TITLE
Fix optional intent argument parsing

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -147,27 +147,54 @@ function buildStartCmd (startAppOptions, apiLevel) {
     cmd.push('-f', startAppOptions.flags);
   }
   if (startAppOptions.optionalIntentArguments) {
-    // expect optionalIntentArguments to be something like '-x options',
-    // '-y option argument' or a combination of the two
-    let argRe = /(-[^\s]+) ([^-]+)/g;
+    // expect optionalIntentArguments to be a single string of the form:
+    //     "-flag key"
+    //     "-flag key value"
+    // or a combination of these (e.g., "-flag1 key1 -flag2 key2 value2")
+
+    // take a string and parse out the part before any spaces, and anything after
+    // the first space
+    let parseKeyValue = function (str) {
+      str = str.trim();
+      let space = str.indexOf(' ');
+      if (space === -1) {
+        return !!str.length ? [str] : [];
+      } else {
+        return [str.substring(0, space).trim(), str.substring(space + 1).trim()];
+      }
+    };
+
+    // cycle through the optionalIntentArguments and pull out the arguments
+    // add a space initially so flags can be distinguished from arguments that
+    // have internal hyphens
+    let optionalIntentArguments = ` ${startAppOptions.optionalIntentArguments}`;
+    let re = / (-[^\s]+) (.+)/;
     while (true) {
-      let optionalIntentArguments = argRe.exec(startAppOptions.optionalIntentArguments);
-      if (!optionalIntentArguments) {
+      let args = re.exec(optionalIntentArguments);
+      if (!args) {
+        if (optionalIntentArguments.length) {
+          // no more flags, so the remainder can be treated as 'key' or 'key value'
+          cmd.push.apply(cmd, parseKeyValue(optionalIntentArguments));
+        }
+        // we are done
         break;
       }
-      let flag = optionalIntentArguments[1];
-      let space = optionalIntentArguments[2].indexOf(' ');
-      let arg, value;
-      if (space === -1) {
-        arg = optionalIntentArguments[2];
-      } else {
-        arg = optionalIntentArguments[2].substring(0, space).trim();
-        value = optionalIntentArguments[2].substring(space + 1).trim();
+
+      // take the flag and see if it is at the beginning of the string
+      // if it is not, then it means we have been through already, and
+      // what is before the flag is the argument for the previous flag
+      let flag = args[1];
+      let flagPos = optionalIntentArguments.indexOf(flag);
+      if (flagPos !== 0) {
+        let prevArgs = optionalIntentArguments.substring(0, flagPos);
+        cmd.push.apply(cmd, parseKeyValue(prevArgs));
       }
-      cmd.push(flag, arg);
-      if (value) {
-        cmd.push(value);
-      }
+
+      // add the flag, as there are no more earlier arguments
+      cmd.push(flag);
+
+      // make optionalIntentArguments hold the remainder
+      optionalIntentArguments = args[2];
     }
   }
   return cmd;

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -1,8 +1,10 @@
-import { getPossibleActivityNames, getDirectories, getAndroidPlatformAndPath } from '../../lib/helpers';
+import { getPossibleActivityNames, getDirectories, getAndroidPlatformAndPath,
+         buildStartCmd } from '../../lib/helpers';
 import { withMocks } from 'appium-test-support';
 import { fs } from 'appium-support';
 import path from 'path';
 import chai from 'chai';
+import _ from 'lodash';
 
 
 const should = chai.should;
@@ -69,4 +71,63 @@ describe('helpers', () => {
       process.env.ANDROID_HOME = oldAndroidHome;
     });
   }));
+
+  describe('buildStartCmd', () => {
+    let startOptions = {
+      pkg: 'com.something',
+      activity: '.SomeActivity'
+    };
+
+    it('should parse optionalIntentArguments with single key', () => {
+      let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key'}, startOptions), 20);
+      cmd[cmd.length-2].should.eql('-d');
+      cmd[cmd.length-1].should.eql('key');
+    });
+    it('should parse optionalIntentArguments with single key/value pair', () => {
+      let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key value'}, startOptions), 20);
+      cmd[cmd.length-3].should.eql('-d');
+      cmd[cmd.length-2].should.eql('key');
+      cmd[cmd.length-1].should.eql('value');
+    });
+    it('should parse optionalIntentArguments with single key/value pair with spaces', () => {
+      let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key value value2'}, startOptions), 20);
+      cmd[cmd.length-3].should.eql('-d');
+      cmd[cmd.length-2].should.eql('key');
+      cmd[cmd.length-1].should.eql('value value2');
+    });
+    it('should parse optionalIntentArguments with multiple keys', () => {
+      let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key1 -e key2'}, startOptions), 20);
+      cmd[cmd.length-4].should.eql('-d');
+      cmd[cmd.length-3].should.eql('key1');
+      cmd[cmd.length-2].should.eql('-e');
+      cmd[cmd.length-1].should.eql('key2');
+    });
+    it('should parse optionalIntentArguments with multiple key/value pairs', () => {
+      let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key1 value1 -e key2 value2'}, startOptions), 20);
+      cmd[cmd.length-6].should.eql('-d');
+      cmd[cmd.length-5].should.eql('key1');
+      cmd[cmd.length-4].should.eql('value1');
+      cmd[cmd.length-3].should.eql('-e');
+      cmd[cmd.length-2].should.eql('key2');
+      cmd[cmd.length-1].should.eql('value2');
+    });
+    it('should parse optionalIntentArguments with hyphens', () => {
+      let arg = 'http://some-url-with-hyphens.com/';
+      let cmd = buildStartCmd(_.defaults({optionalIntentArguments: `-d ${arg}`}, startOptions), 20);
+      cmd[cmd.length-2].should.eql('-d');
+      cmd[cmd.length-1].should.eql(arg);
+    });
+    it('should parse optionalIntentArguments with multiple arguments with hyphens', () => {
+      let arg1 = 'http://some-url-with-hyphens.com/';
+      let arg2 = 'http://some-other-url-with-hyphens.com/';
+      let cmd = buildStartCmd(_.defaults({
+        optionalIntentArguments: `-d ${arg1} -e key ${arg2}`
+      }, startOptions), 20);
+      cmd[cmd.length-5].should.eql('-d');
+      cmd[cmd.length-4].should.eql(arg1);
+      cmd[cmd.length-3].should.eql('-e');
+      cmd[cmd.length-2].should.eql('key');
+      cmd[cmd.length-1].should.eql(arg2);
+    });
+  });
 });


### PR DESCRIPTION
The current implementation does not allow intent arguments that have dashes in them. This re-implements the parsing to allow them.

Fixes #161.