### PR TITLE
Adding ability to check SDK version to user avdmanager or android to …

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,8 @@ import log from './logger.js';
 import AdmZip from 'adm-zip';
 import { exec } from 'teen_process';
 import _ from 'lodash';
-
+import readline from 'readline';
+import Promise from 'bluebird';
 
 const rootDir = path.resolve(__dirname, process.env.NO_PRECOMPILE ? '..' : '../..');
 const androidPlatforms = ['android-4.2', 'android-17', 'android-4.3', 'android-18',
@@ -89,6 +90,29 @@ function getIMEListFromOutput (stdout) {
   }
   return engines;
 }
+
+async function getSdkToolsVersion () {
+  return new Promise((resolve) => {
+    const androidHome = process.env.ANDROID_HOME;
+    let tools = path.resolve(androidHome, 'tools');
+
+    var rd = readline.createInterface({
+      input: fs.createReadStream(tools + '/source.properties'),
+      output: process.stdout,
+      console: false
+    });
+
+    rd.on('line', function (line) {
+      if (line.indexOf("Pkg.Revision") <= -1) {
+        return;
+      }
+      let version = line.substr(line.indexOf("="));
+      log.debug(`Using Android version: ${version}`);
+      resolve(version);
+    });
+  });
+}
+
 
 function getJavaForOs () {
   const sep = path.sep;
@@ -210,7 +234,7 @@ function buildStartCmd (startAppOptions, apiLevel) {
 }
 
 
-export { getDirectories, getAndroidPlatformAndPath, unzipFile, assertZipArchive,
+export { getDirectories, getSdkToolsVersion, getAndroidPlatformAndPath, unzipFile, assertZipArchive,
          getIMEListFromOutput, getJavaForOs, isShowingLockscreen, isCurrentFocusOnKeyguard,
          getSurfaceOrientation, isScreenOnFully, buildStartCmd, getJavaHome,
          rootDir, androidPlatforms };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -2,7 +2,7 @@ import path from 'path';
 import log from '../logger.js';
 import B from 'bluebird';
 import { system, fs } from 'appium-support';
-import { getDirectories } from '../helpers';
+import { getDirectories, getSdkToolsVersion } from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval } from 'asyncbox';
 
@@ -49,7 +49,8 @@ systemCallMethods.getBinaryFromSdkRoot = async function (binaryName) {
   let binaryLoc = null;
   binaryName = this.getBinaryNameForOS(binaryName);
   let binaryLocs = [path.resolve(this.sdkRoot, "platform-tools", binaryName),
-                    path.resolve(this.sdkRoot, "tools", binaryName)];
+                    path.resolve(this.sdkRoot, "tools", binaryName),
+                    path.resolve(this.sdkRoot, "tools/bin", binaryName)];
   // get subpaths for currently installed build tool directories
   let buildToolDirs = [];
   buildToolDirs = await getDirectories(path.resolve(this.sdkRoot, "build-tools"));
@@ -63,7 +64,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function (binaryName) {
     }
   }
   if (binaryLoc === null) {
-    throw new Error(`Could not find ${binaryName} in tools, platform-tools, ` +
+    throw new Error(`Could not find ${binaryName} in tools, tools/bin, platform-tools, ` +
                     `or supported build-tools under ${this.sdkRoot} ` +
                     `do you have the Android SDK installed at this location?`);
   }
@@ -91,6 +92,7 @@ systemCallMethods.getConnectedDevices = async function () {
   log.debug("Getting connected devices...");
   try {
     let {stdout} = await exec(this.executable.path, ['devices']);
+    log.debug("Executing command: " + this.executable.path + " devices");
     // expecting adb devices to return output as
     // List of devices attached
     // emulator-5554	device
@@ -420,14 +422,23 @@ systemCallMethods.checkAvdExist = async function (avdName) {
     let unknownOptionError = new RegExp("unknown option: -list-avds", "i").test(e.stderr);
     if (!unknownOptionError) {
       log.errorAndThrow(`Error executing checkAvdExist. Original error: '${e.message}'; ` +
-                        `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
-
+          `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
     }
-    // If -list-avds option is not available, use android command as an alternative
-    cmd = await this.getSdkBinaryPath('android');
-    args = ['list', 'avd', '-c'];
-    result = await exec(cmd, args);
+    let version = await getSdkToolsVersion();
+    let versionNumber = version.substr(0, version.indexOf("."));
+    if (versionNumber >= 25) {
+      // If SDK > 25 use avdmanager instead of android command
+      cmd = await this.getSdkBinaryPath('avdmanager');
+      args = ['list', 'avd', '-c'];
+      result = await exec(cmd, args);
+    } else {
+      // If -list-avds option is not available, use android command as an alternative
+      cmd = await this.getSdkBinaryPath('android');
+      args = ['list', 'avd', '-c'];
+      result = await exec(cmd, args);
+    }
   }
+
   if (result.stdout.indexOf(avdName) === -1) {
     let existings = `(${result.stdout.trim().replace(/[\n]/g, '), (')})`;
     log.errorAndThrow(`Avd '${avdName}' is not available. please select your avd name from one of these: '${existings}'`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-adb",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "Android Debug Bridge interface",
   "main": "./build/index.js",
   "scripts": {


### PR DESCRIPTION
…find AVD

Since android SDK 25 the avd search now is made with avdmanager instead
of android. Me and @aquintiliano made a method to check the SDK version
and if it’s > 25 will use the avdmanager instead of android