### PR TITLE
Add method to rotate emulators

### DIFF
--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -18,40 +18,33 @@ emuMethods.isEmulatorConnected = async function (udid) {
   return false;
 };
 
+emuMethods.checkEmulatorConnected = async function (udid) {
+  if (!_.isUndefined(udid) && !(await this.isEmulatorConnected(udid)) ) {
+    log.errorAndThrow(`Device '${udid}' is not available.`);
+  } else if ((await this.getConnectedEmulators()).length === 0) {
+    log.errorAndThrow('No devices connected');
+  }
+  if (!_.isUndefined(udid)) {
+    await this.setDeviceId(udid);
+  }
+};
+
 emuMethods.fingerprint = async function (fingerprintId, udid = undefined) {
   if (!fingerprintId) {
     log.errorAndThrow('Fingerprint id parameter must be defined');
   }
-
   // the method used only works for API level 23 and above
   let level = await this.getApiLevel();
   if (parseInt(level, 10) < 23) {
     log.errorAndThrow(`Device API Level must be >= 23. Current Api level '${level}'`);
   }
-
-  if (!_.isUndefined(udid) && !(await this.isEmulatorConnected(udid)) ) {
-    log.errorAndThrow(`Device '${udid}' is not available.`);
-  } else if ((await this.getConnectedEmulators()).length === 0) {
-    log.errorAndThrow('No devices connected');
-  }
-
-  if (udid) {
-    await this.setDeviceId(udid);
-  }
+  await this.checkEmulatorConnected(udid);
   this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'finger', 'touch', fingerprintId]);
 };
 
 emuMethods.rotate = async function (udid) {
-  if (!_.isUndefined(udid) && !(await this.isEmulatorConnected(udid)) ) {
-    log.errorAndThrow(`Device '${udid}' is not available.`);
-  } else if ((await this.getConnectedEmulators()).length === 0) {
-    log.errorAndThrow('No devices connected');
-  }
-
-  if (!_.isUndefined(udid)) {
-    await this.setDeviceId(udid);
-  }
+  await this.checkEmulatorConnected(udid);
   this.resetTelnetAuthToken();
   this.adbExec(['emu', 'rotate']);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -19,6 +19,12 @@ emuMethods.isEmulatorConnected = async function () {
   return !!_.find(emulators, (x) => x && x.udid === this.curDeviceId);
 };
 
+emuMethods.checkEmulatorConnected = async function () {
+  if (!(await this.isEmulatorConnected())) {
+    log.errorAndThrow(`Emulator ${this.curDeviceId} disconnected!`);
+  }
+};
+
 emuMethods.fingerprint = async function (fingerprintId) {
   if (!fingerprintId) {
     log.errorAndThrow('Fingerprint id parameter must be defined');
@@ -28,13 +34,13 @@ emuMethods.fingerprint = async function (fingerprintId) {
   if (parseInt(level, 10) < 23) {
     log.errorAndThrow(`Device API Level must be >= 23. Current Api level '${level}'`);
   }
-  await this.isEmulatorConnected();
+  await this.checkEmulatorConnected();
   await this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'finger', 'touch', fingerprintId]);
 };
 
 emuMethods.rotate = async function () {
-  await this.isEmulatorConnected();
+  await this.checkEmulatorConnected();
   await this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'rotate']);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -28,8 +28,12 @@ emuMethods.isEmulatorConnected = async function (udid) {
 };
 
 emuMethods.checkEmulatorConnected = async function (udid) {
-  if (!_.isUndefined(udid) && !(await this.isEmulatorConnected(udid)) ) {
-    log.errorAndThrow(`Device '${udid}' is not available.`);
+  if (!_.isUndefined(udid)) {
+    if (await this.isEmulatorConnected(udid)) {
+      await this.setDeviceId(udid);
+    } else {
+      log.errorAndThrow(`Device '${udid}' is not available.`);
+    }
   } else if ((await this.getEmulators()).length === 0) {
     log.errorAndThrow('No devices connected');
   }

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -14,27 +14,12 @@ emuMethods.getEmulators = async function() {
   return this.emulators;
 };
 
-emuMethods.isEmulatorConnected = async function (udid) {
+emuMethods.isEmulatorConnected = async function () {
   let emulators = await this.getEmulators();
-  if (!emulators.length) {
-    return false;
-  }
-  return !!_.find(emulators, (x) => x && x.udid === udid);
+  return !!_.find(emulators, (x) => x && x.udid === this.curDeviceId);
 };
 
-emuMethods.checkEmulatorConnected = async function (udid) {
-  if (!_.isUndefined(udid)) {
-    if (await this.isEmulatorConnected(udid)) {
-      await this.setDeviceId(udid);
-    } else {
-      log.errorAndThrow(`Device '${udid}' is not available.`);
-    }
-  } else if ((await this.getEmulators()).length === 0) {
-    log.errorAndThrow('No devices connected');
-  }
-};
-
-emuMethods.fingerprint = async function (fingerprintId, udid = undefined) {
+emuMethods.fingerprint = async function (fingerprintId) {
   if (!fingerprintId) {
     log.errorAndThrow('Fingerprint id parameter must be defined');
   }
@@ -43,13 +28,13 @@ emuMethods.fingerprint = async function (fingerprintId, udid = undefined) {
   if (parseInt(level, 10) < 23) {
     log.errorAndThrow(`Device API Level must be >= 23. Current Api level '${level}'`);
   }
-  await this.checkEmulatorConnected(udid);
+  await this.isEmulatorConnected();
   await this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'finger', 'touch', fingerprintId]);
 };
 
-emuMethods.rotate = async function (udid) {
-  await this.checkEmulatorConnected(udid);
+emuMethods.rotate = async function () {
+  await this.isEmulatorConnected();
   await this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'rotate']);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -21,7 +21,7 @@ emuMethods.isEmulatorConnected = async function () {
 
 emuMethods.checkEmulatorConnected = async function () {
   if (!(await this.isEmulatorConnected())) {
-    log.errorAndThrow(`Emulator ${this.curDeviceId} disconnected!`);
+    log.errorAndThrow(`The emulator "${this.curDeviceId}" was unexpectedly disconnected`);
   }
 };
 

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -38,7 +38,13 @@ emuMethods.fingerprint = async function (fingerprintId, udid = undefined) {
   if (udid) {
     await this.setDeviceId(udid);
   }
+  this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'finger', 'touch', fingerprintId]);
+};
+
+emuMethods.rotate = async function () {
+  this.resetTelnetAuthToken();
+  this.adbExec(['emu', 'rotate']);
 };
 
 emuMethods.resetTelnetAuthToken = async function () {

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -5,17 +5,8 @@ import path from 'path';
 
 let emuMethods = {};
 
-emuMethods.getEmulators = async function() {
-  if (_.isArray(this.emulators) &&
-      this.emulators.length) {
-    return this.emulators;
-  }
-  this.emulators = await this.getConnectedEmulators();
-  return this.emulators;
-};
-
 emuMethods.isEmulatorConnected = async function () {
-  let emulators = await this.getEmulators();
+  let emulators = await this.getConnectedEmulators();
   return !!_.find(emulators, (x) => x && x.udid === this.curDeviceId);
 };
 

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -10,7 +10,7 @@ emuMethods.isEmulatorConnected = async function () {
   return !!_.find(emulators, (x) => x && x.udid === this.curDeviceId);
 };
 
-emuMethods.checkEmulatorConnected = async function () {
+emuMethods.verifyEmulatorConnected = async function () {
   if (!(await this.isEmulatorConnected())) {
     log.errorAndThrow(`The emulator "${this.curDeviceId}" was unexpectedly disconnected`);
   }
@@ -25,13 +25,13 @@ emuMethods.fingerprint = async function (fingerprintId) {
   if (parseInt(level, 10) < 23) {
     log.errorAndThrow(`Device API Level must be >= 23. Current Api level '${level}'`);
   }
-  await this.checkEmulatorConnected();
+  await this.verifyEmulatorConnected();
   await this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'finger', 'touch', fingerprintId]);
 };
 
 emuMethods.rotate = async function () {
-  await this.checkEmulatorConnected();
+  await this.verifyEmulatorConnected();
   await this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'rotate']);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -5,8 +5,17 @@ import path from 'path';
 
 let emuMethods = {};
 
+emuMethods.getEmulators = async function() {
+  if (_.isArray(this.emulators) &&
+      this.emulators.length !== 0) {
+    return this.emulators;
+  }
+  this.emulators = await this.getConnectedEmulators();
+  return this.emulators;
+};
+
 emuMethods.isEmulatorConnected = async function (udid) {
-  let emulators = await this.getConnectedEmulators();
+  let emulators = await this.getEmulators();
   if (!emulators.length) {
     return false;
   }
@@ -21,11 +30,8 @@ emuMethods.isEmulatorConnected = async function (udid) {
 emuMethods.checkEmulatorConnected = async function (udid) {
   if (!_.isUndefined(udid) && !(await this.isEmulatorConnected(udid)) ) {
     log.errorAndThrow(`Device '${udid}' is not available.`);
-  } else if ((await this.getConnectedEmulators()).length === 0) {
+  } else if ((await this.getEmulators()).length === 0) {
     log.errorAndThrow('No devices connected');
-  }
-  if (!_.isUndefined(udid)) {
-    await this.setDeviceId(udid);
   }
 };
 
@@ -39,14 +45,14 @@ emuMethods.fingerprint = async function (fingerprintId, udid = undefined) {
     log.errorAndThrow(`Device API Level must be >= 23. Current Api level '${level}'`);
   }
   await this.checkEmulatorConnected(udid);
-  this.resetTelnetAuthToken();
+  await this.resetTelnetAuthToken();
   await this.adbExec(['emu', 'finger', 'touch', fingerprintId]);
 };
 
 emuMethods.rotate = async function (udid) {
   await this.checkEmulatorConnected(udid);
-  this.resetTelnetAuthToken();
-  this.adbExec(['emu', 'rotate']);
+  await this.resetTelnetAuthToken();
+  await this.adbExec(['emu', 'rotate']);
 };
 
 emuMethods.resetTelnetAuthToken = async function () {

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -42,7 +42,16 @@ emuMethods.fingerprint = async function (fingerprintId, udid = undefined) {
   await this.adbExec(['emu', 'finger', 'touch', fingerprintId]);
 };
 
-emuMethods.rotate = async function () {
+emuMethods.rotate = async function (udid) {
+  if (!_.isUndefined(udid) && !(await this.isEmulatorConnected(udid)) ) {
+    log.errorAndThrow(`Device '${udid}' is not available.`);
+  } else if ((await this.getConnectedEmulators()).length === 0) {
+    log.errorAndThrow('No devices connected');
+  }
+
+  if (!_.isUndefined(udid)) {
+    await this.setDeviceId(udid);
+  }
   this.resetTelnetAuthToken();
   this.adbExec(['emu', 'rotate']);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -7,7 +7,7 @@ let emuMethods = {};
 
 emuMethods.getEmulators = async function() {
   if (_.isArray(this.emulators) &&
-      this.emulators.length !== 0) {
+      this.emulators.length) {
     return this.emulators;
   }
   this.emulators = await this.getConnectedEmulators();

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -19,12 +19,7 @@ emuMethods.isEmulatorConnected = async function (udid) {
   if (!emulators.length) {
     return false;
   }
-  for (let emulator of emulators) {
-    if (emulator.udid === udid) {
-      return true;
-    }
-  }
-  return false;
+  return !!_.find(emulators, (x) => x && x.udid === udid);
 };
 
 emuMethods.checkEmulatorConnected = async function (udid) {

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -21,38 +21,22 @@ describe('adb emulator commands', () => {
         mocks.adb.expects("getConnectedEmulators")
           .once().withExactArgs()
           .returns(emulators);
-        (await adb.isEmulatorConnected("emulator-5554")).should.equal(true);
-        (await adb.isEmulatorConnected("emulator-5554")).should.equal(true);
+        await adb.getEmulators();
         adb.emulators.should.equal(emulators);
         mocks.adb.verify();
       });
     }));
     describe("isEmulatorConnected", withMocks({adb}, (mocks) => {
       it("should verify emulators state", async () => {
-        (await adb.isEmulatorConnected("emulator-5554")).should.equal(true);
-        (await adb.isEmulatorConnected("emulator-5556")).should.equal(true);
-        (await adb.isEmulatorConnected("emulator-5558")).should.equal(false);
-        mocks.adb.verify();
-      });
-    }));
-    describe("checkEmulatorConnected", withMocks({adb}, (mocks) => {
-      it("should throw exception no emulators connected", async () => {
-        delete adb.emulators;
-        mocks.adb.expects("getConnectedEmulators")
-          .once().withExactArgs()
-          .returns([]);
-        await adb.checkEmulatorConnected().should.eventually.be.rejected;
-        await adb.checkEmulatorConnected("emulator-5554").should.eventually.be.rejected;
-        mocks.adb.verify();
-      });
-      it("should setDeviceId on emulator connected", async () => {
-        mocks.adb.expects("isEmulatorConnected")
-          .once().withExactArgs("emulator-5554")
-          .returns(true);
-        mocks.adb.expects("setDeviceId")
-          .once().withExactArgs("emulator-5554")
+        mocks.adb.expects("getEmulators")
+          .atLeast(3)
           .returns(emulators);
-        await adb.checkEmulatorConnected("emulator-5554");
+        adb.curDeviceId = "emulator-5554";
+        (await adb.isEmulatorConnected()).should.equal(true);
+        adb.curDeviceId = "emulator-5556";
+        (await adb.isEmulatorConnected()).should.equal(true);
+        adb.curDeviceId = "emulator-5558";
+        (await adb.isEmulatorConnected()).should.equal(false);
         mocks.adb.verify();
       });
     }));
@@ -72,9 +56,9 @@ describe('adb emulator commands', () => {
         mocks.adb.expects("getApiLevel")
           .once().withExactArgs()
           .returns(23);
-        mocks.adb.expects("getConnectedEmulators")
+        mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
-          .returns(emulators);
+          .returns(true);
         mocks.adb.expects("resetTelnetAuthToken")
           .once().withExactArgs()
           .returns();
@@ -87,10 +71,9 @@ describe('adb emulator commands', () => {
     }));
     describe("rotate", withMocks({adb}, (mocks) => {
       it("should call adbExec with the correct args", async () => {
-        delete adb.emulators;
-        mocks.adb.expects("getConnectedEmulators")
+        mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
-          .returns(emulators);
+          .returns(true);
         mocks.adb.expects("resetTelnetAuthToken")
           .once().withExactArgs()
           .returns();

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -87,6 +87,18 @@ describe('adb emulator commands', () => {
         await adb.rotate();
         mocks.adb.verify();
       });
+      it("should call adb exec with the correct rotate args", async () => {
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "rotate"]);
+        mocks.adb.expects("setDeviceId")
+          .once().withExactArgs("emulator-5554")
+          .returns();
+        mocks.adb.expects("getConnectedEmulators")
+          .atLeast(1).withExactArgs()
+          .returns(emulators);
+        await adb.rotate("emulator-5554");
+        mocks.adb.verify();
+      });
     }));
   });
 });

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -30,13 +30,13 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
     }));
-    describe("checkEmulatorConnected", withMocks({adb}, (mocks) => {
+    describe("verifyEmulatorConnected", withMocks({adb}, (mocks) => {
       it("should throw an exception on emulator not connected", async () => {
         adb.curDeviceId = "emulator-5558";
         mocks.adb.expects("isEmulatorConnected")
           .once()
           .returns(false);
-        await adb.checkEmulatorConnected().should.eventually.be.rejected;
+        await adb.verifyEmulatorConnected().should.eventually.be.rejected;
         mocks.adb.verify();
       });
     }));

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -16,19 +16,9 @@ const fingerprintId = 1111;
 describe('adb emulator commands', () => {
   let adb = new ADB();
   describe("emu", () => {
-    describe("getEmulators", withMocks({adb}, (mocks) => {
-      it("should cache emulators list", async () => {
-        mocks.adb.expects("getConnectedEmulators")
-          .once().withExactArgs()
-          .returns(emulators);
-        await adb.getEmulators();
-        adb.emulators.should.equal(emulators);
-        mocks.adb.verify();
-      });
-    }));
     describe("isEmulatorConnected", withMocks({adb}, (mocks) => {
       it("should verify emulators state", async () => {
-        mocks.adb.expects("getEmulators")
+        mocks.adb.expects("getConnectedEmulators")
           .atLeast(3)
           .returns(emulators);
         adb.curDeviceId = "emulator-5554";

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -40,6 +40,16 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
     }));
+    describe("checkEmulatorConnected", withMocks({adb}, (mocks) => {
+      it("should throw an exception on emulator not connected", async () => {
+        adb.curDeviceId = "emulator-5558";
+        mocks.adb.expects("isEmulatorConnected")
+          .once()
+          .returns(false);
+        await adb.checkEmulatorConnected().should.eventually.be.rejected;
+        mocks.adb.verify();
+      });
+    }));
     describe("fingerprint", withMocks({adb}, (mocks) => {
       it("should throw exception on undefined fingerprintId", async () => {
         await adb.fingerprint().should.eventually.be.rejected;

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -11,7 +11,7 @@ const emulators = [
   { udid: 'emulator-5554', state: 'device', port: 5554 },
   { udid: 'emulator-5556', state: 'device', port: 5556 },
 ];
-// const fingerprint = 1111;
+const fingerprintId = 1111;
 
 describe('adb emulator commands', () => {
   let adb = new ADB();
@@ -65,7 +65,7 @@ describe('adb emulator commands', () => {
         mocks.adb.expects("getApiLevel")
           .once().withExactArgs()
           .returns(21);
-        await adb.fingerprint("1111").should.eventually.be.rejected;
+        await adb.fingerprint(fingerprintId).should.eventually.be.rejected;
         mocks.adb.verify();
       });
       it("should call adbExec with the correct args", async () => {
@@ -79,9 +79,9 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "finger", "touch", "1111"])
+          .once().withExactArgs(["emu", "finger", "touch", fingerprintId])
           .returns();
-        await adb.fingerprint("1111");
+        await adb.fingerprint(fingerprintId);
         mocks.adb.verify();
       });
     }));

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -82,6 +82,19 @@ describe('adb emulator commands', () => {
         await adb.fingerprint(1111).should.eventually.be.rejected;
         mocks.adb.verify();
       });
+      it("should call deviceId on checkEmulatorConnected", async () => {
+        mocks.adb.expects("getConnectedEmulators")
+          .atLeast(1).withExactArgs()
+          .returns(emulators);
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs("emulator-5554")
+          .returns(true);
+        mocks.adb.expects('setDeviceId')
+          .once()
+          .withExactArgs('emulator-5554');
+        await adb.checkEmulatorConnected("emulator-5554");
+        mocks.adb.verify();
+      });
       it("should call adb exec with the correct rotate args", async () => {
         mocks.adb.expects("getConnectedEmulators")
           .atLeast(1).withExactArgs()
@@ -99,7 +112,8 @@ describe('adb emulator commands', () => {
         mocks.adb.expects("setDeviceId")
           .once().withExactArgs("emulator-5554")
           .returns();
-        mocks.adb.expects('resetTelnetAuthToken').once();
+        mocks.adb.expects('resetTelnetAuthToken')
+          .once();
         mocks.adb.expects("adbExec")
           .once().withExactArgs(["emu", "rotate"]);
         await adb.rotate("emulator-5554");

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -83,22 +83,25 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
       it("should call adb exec with the correct rotate args", async () => {
+        mocks.adb.expects("getConnectedEmulators")
+          .atLeast(1).withExactArgs()
+          .returns(emulators);
         mocks.adb.expects('resetTelnetAuthToken').once();
         mocks.adb.expects("adbExec")
           .once().withExactArgs(["emu", "rotate"]);
         await adb.rotate();
         mocks.adb.verify();
       });
-      it("should call adb exec with the correct rotate args", async () => {
-        mocks.adb.expects('resetTelnetAuthToken').once();
-        mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "rotate"]);
-        mocks.adb.expects("setDeviceId")
-          .once().withExactArgs("emulator-5554")
-          .returns();
+      it("should call adb exec with the correct rotate args and set the deviceId", async () => {
         mocks.adb.expects("getConnectedEmulators")
           .atLeast(1).withExactArgs()
           .returns(emulators);
+        mocks.adb.expects("setDeviceId")
+          .once().withExactArgs("emulator-5554")
+          .returns();
+        mocks.adb.expects('resetTelnetAuthToken').once();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "rotate"]);
         await adb.rotate("emulator-5554");
         mocks.adb.verify();
       });

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -45,6 +45,16 @@ describe('adb emulator commands', () => {
         await adb.checkEmulatorConnected("emulator-5554").should.eventually.be.rejected;
         mocks.adb.verify();
       });
+      it("should setDeviceId on emulator connected", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs("emulator-5554")
+          .returns(true);
+        mocks.adb.expects("setDeviceId")
+          .once().withExactArgs("emulator-5554")
+          .returns(emulators);
+        await adb.checkEmulatorConnected("emulator-5554");
+        mocks.adb.verify();
+      });
     }));
     describe("fingerprint", withMocks({adb}, (mocks) => {
       it("should throw exception on undefined fingerprintId", async () => {

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -41,8 +41,9 @@ describe('adb emulator commands', () => {
         mocks.adb.expects("setDeviceId")
           .once().withExactArgs("emulator-5556")
           .returns();
+        mocks.adb.expects('resetTelnetAuthToken').atLeast(3);
         mocks.adb.expects("adbExec")
-          .atLeast(1)
+          .atLeast(3)
           .withExactArgs(["emu", "finger", "touch", fingerprint])
           .returns("");
         await adb.fingerprint(fingerprint);
@@ -82,12 +83,14 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
       it("should call adb exec with the correct rotate args", async () => {
+        mocks.adb.expects('resetTelnetAuthToken').once();
         mocks.adb.expects("adbExec")
           .once().withExactArgs(["emu", "rotate"]);
         await adb.rotate();
         mocks.adb.verify();
       });
       it("should call adb exec with the correct rotate args", async () => {
+        mocks.adb.expects('resetTelnetAuthToken').once();
         mocks.adb.expects("adbExec")
           .once().withExactArgs(["emu", "rotate"]);
         mocks.adb.expects("setDeviceId")

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -81,6 +81,12 @@ describe('adb emulator commands', () => {
         await adb.fingerprint(1111).should.eventually.be.rejected;
         mocks.adb.verify();
       });
+      it("should call adb exec with the correct rotate args", async () => {
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "rotate"]);
+        await adb.rotate();
+        mocks.adb.verify();
+      });
     }));
   });
 });


### PR DESCRIPTION
We can rotate the emulators using `adb emu rotate` command, i'm adding this method here so we can call it later from base android drivers.