### PR TITLE
Be a little more defensive around permissions checking

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -125,14 +125,20 @@ methods.revokePermission = async function (pkg, permission) {
 
 methods.getGrantedPermissions = async function (pkg) {
   let stdout = await this.shell(['pm', 'dump', pkg]);
-  let reqPermissions = new RegExp(/install permissions:([\s\S]*?)DUMP OF SERVICE activity:/g).exec(stdout)[0].split("\n");
-  return await cleanUpReqPermissions(reqPermissions);
+  let match = new RegExp(/install permissions:([\s\S]*?)DUMP OF SERVICE activity:/g).exec(stdout);
+  if (!match) {
+    throw new Error('Unable to get granted permissions');
+  }
+  return await cleanUpReqPermissions(match[0].split('\n'));
 };
 
 methods.getReqPermissions = async function (pkg) {
   let stdout = await this.shell(['pm', 'dump', pkg]);
-  let reqPermissions = new RegExp(/requested permissions:([\s\S]*?)install permissions:/g).exec(stdout)[0].split("\n");
-  return await cleanUpReqPermissions(reqPermissions);
+  let match = new RegExp(/requested permissions:([\s\S]*?)install permissions:/g).exec(stdout);
+  if (!match) {
+    throw new Error('Unable to get requested permissions');
+  }
+  return await cleanUpReqPermissions(match[0].split('\n'));
 };
 
 async function cleanUpReqPermissions (reqPermissions) {


### PR DESCRIPTION
Throw a useful error, rather than an error about `0` not being a property of undefined, when there is no match (which seems to happen on Android 5.1).