### PR TITLE
Use all processes when looking for pids

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -424,16 +424,7 @@ methods.getPIDsByName = async function (name) {
     if (name.length > 15) {
       name = name.substr(name.length - 15);
     }
-    let stdout;
-    try {
-      stdout = await this.shell(["ps", name]);
-    } catch (err) {
-      // on some systems `name` is not accepted
-      // so get **all** the processes and skip wrong ones below
-      log.debug(`Unable to get process for '${name}'. Retrieving all processes.`);
-      stdout = await this.shell(["ps"]);
-    }
-    stdout = stdout.trim();
+    let stdout = await this.shell(["ps"]).trim();
     let pids = [];
     for (let line of stdout.split("\n")) {
       if (line.indexOf(name) !== -1) {

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -484,7 +484,7 @@ describe('adb commands', () => {
     describe('getPIDsByName', withMocks({adb}, (mocks) => {
       it('should call shell and parse pids correctly', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['ps', '.contactmanager'])
+          .once().withExactArgs(['ps'])
           .returns(psOutput);
         (await adb.getPIDsByName(contactManagerPackage))[0].should.equal(5078);
         mocks.adb.verify();


### PR DESCRIPTION
Rather than getting processes by name, which does not work on recent systems, get all the processes and then sort through them for name. There are never _that_ many processes that this is onerous.

Fixes #177