### PR TITLE
Correct the getConnectedDevices function

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -104,6 +104,7 @@ systemCallMethods.getConnectedDevices = async function () {
       for (let line of stdout.split("\n")) {
         if (line.trim() !== "" &&
             line.indexOf("List of devices") === -1 &&
+            line.indexOf("adb server") === -1 &&
             line.indexOf("* daemon") === -1 &&
             line.indexOf("offline") === -1) {
           let lineInfo = line.split("\t");

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -20,6 +20,19 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
+  it('getConnectedDevices should get all connected devices which have valid udid', async () => {
+    let stdoutValue = "List of devices attached \n" +
+                      "adb server version (32) doesn't match this client (36); killing...\n" +
+                      "* daemon started successfully *\n" +
+                      "emulator-5554	device";
+    mocks.teen_process.expects("exec")
+      .once().withExactArgs(adb.executable.path, ['devices'])
+      .returns({stdout:stdoutValue});
+    
+    let devices = await adb.getConnectedDevices();
+    devices.should.have.length.above(0);
+    mocks.teen_process.verify();
+  });
   it('getConnectedDevices should fail when adb devices returns unexpected output', async () => {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['devices'])


### PR DESCRIPTION
Handle a new case that there is a message "adb server version (32) doesn't match this client (36); killing..." when the running adb doesn't match the appium-adb.

Ex:
adb.exe devices
List of devices attached
adb server version (32) doesn't match this client (36); killing...
\* daemon started successfully \*
0816f3699208ee6d        device