### PR TITLE
Add method to clear a text field using adb

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -142,6 +142,23 @@ methods.inputText = async function (text) {
   await this.shell(['input', 'text', text]);
 };
 
+methods.clearTextField = async function (length = 100) {
+  // assumes that the EditText field already has focus
+  log.debug(`Clearing up to ${length} characters`);
+  if (length === 0) {
+    return;
+  }
+  let args = ['input', 'keyevent'];
+  for (let i = 0; i < length; i++) {
+    // we cannot know where the cursor is in the text field, so delete both before
+    // and after so that we get rid of everything
+    // https://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_DEL
+    // https://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_FORWARD_DEL
+    args.push('67', '112');
+  }
+  await this.shell(args);
+};
+
 methods.lock = async function () {
   let locked = await this.isScreenLocked();
   locked = await this.isScreenLocked();

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -208,6 +208,15 @@ describe('adb commands', () => {
         mocks.adb.verify();
       });
     }));
+    describe('clearTextField', withMocks({adb}, (mocks) => {
+      it('should call shell with correct args', async () => {
+        mocks.adb.expects("shell")
+          .once().withExactArgs(['input', 'keyevent', '67', '112', '67', '112', '67', '112', '67', '112'])
+          .returns("");
+        await adb.clearTextField(4);
+        mocks.adb.verify();
+      });
+    }));
     describe('lock', withMocks({adb, log}, (mocks) => {
       it('should call isScreenLocked, keyevent and errorAndThrow', async () => {
         mocks.adb.expects("isScreenLocked")


### PR DESCRIPTION
Android text field clearing is a problem. `adb` can send a key event to delete, and can do it quickly and reliably. Add a method to do that so we can offer a better way to clear, if possible.