### PR TITLE
Add proxy settings

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -728,19 +728,19 @@ methods.getScreenSize = async function() {
   return null;
 };
 
-methods.setHttpProxy = async function (proxy_host, proxy_port) {
-  let proxy = `${proxy_host}:${proxy_port}`;
-  if (_.isUndefined(proxy_host)) {
+methods.setHttpProxy = async function (proxyHost, proxyPort) {
+  let proxy = `${proxyHost}:${proxyPort}`;
+  if (_.isUndefined(proxyHost)) {
     log.errorAndThrow(`Call to setHttpProxy method with undefined proxy_host: ${proxy}`);
   }
-  if (_.isUndefined(proxy_port)) {
+  if (_.isUndefined(proxyPort)) {
     log.errorAndThrow(`Call to setHttpProxy method with undefined proxy_port ${proxy}`);
   }
   await this.shell(['settings', 'put', 'global', 'http_proxy', proxy]);
   await this.shell(['settings', 'put', 'secure', 'http_proxy', proxy]);
   await this.shell(['settings', 'put', 'system', 'http_proxy', proxy]);
-  await this.shell(['settings', 'put', 'system', 'global_http_proxy_host', proxy_host]);
-  await this.shell(['settings', 'put', 'system', 'global_http_proxy_port', proxy_port]);
+  await this.shell(['settings', 'put', 'system', 'global_http_proxy_host', proxyHost]);
+  await this.shell(['settings', 'put', 'system', 'global_http_proxy_port', proxyPort]);
 };
 
 export default methods;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -728,4 +728,13 @@ methods.getScreenSize = async function() {
   return null;
 };
 
+methods.setHttpProxy = async function (proxy_host, proxy_port) {
+  let proxy = `${proxy_host}:${proxy_port}`;
+  await this.shell(['settings', 'put', 'global', 'http_proxy', proxy]);
+  await this.shell(['settings', 'put', 'secure', 'http_proxy', proxy]);
+  await this.shell(['settings', 'put', 'system', 'http_proxy', proxy]);
+  await this.shell(['settings', 'put', 'system', 'global_http_proxy_host', proxy_host]);
+  await this.shell(['settings', 'put', 'system', 'global_http_proxy_port', proxy_port]);
+};
+
 export default methods;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -730,6 +730,12 @@ methods.getScreenSize = async function() {
 
 methods.setHttpProxy = async function (proxy_host, proxy_port) {
   let proxy = `${proxy_host}:${proxy_port}`;
+  if (_.isUndefined(proxy_host)) {
+    log.errorAndThrow(`Call to setHttpProxy method with undefined proxy_host: ${proxy}`);
+  }
+  if (_.isUndefined(proxy_port)) {
+    log.errorAndThrow(`Call to setHttpProxy method with undefined proxy_port ${proxy}`);
+  }
   await this.shell(['settings', 'put', 'global', 'http_proxy', proxy]);
   await this.shell(['settings', 'put', 'secure', 'http_proxy', proxy]);
   await this.shell(['settings', 'put', 'system', 'http_proxy', proxy]);

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -832,4 +832,23 @@ describe('adb commands', () => {
   it('getAdbPath should correctly return adbPath', () => {
     adb.getAdbPath().should.equal(adb.executable.path);
   });
+  describe('setHttpProxy', withMocks({adb}, (mocks) => {
+    it('should throw an error on undefined proxy_host', async () => {
+      await adb.setHttpProxy().should.eventually.be.rejected;
+    });
+    it('should throw an error on undefined proxy_port', async () => {
+      await adb.setHttpProxy("http://localhost").should.eventually.be.rejected;
+    });
+    it('should call shell settings methods with correct args', async () => {
+      let proxy_host = "http://localhost";
+      let proxy_port = 4723;
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'global', 'http_proxy', `${proxy_host}:${proxy_port}`]);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'secure', 'http_proxy', `${proxy_host}:${proxy_port}`]);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'system', 'http_proxy', `${proxy_host}:${proxy_port}`]);
+      mocks.adb.expects('shell').atLeast(1).withExactArgs(['settings', 'put', 'system', 'global_http_proxy_host', proxy_host]);
+      mocks.adb.expects('shell').atLeast(1).withExactArgs(['settings', 'put', 'system', 'global_http_proxy_port', proxy_port]);
+      await adb.setHttpProxy(proxy_host, proxy_port);
+      mocks.adb.verify();
+    });
+  }));
 });

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -840,14 +840,14 @@ describe('adb commands', () => {
       await adb.setHttpProxy("http://localhost").should.eventually.be.rejected;
     });
     it('should call shell settings methods with correct args', async () => {
-      let proxy_host = "http://localhost";
-      let proxy_port = 4723;
-      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'global', 'http_proxy', `${proxy_host}:${proxy_port}`]);
-      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'secure', 'http_proxy', `${proxy_host}:${proxy_port}`]);
-      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'system', 'http_proxy', `${proxy_host}:${proxy_port}`]);
-      mocks.adb.expects('shell').atLeast(1).withExactArgs(['settings', 'put', 'system', 'global_http_proxy_host', proxy_host]);
-      mocks.adb.expects('shell').atLeast(1).withExactArgs(['settings', 'put', 'system', 'global_http_proxy_port', proxy_port]);
-      await adb.setHttpProxy(proxy_host, proxy_port);
+      let proxyHost = "http://localhost";
+      let proxyPort = 4723;
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'global', 'http_proxy', `${proxyHost}:${proxyPort}`]);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'secure', 'http_proxy', `${proxyHost}:${proxyPort}`]);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'system', 'http_proxy', `${proxyHost}:${proxyPort}`]);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'system', 'global_http_proxy_host', proxyHost]);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'put', 'system', 'global_http_proxy_port', proxyPort]);
+      await adb.setHttpProxy(proxyHost, proxyPort);
       mocks.adb.verify();
     });
   }));


### PR DESCRIPTION
Add a method to set proxy settings via adb for the emulators, the idea is user can set proxy settings in the capabilities so they can use tunnels. They will also have to add the `--http-proxy` param in `avdArgs`.