### PR TITLE
Add flag so launching apps waits for the launch

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -133,7 +133,7 @@ function isScreenOnFully (dumpsys) {
 }
 
 function buildStartCmd (startAppOptions, apiLevel) {
-  let cmd = ['am', 'start', '-n', `${startAppOptions.pkg}/${startAppOptions.activity}`];
+  let cmd = ['am', 'start', '-W', '-n', `${startAppOptions.pkg}/${startAppOptions.activity}`];
   if (startAppOptions.stopApp && apiLevel >= 15) {
     cmd.push('-S');
   }

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -12,7 +12,7 @@ const should = chai.should(),
       startAppOptions = {stopApp: true, action: 'action', category: 'cat',
                          flags: 'flags', pkg: 'pkg', activity: 'act',
                          optionalIntentArguments: '-x options -y option argument -z option arg with spaces'},
-      cmd = ['am', 'start', '-n', 'pkg/act', '-S', '-a', 'action', '-c', 'cat',
+      cmd = ['am', 'start', '-W', '-n', 'pkg/act', '-S', '-a', 'action', '-c', 'cat',
              '-f', 'flags', '-x', 'options', '-y', 'option', 'argument',
              '-z', 'option', 'arg with spaces'],
       language = 'en',
@@ -146,7 +146,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, '.SuperManager, .OtherManager', false, 1000)
         .should.eventually.be.rejected;
       mocks.adb.verify();
-    });    
+    });
   }));
   describe('waitForActivity', withMocks({adb}, (mocks) => {
     it('should call waitForActivityOrNot with correct arguments', async () => {


### PR DESCRIPTION
Rather than just launching and allowing things to go on, wait for the launch to happen. See https://github.com/appium/appium/issues/5830 and https://github.com/appium/appium/issues/6505.