### PR TITLE
Fixed issues with Android 7 (issue #6665 in Appium)

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -424,7 +424,7 @@ methods.getPIDsByName = async function (name) {
     if (name.length > 15) {
       name = name.substr(name.length - 15);
     }
-    let stdout = await this.shell(["ps", name]);
+    let stdout = await this.shell(["set `ps | grep '" + name + "'`;echo $2"]);
     stdout = stdout.trim();
     let pids = [];
     for (let line of stdout.split("\n")) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -165,6 +165,7 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
   // setting default timeout for each command to prevent infinite wait.
   opts.timeout = opts.timeout || DEFAULT_ADB_EXEC_TIMEOUT;
   let execFunc = async () => {
+    let linkerWarningRe = /^WARNING: linker.+$/m;
     try {
       if (!(cmd instanceof Array)) {
         cmd = [cmd];
@@ -175,7 +176,6 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
       let {stdout} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out stupid stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out
-      let linkerWarningRe = /^WARNING: linker.+$/m;
       stdout = stdout.replace(linkerWarningRe, '').trim();
       return stdout;
     } catch (e) {
@@ -185,6 +185,14 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         log.info(`error sending command, reconnecting device and retrying: ${cmd}`);
         await sleep(1000);
         await this.getDevicesWithRetry();
+      }
+      if (e.stderr) {
+        return e.stderr;
+      }
+      if (e.stdout) {
+        let stdout = e.stdout;
+        stdout = stdout.replace(linkerWarningRe, '').trim();
+        return stdout;
       }
       throw new Error(`Error executing adbExec. Original error: ${e.message}` +
                         JSON.stringify(e));

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -484,7 +484,7 @@ describe('adb commands', () => {
     describe('getPIDsByName', withMocks({adb}, (mocks) => {
       it('should call shell and parse pids correctly', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(["ps", '.contactmanager'])
+          .once().withExactArgs(["set `ps | grep '.contactmanager'`;echo $2"])
           .returns(psOutput);
         (await adb.getPIDsByName(contactManagerPackage))[0].should.equal(5078);
         mocks.adb.verify();


### PR DESCRIPTION
* Adjust reading of the process id with a given name to also make it work on Android 7 by using a combination of "ps" and "grep" commands because the api of "ps" has changed
* If an adb exec command fails, pass the stderr or the stdout (if possible) to the caller (because failing adb exec commands on Android 7 may throw an exception while on Android 6 they did not; instead, on Android 6 the exception text was returned in stdout)