### PR TITLE
adding killEmulator function to kill specific emulator with AVD name.

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -344,6 +344,17 @@ systemCallMethods.killAllEmulators = async function () {
   }
 };
 
+systemCallMethods.killEmulator = async function (avdName) {
+  log.debug(`killing avd '${avdName}'`);
+  let device = await this.getRunningAVD(avdName);
+  if (device) {
+    await this.adbExec(['emu', 'kill']);
+    log.info(`successfully killed emulator '${avdName}'`);
+  } else {
+    log.info(`no avd with name '${avdName}' running. skipping kill step.`);
+  }
+};
+
 systemCallMethods.launchAVD = async function (avdName, avdArgs, language, country,
   avdLaunchTimeout = 60000, avdReadyTimeout = 60000, retryTimes = 1) {
   log.debug(`Launching Emulator with AVD ${avdName}, launchTimeout` +
@@ -352,6 +363,7 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   if (avdName[0] === "@") {
     avdName = avdName.substr(1);
   }
+  await this.checkAvdExist(avdName);
   let launchArgs = ["-avd", avdName];
   if (typeof language === "string") {
     log.debug(`Setting Android Device Language to ${language}`);
@@ -385,6 +397,16 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   await retry(retryTimes, this.getRunningAVDWithRetry.bind(this), avdName, avdLaunchTimeout);
   await this.waitForEmulatorReady(avdReadyTimeout);
   return proc;
+};
+
+systemCallMethods.checkAvdExist = async function (avdName) {
+  let cmd = await this.getSdkBinaryPath('android');
+  let args = ['list', 'avd', '-c'];
+  let {stdout} = await exec(cmd, args);
+  if (stdout.indexOf(avdName) === -1) {
+    let existings = `(${stdout.trim().replace(/[\n]/g, '), (')})`;
+    log.errorAndThrow(`Avd '${avdName}' is not available. please select your avd name from one of these: '${existings}'`);
+  }
 };
 
 systemCallMethods.waitForEmulatorReady = async function (timeoutMs = 20000) {


### PR DESCRIPTION
Add a new function to kill emulator with specific AVD name.
This function is required by `appium-android-driver` to be able to wipe-data of running emulator and close emulator at the end of the test.

I was not able to make it work with `teen_process`. Teen_process escape command parameters. If that can be fixed it is better to use `exec` instead of `execRuntime`.