### PR TITLE
Change 'get AVD list command' in systemCallMethods.checkAvdExist

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -411,11 +411,25 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
 };
 
 systemCallMethods.checkAvdExist = async function (avdName) {
-  let cmd = await this.getSdkBinaryPath('emulator');
-  let args = ['-list-avds'];
-  let {stdout} = await exec(cmd, args);
-  if (stdout.indexOf(avdName) === -1) {
-    let existings = `(${stdout.trim().replace(/[\n]/g, '), (')})`;
+  let cmd, args, result;
+  try {
+    cmd = await this.getSdkBinaryPath('emulator');
+    args = ['-list-avds'];
+    result = await exec(cmd, args);
+  } catch (e) {
+    let unknownOptionError = new RegExp("unknown option: -list-avds", "i").test(e.stderr);
+    if (!unknownOptionError) {
+      log.errorAndThrow(`Error executing checkAvdExist. Original error: '${e.message}'; ` +
+                        `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
+
+    }
+    // If -list-avds option is not available, use android command as an alternative
+    cmd = await this.getSdkBinaryPath('android');
+    args = ['list', 'avd', '-c'];
+    result = await exec(cmd, args);
+  }
+  if (result.stdout.indexOf(avdName) === -1) {
+    let existings = `(${result.stdout.trim().replace(/[\n]/g, '), (')})`;
     log.errorAndThrow(`Avd '${avdName}' is not available. please select your avd name from one of these: '${existings}'`);
   }
 };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -411,8 +411,8 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
 };
 
 systemCallMethods.checkAvdExist = async function (avdName) {
-  let cmd = await this.getSdkBinaryPath('android');
-  let args = ['list', 'avd', '-c'];
+  let cmd = await this.getSdkBinaryPath('emulator');
+  let args = ['-list-avds'];
   let {stdout} = await exec(cmd, args);
   if (stdout.indexOf(avdName) === -1) {
     let existings = `(${stdout.trim().replace(/[\n]/g, '), (')})`;


### PR DESCRIPTION
When I want to E2E test Android app with Google Play Services, appium-adb can't recognize AVD with Google API, test failed.
checkAvdExist `android list avd -c` command does not return AVD list with Google API.
So I change 'android list avd -c' to 'emulator -list-avds'.