### PR TITLE
change 'get AVD list command' in systemCallMethods.checkAvdExist

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -411,8 +411,8 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
 };
 
 systemCallMethods.checkAvdExist = async function (avdName) {
-  let cmd = await this.getSdkBinaryPath('android');
-  let args = ['list', 'avd', '-c'];
+  let cmd = await this.getSdkBinaryPath('emulator');
+  let args = ['-list-avds'];
   let {stdout} = await exec(cmd, args);
   if (stdout.indexOf(avdName) === -1) {
     let existings = `(${stdout.trim().replace(/[\n]/g, '), (')})`;


### PR DESCRIPTION
When I want to E2E test Android app with Google Play Services, appium-adb can't recognize AVD with Google API, test failed.
checkAvdExist `android list avd -c` command does not return AVD list with Google API.
So I change 'android list avd -c' to 'emulator -list-avds'.