### PR TITLE
Stop swallowing errors in adb exec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
+  - "6"
 env:
   global:
     - _FORCE_LOGS=1

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -182,20 +182,18 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
       let protocolFaultError = new RegExp("protocol fault \\(no status\\)", "i").test(e);
       let deviceNotFoundError = new RegExp("error: device ('.+' )?not found", "i").test(e);
       if (protocolFaultError || deviceNotFoundError) {
-        log.info(`error sending command, reconnecting device and retrying: ${cmd}`);
+        log.info(`Error sending command, reconnecting device and retrying: ${cmd}`);
         await sleep(1000);
         await this.getDevicesWithRetry();
       }
-      if (e.stderr) {
-        return e.stderr;
-      }
+
       if (e.stdout) {
         let stdout = e.stdout;
         stdout = stdout.replace(linkerWarningRe, '').trim();
         return stdout;
       }
-      throw new Error(`Error executing adbExec. Original error: ${e.message}` +
-                        JSON.stringify(e));
+      throw new Error(`Error executing adbExec. Original error: '${e.message}'; ` +
+                        `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
     }
   };
   return await retry(2, execFunc);
@@ -203,7 +201,7 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
 
 systemCallMethods.shell = async function (cmd, opts = {}) {
   if (!await this.isDeviceConnected()) {
-    throw new Error(`No device connected, cannot run adb shell command "${cmd.join(' ')}"`);
+    throw new Error(`No device connected, cannot run adb shell command '${cmd.join(' ')}'`);
   }
   let execCmd = ['shell'];
   if (cmd instanceof Array) {
@@ -217,7 +215,7 @@ systemCallMethods.shell = async function (cmd, opts = {}) {
 systemCallMethods.createSubProcess = function (args = []) {
   // add the default arguments
   args = this.executable.defaultArgs.concat(args);
-  log.debug(`Creating ADB subprocess with args: ${args.join(', ')}`);
+  log.debug(`Creating ADB subprocess with args: ${JSON.stringify(args)}`);
   return new SubProcess(this.getAdbPath(), args);
 };
 


### PR DESCRIPTION
We are returning the stderr instead of throwing errors, so some classes of errors are just swallowed without any indication. (This happens, for instance, when trying to stop a device at API level 25).