### PR TITLE
Enable to set a wildcard value in appWaitActivity.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -209,23 +209,8 @@ function buildStartCmd (startAppOptions, apiLevel) {
   return cmd;
 }
 
-// turns pkg.activity.name to .activity.name
-// also turns activity.name to .activity.name
-function getPossibleActivityNames (pkgName, activityName) {
-  let names = [activityName];
-  // need to beware of namespaces with overlapping chars:
-  //   com.foo.bar
-  //   com.foo.barx
-  if (activityName.indexOf(`${pkgName}.`) === 0) {
-    names.push(activityName.substring(pkgName.length));
-  }
-  if (activityName[0] !== '.') {
-    names.push(`.${activityName}`);
-  }
-  return names;
-}
 
 export { getDirectories, getAndroidPlatformAndPath, unzipFile, assertZipArchive,
          getIMEListFromOutput, getJavaForOs, isShowingLockscreen, isCurrentFocusOnKeyguard,
-         getSurfaceOrientation, isScreenOnFully, buildStartCmd, getPossibleActivityNames,
-         getJavaHome, rootDir, androidPlatforms };
+         getSurfaceOrientation, isScreenOnFully, buildStartCmd, getJavaHome,
+         rootDir, androidPlatforms };

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -1,4 +1,4 @@
-import { buildStartCmd, getPossibleActivityNames } from '../helpers.js';
+import { buildStartCmd } from '../helpers.js';
 import { exec } from 'teen_process';
 import log from '../logger.js';
 import path from 'path';
@@ -119,15 +119,23 @@ apkUtilsMethods.waitForActivityOrNot = async function (pkg, activity, not,
   let allActivities = activity.split(",");
   for (let oneActivity of allActivities) {
     oneActivity = oneActivity.trim();
-    possibleActivityNames.push(...getPossibleActivityNames(pkg, oneActivity));
+    // Only accept fully qualified activity name.
+    if (!oneActivity.startsWith('.')) {
+      possibleActivityNames.push(oneActivity);
+    }
+    possibleActivityNames.push(`${pkg}.${oneActivity}`.replace(/\.+/g, '.'));
   }
   log.debug(`Possible activities, to be checked: ${possibleActivityNames.join(', ')}`);
+  let possibleActivityPatterns = possibleActivityNames.map((possibleActivityName) =>
+    new RegExp(`^${possibleActivityName.replace(/\./g, '\\.').replace(/\*/g, '.*?')}$`)
+  );
 
   while (Date.now() < endAt) {
     let {appPackage, appActivity} = await this.getFocusedPackageAndActivity();
-    log.debug(`Found package: '${appPackage}' and activity: '${appActivity}'`);
+    let fullyQualifiedActivity = appActivity.startsWith('.') ? `${appPackage}${appActivity}` : appActivity;
+    log.debug(`Found package: '${appPackage}' and fully qualified activity name : '${fullyQualifiedActivity}'`);
     let foundAct = ((appPackage === pkg) &&
-                    (_.findIndex(possibleActivityNames, (possibleActivity) => possibleActivity === appActivity) !== -1));
+                    (_.findIndex(possibleActivityPatterns, (possiblePattern) => possiblePattern.test(fullyQualifiedActivity)) !== -1));
     if ((!not && foundAct) || (not && !foundAct)) {
       return;
     }

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -83,6 +83,34 @@ describe('apk utils', function () {
                           waitActivity: '.ContactManager'});
       await assertPackageAndActivity();
     });
+    it('should start activity when wait activity is a wildcard', async () => {
+      await adb.install(contactManagerPath);
+      await adb.startApp({pkg: 'com.example.android.contactmanager',
+                          activity: 'ContactManager',
+                          waitActivity: '*'});
+      await assertPackageAndActivity();
+    });
+    it('should start activity when wait activity contains a wildcard', async () => {
+      await adb.install(contactManagerPath);
+      await adb.startApp({pkg: 'com.example.android.contactmanager',
+                          activity: 'ContactManager',
+                          waitActivity: '*.ContactManager'});
+      await assertPackageAndActivity();
+    });
+    it('should throw error for wrong activity when wait activity contains a wildcard', async () => {
+      await adb.install(contactManagerPath);
+      await adb.startApp({pkg: 'com.example.android.contactmanager',
+                          activity: 'SuperManager',
+                          waitActivity: '*.ContactManager'}).should.eventually
+                                                            .be.rejectedWith('Activity');
+    });
+    it('should throw error for wrong wait activity which contains wildcard', async () => {
+      await adb.install(contactManagerPath);
+      await adb.startApp({pkg: 'com.example.android.contactmanager',
+                          activity: 'ContactManager',
+                          waitActivity: '*.SuperManager'}).should.eventually
+                                                          .be.rejectedWith('SuperManager');
+    });
 
   });
   it('getFocusedPackageAndActivity should be able get package and activity', async () => {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -141,6 +141,70 @@ describe('Apk-utils', () => {
         .should.eventually.be.rejected;
       mocks.adb.verify();
     });
+    it('should be able to match activities if waitActivity is a wildcard', async () => {
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+                 `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
+
+      await adb.waitForActivityOrNot(pkg, `*`, false);
+      mocks.adb.verify();
+    });
+    it('should be able to match activities if waitActivity is shortened and contains a whildcard', async () => {
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+                 `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
+
+      await adb.waitForActivityOrNot(pkg, `.*Manager`, false);
+      mocks.adb.verify();
+    });
+    it('should be able to match activities if waitActivity contains a wildcard alternative to activity', async () => {
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+                 `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
+
+      await adb.waitForActivityOrNot(pkg, `${pkg}.*`, false);
+      mocks.adb.verify();
+    });
+    it('should be able to match activities if waitActivity contains a wildcard on head', async () => {
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+                 `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
+
+      await adb.waitForActivityOrNot(pkg, `*.contactmanager.ContactManager`, false);
+      mocks.adb.verify();
+    });
+    it('should be able to match activities if waitActivity contains a wildcard across a pkg name and an activity name', async () => {
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+                 `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
+
+      await adb.waitForActivityOrNot(pkg, `com.*Manager`, false);
+      mocks.adb.verify();
+    });
+    it('should be able to match activities if waitActivity contains wildcards in both a pkg name and an activity name', async () => {
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+                 `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
+
+      await adb.waitForActivityOrNot(pkg, `com.*.contactmanager.*Manager`, false);
+      mocks.adb.verify();
+    });
+    it('should fail if activity not to match from regexp activities', async () => {
+      mocks.adb.expects('shell')
+        .atLeast(1).withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+                 `ActivityRecord{2 u com.example.android.supermanager/.SuperManager t181}}}`);
+
+      await adb.waitForActivityOrNot('com.example.android.supermanager', `${pkg}.*`, false, 1000)
+        .should.eventually.be.rejected;
+      mocks.adb.verify();
+    });
   }));
   describe('waitForActivity', withMocks({adb}, (mocks) => {
     it('should call waitForActivityOrNot with correct arguments', async () => {

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -1,4 +1,4 @@
-import { getPossibleActivityNames, getDirectories, getAndroidPlatformAndPath,
+import { getDirectories, getAndroidPlatformAndPath,
          buildStartCmd } from '../../lib/helpers';
 import { withMocks } from 'appium-test-support';
 import { fs } from 'appium-support';
@@ -10,25 +10,6 @@ import _ from 'lodash';
 const should = chai.should;
 
 describe('helpers', () => {
-  describe('getPossibleActivityNames', () => {
-    it('should correctly remove pkg from pkg.activity.name', () => {
-      getPossibleActivityNames('pkg', 'pkg.activity.name')
-        .should.include('.activity.name');
-    });
-    it('should return .act.name when act.name is passed', () => {
-      getPossibleActivityNames('pkg', 'act.name')
-        .should.include('.act.name');
-    });
-    it('should not amend a valid activity name', () => {
-      getPossibleActivityNames('pkg', '.activity.name')
-        .should.include('.activity.name');
-    });
-    it('should handle case where application id is different from package name', () => {
-      getPossibleActivityNames('com.ga.aaa.android.bbb.activities.local', 'com.ga.aaa.android.bbb.activity.FirstLaunchActivity')
-        .should.include('com.ga.aaa.android.bbb.activity.FirstLaunchActivity');
-    });
-  });
-
   describe('getDirectories', withMocks({fs}, (mocks) => {
     it('should sort the directories', async () => {
       let rootPath = '/path/to/root';


### PR DESCRIPTION
Fixes appium/appium#7607
When an app contains multiple activities, it's difficult to target correct activity names.
This PR adds an ability to set appWaitActivity value containing wildcards.