### PR TITLE
Grant permissions on install

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -170,7 +170,7 @@ apkUtilsMethods.uninstallApk = async function (pkg) {
 };
 
 apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = {}) {
-  let stdout = await this.shell(['pm', 'install', '-r', apkPathOnDevice], opts);
+  let stdout = await this.shell(['pm', 'install', '-rg', apkPathOnDevice], opts);
   if (stdout.indexOf("Failure") !== -1) {
     log.errorAndThrow(`Remote install failed: ${stdout}`);
   }
@@ -178,10 +178,10 @@ apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = 
 
 apkUtilsMethods.install = async function (apk, replace = true, timeout = 60000) {
   if (replace) {
-    await this.adbExec(['install', '-r', apk], {timeout});
+    await this.adbExec(['install', '-rg', apk], {timeout});
   } else {
     try {
-      await this.adbExec(['install', apk], {timeout});
+      await this.adbExec(['install', '-g', apk], {timeout});
     } catch (err) {
       // on some systems this will throw an error if the app already
       // exists

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -181,7 +181,7 @@ describe('Apk-utils', () => {
   describe('installFromDevicePath', withMocks({adb}, (mocks) => {
     it('should call forceStop and adbExec with correct arguments', async () => {
       mocks.adb.expects('shell')
-        .once().withExactArgs(['pm', 'install', '-r', 'foo'], {})
+        .once().withExactArgs(['pm', 'install', '-rg', 'foo'], {})
         .returns('');
       (await adb.installFromDevicePath('foo'));
       mocks.adb.verify();
@@ -190,9 +190,16 @@ describe('Apk-utils', () => {
   describe('install', withMocks({adb}, (mocks) => {
     it('should call forceStop and adbExec with correct arguments', async () => {
       mocks.adb.expects('adbExec')
-        .once().withExactArgs(['install', '-r', 'foo'], {timeout: 60000})
+        .once().withExactArgs(['install', '-rg', 'foo'], {timeout: 60000})
         .returns('');
       (await adb.install('foo'));
+      mocks.adb.verify();
+    });
+    it('should call forceStop and adbExec with correct arguments when not replacing', async () => {
+      mocks.adb.expects('adbExec')
+        .once().withExactArgs(['install', '-g', 'foo'], {timeout: 60000})
+        .returns('');
+      (await adb.install('foo', false));
       mocks.adb.verify();
     });
   }));


### PR DESCRIPTION
Use `-g` to grant all the permissions from the manifest, upon install.

Addresses https://github.com/appium/appium/issues/6928 and https://github.com/appium/appium/issues/6091