### PR TITLE
Fix getting non-granted permissions

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -129,7 +129,8 @@ methods.getGrantedPermissions = async function (pkg) {
   if (!match) {
     throw new Error('Unable to get granted permissions');
   }
-  return match[0].match(/(android\.permission\.\w+):\sgranted=true/g) || [];
+  return (match[0].match(/android\.permission\.\w+:\sgranted=true/g) || [])
+    .map(x => x.replace(/:\sgranted=true/g, ''));
 };
 
 methods.getNonGrantedPermissions = async function (pkg) {
@@ -138,7 +139,8 @@ methods.getNonGrantedPermissions = async function (pkg) {
   if (!match) {
     throw new Error('Unable to get non-granted permissions');
   }
-  return match[0].match(/(android\.permission\.\w+):\sgranted=false/g) || [];
+  return (match[0].match(/(android\.permission\.\w+):\sgranted=false/g) || [])
+    .map(x => x.replace(/:\sgranted=false/g, ''));
 };
 
 methods.getReqPermissions = async function (pkg) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -92,7 +92,7 @@ methods.grantAllPermissions = async function (pkg, apk) {
      * The app has to list the permissions in the manifest.
      * refer: https://developer.android.com/training/permissions/requesting.html
      */
-    let permissions = await this.getReqPermissions(pkg);
+    let permissions = await this.getNonGrantedPermissions(pkg);
     let cmd = [];
     for (let permission of permissions) {
       //As it consumes more time for granting each permission,
@@ -129,7 +129,16 @@ methods.getGrantedPermissions = async function (pkg) {
   if (!match) {
     throw new Error('Unable to get granted permissions');
   }
-  return await cleanUpReqPermissions(match[0].split('\n'));
+  return match[0].match(/(android\.permission\.\w+):\sgranted=true/g) || [];
+};
+
+methods.getNonGrantedPermissions = async function (pkg) {
+  let stdout = await this.shell(['pm', 'dump', pkg]);
+  let match = new RegExp(/install permissions:([\s\S]*?)DUMP OF SERVICE activity:/g).exec(stdout);
+  if (!match) {
+    throw new Error('Unable to get non-granted permissions');
+  }
+  return match[0].match(/(android\.permission\.\w+):\sgranted=false/g) || [];
 };
 
 methods.getReqPermissions = async function (pkg) {
@@ -138,14 +147,8 @@ methods.getReqPermissions = async function (pkg) {
   if (!match) {
     throw new Error('Unable to get requested permissions');
   }
-  return await cleanUpReqPermissions(match[0].split('\n'));
+  return match[0].match(/(android\.permission\.\w+)/g) || [];
 };
-
-async function cleanUpReqPermissions (reqPermissions) {
-  return reqPermissions
-      .filter((p) => p.trim().startsWith('android.permission'))
-      .map((p) => p.trim().replace(': granted=true', ''));
-}
 
 methods.stopAndClear = async function (pkg) {
   try {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -139,7 +139,7 @@ methods.getNonGrantedPermissions = async function (pkg) {
   if (!match) {
     throw new Error('Unable to get non-granted permissions');
   }
-  return (match[0].match(/(android\.permission\.\w+):\sgranted=false/g) || [])
+  return (match[0].match(/android\.permission\.\w+:\sgranted=false/g) || [])
     .map(x => x.replace(/:\sgranted=false/g, ''));
 };
 
@@ -149,7 +149,7 @@ methods.getReqPermissions = async function (pkg) {
   if (!match) {
     throw new Error('Unable to get requested permissions');
   }
-  return match[0].match(/(android\.permission\.\w+)/g) || [];
+  return match[0].match(/android\.permission\.\w+/g) || [];
 };
 
 methods.stopAndClear = async function (pkg) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -92,9 +92,12 @@ methods.grantAllPermissions = async function (pkg, apk) {
      * The app has to list the permissions in the manifest.
      * refer: https://developer.android.com/training/permissions/requesting.html
      */
-    let permissions = await this.getNonGrantedPermissions(pkg);
+    const stdout = await this.shell(['pm', 'dump', pkg]);
+    const requestedPermissions = await this.getReqPermissions(pkg, stdout);
+    const grantedPermissions = await this.getGrantedPermissions(pkg, stdout);
+    const permissonsToGrant = requestedPermissions.filter(x => grantedPermissions.indexOf(x) < 0);
     let cmd = [];
-    for (let permission of permissions) {
+    for (let permission of permissonsToGrant) {
       //As it consumes more time for granting each permission,
       //trying to grant all permission by forming equivalent command.
       cmd.push('pm', 'grant', pkg, permission, ';');
@@ -123,8 +126,8 @@ methods.revokePermission = async function (pkg, permission) {
   }
 };
 
-methods.getGrantedPermissions = async function (pkg) {
-  let stdout = await this.shell(['pm', 'dump', pkg]);
+methods.getGrantedPermissions = async function (pkg, cmdOutput = null) {
+  let stdout = cmdOutput || await this.shell(['pm', 'dump', pkg]);
   let match = new RegExp(/install permissions:([\s\S]*?)DUMP OF SERVICE activity:/g).exec(stdout);
   if (!match) {
     throw new Error('Unable to get granted permissions');
@@ -133,18 +136,18 @@ methods.getGrantedPermissions = async function (pkg) {
     .map(x => x.replace(/:\sgranted=true/g, ''));
 };
 
-methods.getNonGrantedPermissions = async function (pkg) {
-  let stdout = await this.shell(['pm', 'dump', pkg]);
+methods.getDeniedPermissions = async function (pkg, cmdOutput = null) {
+  let stdout = cmdOutput || await this.shell(['pm', 'dump', pkg]);
   let match = new RegExp(/install permissions:([\s\S]*?)DUMP OF SERVICE activity:/g).exec(stdout);
   if (!match) {
-    throw new Error('Unable to get non-granted permissions');
+    throw new Error('Unable to get denied permissions');
   }
   return (match[0].match(/android\.permission\.\w+:\sgranted=false/g) || [])
     .map(x => x.replace(/:\sgranted=false/g, ''));
 };
 
-methods.getReqPermissions = async function (pkg) {
-  let stdout = await this.shell(['pm', 'dump', pkg]);
+methods.getReqPermissions = async function (pkg, cmdOutput = null) {
+  let stdout = cmdOutput || await this.shell(['pm', 'dump', pkg]);
   let match = new RegExp(/requested permissions:([\s\S]*?)install permissions:/g).exec(stdout);
   if (!match) {
     throw new Error('Unable to get requested permissions');

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -720,9 +720,9 @@ describe('adb commands', () => {
         result.should.not.include(perm);
       }
     });
-    it('should properly list non-granted permissions', async () => {
+    it('should properly list denied permissions', async () => {
       mocks.adb.expects("shell").once().returns(dumpedOutput);
-      const result = await adb.getNonGrantedPermissions('io.appium.android');
+      const result = await adb.getDeniedPermissions('io.appium.android');
       for (let perm of ['android.permission.MODIFY_AUDIO_SETTINGS',
                         'android.permission.RECEIVE_BOOT_COMPLETED',
                         'android.permission.BLUETOOTH',

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -678,7 +678,7 @@ describe('adb commands', () => {
     });
     it('should properly list requested permissions', async () => {
       mocks.adb.expects("shell").once().returns(dumpedOutput);
-      const result = await adb.getGrantedPermissions('io.appium.android');
+      const result = await adb.getReqPermissions('io.appium.android');
       for (let perm of ['android.permission.ACCESS_NETWORK_STATE',
                         'android.permission.WRITE_EXTERNAL_STORAGE',
                         'android.permission.INTERNET',


### PR DESCRIPTION
This should speed up granting permissions for apps, since not all permissions should be granted explicitly. Some of them are considered as "normal" and are granted by default. See https://developer.android.com/guide/topics/permissions/requesting.html#normal-dangerous for more details.