### PR TITLE
Show better error description in case package name cannot be parsed from aapt output

### DIFF
--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -2,6 +2,7 @@ import { exec } from 'teen_process';
 import log from '../logger.js';
 import { getAndroidPlatformAndPath, unzipFile, assertZipArchive } from '../helpers.js';
 import { system, fs } from 'appium-support';
+import _ from 'lodash';
 import path from 'path';
 
 const helperJarPath = path.resolve(__dirname, '..', '..', '..', 'jars');
@@ -62,7 +63,7 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function (localApk)
     if (apkPackage && apkPackage.length >= 2) {
       apkPackage = apkPackage[1];
     } else {
-      apkPackage = null;
+      log.errorAndThrow(`Cannot parse package name from "${_.join([this.binaries.aapt].concat(args), ' ')}" output`);
     }
     let apkActivity = new RegExp(/launchable-activity: name='([^']+)'/g).exec(stdout);
     if (apkActivity && apkActivity.length >= 2) {

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -63,7 +63,8 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function (localApk)
     if (apkPackage && apkPackage.length >= 2) {
       apkPackage = apkPackage[1];
     } else {
-      log.errorAndThrow(`Cannot parse package name from "${_.join([this.binaries.aapt].concat(args), ' ')}" output`);
+      log.errorAndThrow(`Cannot parse package name from ` +
+        `'${_.join([this.binaries.aapt, 'dump', 'badging', '"' + localApk + '"'], ' ')}' command  output`);
     }
     let apkActivity = new RegExp(/launchable-activity: name='([^']+)'/g).exec(stdout);
     if (apkActivity && apkActivity.length >= 2) {


### PR DESCRIPTION
the current one "Path must be a string. Received null" is not very descriptive.