### PR TITLE
refactored targetSdkVersionFromManifest 

### DIFF
--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -96,9 +96,12 @@ manifestMethods.targetSdkVersionFromManifest = async function (localApk) {
     let args = ['dump', 'badging', localApk];
     let {stdout} = await exec(this.binaries.aapt, args);
     let targetSdkVersion = new RegExp(/targetSdkVersion:'([^']+)'/g).exec(stdout);
+    if (!targetSdkVersion) {
+      throw new Error(`targetSdkVersion is not specified in the application.`);
+    }
     return parseInt(targetSdkVersion[1], 10);
   } catch (e) {
-    log.errorAndThrow(`targetSdkVersionFromManifest failed. Original error: ${e.message}`);
+    log.errorAndThrow(`fetching targetSdkVersion from local APK failed. Original error: ${e.message}`);
   }
 };
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -193,8 +193,14 @@ apkUtilsMethods.install = async function (apk, replace = true, timeout = 60000) 
   }
   if (apk.includes('.apk')) {
     let apiLevel = await this.getApiLevel();
-    let targetSdk = await this.targetSdkVersionFromManifest(apk);
-    if (apiLevel >= 23 && targetSdk >= 23) {
+    let targetSdk = null;
+    try {
+      targetSdk = await this.targetSdkVersionFromManifest(apk);
+    } catch (e) {
+      //avoiding logging error stack, as calling library function would have logged
+      log.warn(`Ran into problem getting target SDK version; ignoring...`);
+    }
+    if (apiLevel >= 23 && (!targetSdk || targetSdk >= 23)) {
       await this.grantAllPermissions(await this.getPackageName(apk));
     }
   }


### PR DESCRIPTION
PR https://github.com/appium/appium-adb/pull/186 not working with some applications.
Issue: #https://github.com/appium/appium/issues/7349, #https://github.com/appium/appium/issues/7353
- Granting permissions at run time works only when both below 2 cases matched
    
1.  Device API should be 23 and above (From device point of view)
2.  Application's `targetSdkVersion` version should be 23 and above (From Application point of view)

But there is no direct way to fetch `targetSdkVersion` from application's APK. Here we are relying on dumping apk info using (`aapt dump badging APK`). But unfortunately in legacy applications we do not find targetSdkVersion info. 

Till we find the better alternatives to figure out `targetSdkVersion`, removing the `targetSdkVersion` to grant permissions.

cc: @jlipps, @imurchie  