### PR TITLE
Add installOrUpgrade method to improve utilities setup

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -209,7 +209,7 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60
     return;
   }
   if (!await this.isAppInstalled(pkg)) {
-    await this.installApk(apk, false, timeout);
+    await this.install(apk, false, timeout);
     return;
   }
   const pkgInfo = this.getPackageInfo(pkg);
@@ -229,13 +229,13 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60
   log.debug(`The installed "${pkg}" package is older than ${apk} (${pkgVersionCode} < ${apkVersionCode}). ` +
             `Executing upgrade`);
   try {
-    await this.installApk(apk, true, timeout);
+    await this.install(apk, true, timeout);
   } catch (err) {
     log.warn(`Cannot upgrade ${pkg} because of "${err.message}". Trying full reinstall`);
     if (!await this.uninstallApk(pkg)) {
       log.errorAndThrow(`"${pkg}" package cannot be uninstalled`);
     }
-    await this.installApk(apk, false, timeout);
+    await this.install(apk, false, timeout);
   }
 };
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -198,6 +198,47 @@ apkUtilsMethods.install = async function (apk, replace = true, timeout = 60000) 
   }
 };
 
+apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60000) {
+  let apkInfo = null;
+  if (!pkg) {
+    apkInfo = await this.getApkInfo(apk);
+    pkg = apkInfo.name;
+  }
+  if (!pkg) {
+    log.warn(`Cannot read the package name of ${apk}. Assuming correct app version is already installed`);
+    return;
+  }
+  if (!await this.isAppInstalled(pkg)) {
+    await this.adbExec(['install', apk], {timeout});
+    return;
+  }
+  const pkgInfo = this.getPackageInfo(pkg);
+  const pkgVersionCode = pkgInfo.versionCode;
+  if (!apkInfo) {
+    apkInfo = await this.getApkInfo(apk);
+  }
+  const apkVersionCode = apkInfo.versionCode;
+  if (!_.isUndefined(apkVersionCode) && !_.isUndefined(pkgVersionCode)) {
+    if (pkgVersionCode >= apkVersionCode) {
+      log.debug(`The installed "${pkg}" package does not require upgrade (${pkgVersionCode} >= ${apkVersionCode})`);
+      return;
+    }
+    log.debug(`The installed "${pkg}" package is older than ${apk} (${pkgVersionCode} < ${apkVersionCode}). ` +
+              `Executing upgrade`);
+    try {
+      await this.adbExec(['install', '-r', apk], {timeout});
+    } catch (err1) {
+      log.warn(`Cannot upgrade ${pkg} because of "${err1.message}". Trying full reinstall`);
+      if (!await this.uninstallApk(pkg)) {
+        log.errorAndThrow(`"${pkg}" package cannot be uninstalled`);
+      }
+      await this.adbExec(['install', apk], {timeout});
+    }
+    return;
+  }
+  log.warn(`Cannot read version codes of ${apk} and/or ${pkg}. Assuming correct app version is already installed`);
+};
+
 apkUtilsMethods.extractStringsFromApk = async function (apk, language, out) {
   log.debug(`Extracting strings for language: ${language || "default"}`);
   let stringsJson = 'strings.json';

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -209,7 +209,7 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60
     return;
   }
   if (!await this.isAppInstalled(pkg)) {
-    await this.adbExec(['install', apk], {timeout});
+    await this.installApk(apk, false, timeout);
     return;
   }
   const pkgInfo = this.getPackageInfo(pkg);
@@ -218,25 +218,25 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60
     apkInfo = await this.getApkInfo(apk);
   }
   const apkVersionCode = apkInfo.versionCode;
-  if (!_.isUndefined(apkVersionCode) && !_.isUndefined(pkgVersionCode)) {
-    if (pkgVersionCode >= apkVersionCode) {
-      log.debug(`The installed "${pkg}" package does not require upgrade (${pkgVersionCode} >= ${apkVersionCode})`);
-      return;
-    }
-    log.debug(`The installed "${pkg}" package is older than ${apk} (${pkgVersionCode} < ${apkVersionCode}). ` +
-              `Executing upgrade`);
-    try {
-      await this.adbExec(['install', '-r', apk], {timeout});
-    } catch (err1) {
-      log.warn(`Cannot upgrade ${pkg} because of "${err1.message}". Trying full reinstall`);
-      if (!await this.uninstallApk(pkg)) {
-        log.errorAndThrow(`"${pkg}" package cannot be uninstalled`);
-      }
-      await this.adbExec(['install', apk], {timeout});
-    }
+  if (_.isUndefined(apkVersionCode) || _.isUndefined(pkgVersionCode)) {
+    log.warn(`Cannot read version codes of ${apk} and/or ${pkg}. Assuming correct app version is already installed`);
     return;
   }
-  log.warn(`Cannot read version codes of ${apk} and/or ${pkg}. Assuming correct app version is already installed`);
+  if (pkgVersionCode >= apkVersionCode) {
+    log.debug(`The installed "${pkg}" package does not require upgrade (${pkgVersionCode} >= ${apkVersionCode})`);
+    return;
+  }
+  log.debug(`The installed "${pkg}" package is older than ${apk} (${pkgVersionCode} < ${apkVersionCode}). ` +
+            `Executing upgrade`);
+  try {
+    await this.installApk(apk, true, timeout);
+  } catch (err) {
+    log.warn(`Cannot upgrade ${pkg} because of "${err.message}". Trying full reinstall`);
+    if (!await this.uninstallApk(pkg)) {
+      log.errorAndThrow(`"${pkg}" package cannot be uninstalled`);
+    }
+    await this.installApk(apk, false, timeout);
+  }
 };
 
 apkUtilsMethods.extractStringsFromApk = async function (apk, language, out) {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -500,7 +500,7 @@ describe('Apk-utils', () => {
         name: pkgId
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(false);
-      mocks.adb.expects('installApk').withArgs(apkPath, false).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, false).once().returns(true);
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
@@ -562,7 +562,7 @@ describe('Apk-utils', () => {
         versionCode: 1
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('installApk').withArgs(apkPath, true).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, true).once().returns(true);
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
@@ -576,7 +576,7 @@ describe('Apk-utils', () => {
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('installApk').withArgs(apkPath).twice().throws();
+      mocks.adb.expects('install').withArgs(apkPath).twice().throws();
       let isExceptionThrown = false;
       try {
         await adb.installOrUpgrade(apkPath);
@@ -596,7 +596,7 @@ describe('Apk-utils', () => {
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns(false);
-      mocks.adb.expects('installApk').withArgs(apkPath, true).once().throws();
+      mocks.adb.expects('install').withArgs(apkPath, true).once().throws();
       let isExceptionThrown = false;
       try {
         await adb.installOrUpgrade(apkPath);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -496,106 +496,115 @@ describe('Apk-utils', () => {
     const apkPath = '/path/to/my.apk';
 
     it('should execute install if the package is not present', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(false);
-      mocks.adb.expects('adbExec').once().returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(false);
+      mocks.adb.expects('installApk').withArgs(apkPath, false).once().returns(true);
       await adb.installOrUpgrade(apkPath);
+      mocks.adb.verify();
     });
     it('should return if the same package version is already installed', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         versionCode: 1
       });
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 1
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       await adb.installOrUpgrade(apkPath, pkgId);
+      mocks.adb.verify();
     });
     it('should return if newer package version is already installed', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 1
       });
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 2
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       await adb.installOrUpgrade(apkPath);
+      mocks.adb.verify();
     });
     it('should not throw an error if apk version code cannot be read', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId
       });
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 2
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       await adb.installOrUpgrade(apkPath);
+      mocks.adb.verify();
     });
     it('should not throw an error if pkg version code cannot be read', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 1
       });
       mocks.adb.expects('getPackageInfo').once().returns({});
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       await adb.installOrUpgrade(apkPath);
+      mocks.adb.verify();
     });
     it('should not throw an error if pkg id cannot be read', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({});
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({});
       await adb.installOrUpgrade(apkPath);
+      mocks.adb.verify();
     });
     it('should perform upgrade if older package version is installed', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 2
       });
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 1
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(true);
-      mocks.adb.expects('adbExec').once().returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
+      mocks.adb.expects('installApk').withArgs(apkPath, true).once().returns(true);
       await adb.installOrUpgrade(apkPath);
+      mocks.adb.verify();
     });
     it('should throw an exception if upgrade and reinstall fail', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 2
       });
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 1
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(true);
-      mocks.adb.expects('uninstallApk').withExactArgs([pkgId]).once().returns(true);
-      mocks.adb.expects('adbExec').twice().throws();
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
+      mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns(true);
+      mocks.adb.expects('installApk').withArgs(apkPath).twice().throws();
       let isExceptionThrown = false;
       try {
         await adb.installOrUpgrade(apkPath);
       } catch (e) {
         isExceptionThrown = true;
       }
-      isExceptionThrown.should.be.true();
+      isExceptionThrown.should.be.true;
+      mocks.adb.verify();
     });
     it('should throw an exception if upgrade and uninstall fail', async () => {
-      mocks.adb.expects('getApkInfo').withExactArgs([apkPath]).once().returns({
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 2
       });
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 1
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs([pkgId]).once().returns(true);
-      mocks.adb.expects('uninstallApk').withExactArgs([pkgId]).once().returns(false);
-      mocks.adb.expects('adbExec').once().throws();
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
+      mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns(false);
+      mocks.adb.expects('installApk').withArgs(apkPath, true).once().throws();
       let isExceptionThrown = false;
       try {
         await adb.installOrUpgrade(apkPath);
       } catch (e) {
         isExceptionThrown = true;
       }
-      isExceptionThrown.should.be.true();
+      isExceptionThrown.should.be.true;
+      mocks.adb.verify();
     });
   }));
 });


### PR DESCRIPTION
The currently present _install_ method is unable to properly upgrade a package if an older version is already installed