### PR TITLE
Set the default temp folder path

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import os from 'os';
 import path from 'path';
 import methods from './tools/index.js';
 import { rootDir} from './helpers';
@@ -15,7 +16,7 @@ const DEFAULT_OPTS = {
   keyAlias: null,
   keyPassword: null,
   executable: {path: "adb", defaultArgs: []},
-  tmpDir: null,
+  tmpDir: os.tmpdir(),
   curDeviceId: null,
   emulatorPort : null,
   logcat: null,


### PR DESCRIPTION
Fixes the case when package activity name cannot be extracted from manifest file. See https://github.com/appium/appium/issues/8221 for more details.