### PR TITLE
Remove third-party restriction from app installed check

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -12,11 +12,8 @@ apkUtilsMethods.isAppInstalled = async function (pkg) {
   try {
     let installed = false;
     log.debug(`Getting install status for ${pkg}`);
-    let apiLevel = await this.getApiLevel();
-    let thirdparty = apiLevel >= 15 ? "-3" : "";
-    let stdout = await this.shell(['pm', 'list', 'packages', thirdparty, pkg]);
-    let apkInstalledRgx = new RegExp(`^package:${pkg.replace(/(\.)/g, "\\$1")}$`,
-                                     'm');
+    let stdout = await this.shell(['pm', 'list', 'packages', pkg]);
+    let apkInstalledRgx = new RegExp(`^package:${pkg.replace(/(\.)/g, "\\$1")}$`, 'm');
     installed = apkInstalledRgx.test(stdout);
     log.debug(`App is${!installed ? ' not' : ''} installed`);
     return installed;

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -22,6 +22,9 @@ describe('apk utils', function () {
   before(async () => {
     adb = await ADB.createADB();
   });
+  it('should be able to check status of third party app', async () => {
+    (await adb.isAppInstalled('com.android.phone')).should.be.true;
+  });
   it('should be able to install/remove app and detect its status', async () => {
     (await adb.isAppInstalled('foo')).should.be.false;
     await adb.install(contactManagerPath);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -24,22 +24,16 @@ describe('Apk-utils', () => {
   describe('isAppInstalled', withMocks({adb}, (mocks) => {
     it('should parse correctly and return true', async () => {
       const pkg = 'dummy.package';
-      mocks.adb.expects('getApiLevel')
-        .once().withExactArgs()
-        .returns("17");
       mocks.adb.expects('shell')
-        .once().withExactArgs(['pm', 'list', 'packages', '-3', pkg])
+        .once().withExactArgs(['pm', 'list', 'packages', pkg])
         .returns(`package:${pkg}`);
       (await adb.isAppInstalled(pkg)).should.be.true;
       mocks.adb.verify();
     });
     it('should parse correctly and return false', async () => {
       const pkg = 'dummy.package';
-      mocks.adb.expects('getApiLevel')
-        .once().withExactArgs()
-        .returns("17");
       mocks.adb.expects('shell')
-        .once().withExactArgs(['pm', 'list', 'packages', '-3', pkg])
+        .once().withExactArgs(['pm', 'list', 'packages', pkg])
         .returns("");
       (await adb.isAppInstalled(pkg)).should.be.false;
       mocks.adb.verify();


### PR DESCRIPTION
There is no discernible reason to exclude third-party apps from the check. Resolves https://github.com/appium/appium/issues/5538