### PR TITLE
Add getAdbVersion method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ console.log(await adb.getPIDsByName('m.android.phone'));
 - `createADB`
 - `initJars`
 - `getAdbWithCorrectAdbPath`
+- `getAdbVersion`
 - `initAapt`
 - `initZipAlign`
 - `getApiLevel`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,12 @@
+
+# getAdbVersion()
+
+```json
+{
+  "versionString": "1.0.39",
+  "versionFloat": 1,
+  "major": 1,
+  "minor": 0,
+  "patch": 39
+}
+```

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -412,19 +412,20 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   return proc;
 };
 
-systemCallMethods.getAdbVersion = async function () {
-  if (!_.isUndefined(this.adbVersion)) {
-    return this.adbVersion;
-  }
+systemCallMethods.getAdbVersion = _.memoize(async function () {
   try {
-    let version = await this.adbExec('version');
-    this.adbVersion = version.replace(/Android\sDebug\sBridge\sversion\s([\d\.]*)[\s\w\-]*/, "$1");
-    return this.adbVersion;
+    let adbVersion = (await this.adbExec('version'))
+      .replace(/Android\sDebug\sBridge\sversion\s([\d\.]*)[\s\w\-]*/, "$1");
+    return {
+      versionString: adbVersion,
+      versionFloat: parseFloat(adbVersion).toFixed(1)
+    };
   } catch (e) {
     log.errorAndThrow(`Error executing adb version. Original error: '${e.message}'; ` +
-                      `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
+                        `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
   }
-};
+});
+
 
 systemCallMethods.checkAvdExist = async function (avdName) {
   let cmd, result;

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -418,7 +418,7 @@ systemCallMethods.getAdbVersion = _.memoize(async function () {
       .replace(/Android\sDebug\sBridge\sversion\s([\d\.]*)[\s\w\-]*/, "$1");
     return {
       versionString: adbVersion,
-      versionFloat: parseFloat(adbVersion).toFixed(1)
+      versionFloat: parseFloat(adbVersion.replace(/.([^.]*)$/, '$1'))
     };
   } catch (e) {
     log.errorAndThrow(`Error executing adb version. Original error: '${e.message}'; ` +

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -425,7 +425,7 @@ systemCallMethods.getAdbVersion = _.memoize(async function () {
       patch: parts[2] ? parseInt(parts[2], 10) : undefined,
     };
   } catch (e) {
-    log.errorAndThrow(`Error executing adb version. Original error: '${e.message}'; ` +
+    log.errorAndThrow(`Error getting adb version. Original error: '${e.message}'; ` +
                         `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
   }
 });

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -418,7 +418,7 @@ systemCallMethods.getAdbVersion = async function () {
   }
   try {
     let version = await this.adbExec('version');
-    this.adbVersion = version.replace(/(Android\sDebug\sBridge\sversion\s)([\d\.]*)([\s\w\-])*/, "$2");
+    this.adbVersion = version.replace(/Android\sDebug\sBridge\sversion\s([\d\.]*)[\s\w\-]*/, "$1");
     return this.adbVersion;
   } catch (e) {
     log.errorAndThrow(`Error executing adb version. Original error: '${e.message}'; ` +

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -416,9 +416,13 @@ systemCallMethods.getAdbVersion = _.memoize(async function () {
   try {
     let adbVersion = (await this.adbExec('version'))
       .replace(/Android\sDebug\sBridge\sversion\s([\d\.]*)[\s\w\-]*/, "$1");
+    let parts = adbVersion.split('.');
     return {
       versionString: adbVersion,
-      versionFloat: parseFloat(adbVersion.replace(/.([^.]*)$/, '$1'))
+      versionFloat: parseFloat(adbVersion),
+      major: parseInt(parts[0], 10),
+      minor: parseInt(parts[1], 10),
+      patch: parts[2] ? parseInt(parts[2], 10) : undefined,
     };
   } catch (e) {
     log.errorAndThrow(`Error executing adb version. Original error: '${e.message}'; ` +

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -5,6 +5,7 @@ import { system, fs } from 'appium-support';
 import { getDirectories, getSdkToolsVersion } from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval } from 'asyncbox';
+import _ from 'lodash';
 
 
 let systemCallMethods = {};
@@ -409,6 +410,20 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   await retry(retryTimes, this.getRunningAVDWithRetry.bind(this), avdName, avdLaunchTimeout);
   await this.waitForEmulatorReady(avdReadyTimeout);
   return proc;
+};
+
+systemCallMethods.getAdbVersion = async function () {
+  if (!_.isUndefined(this.adbVersion)) {
+    return this.adbVersion;
+  }
+  try {
+    let version = await this.adbExec('version');
+    this.adbVersion = version.replace(/(Android\sDebug\sBridge\sversion\s)([\d\.]*)([\s\w\-])*/, "$2");
+    return this.adbVersion;
+  } catch (e) {
+    log.errorAndThrow(`Error executing adb version. Original error: '${e.message}'; ` +
+                      `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
+  }
 };
 
 systemCallMethods.checkAvdExist = async function (avdName) {

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -114,7 +114,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
       .returns("Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android");
     let adbVersion = await adb.getAdbVersion();
     adbVersion.versionString.should.equal("1.0.39");
-    adbVersion.versionFloat.should.equal("1.0");
+    adbVersion.versionFloat.should.be.within(1.0, 1.0);
     // verify adb exec is called once, since we are caching the result
     await adb.getAdbVersion();
     mocks.adb.verify();

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -112,11 +112,11 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
       .once()
       .withExactArgs('version')
       .returns("Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android");
-    let version = await adb.getAdbVersion();
-    version.should.equal("1.0.39");
+    let adbVersion = await adb.getAdbVersion();
+    adbVersion.versionString.should.equal("1.0.39");
+    adbVersion.versionFloat.should.equal("1.0");
     // verify adb exec is called once, since we are caching the result
     await adb.getAdbVersion();
-    adb.adbVersion.should.equal("1.0.39");
     mocks.adb.verify();
   });
   it('fileExists should return true for if ls returns', async () => {

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -4,6 +4,7 @@ import ADB from '../..';
 import * as teen_process from 'teen_process';
 import { withMocks } from 'appium-test-support';
 import B from 'bluebird';
+import _ from 'lodash';
 
 
 chai.use(chaiAsPromised);
@@ -118,7 +119,16 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     adbVersion.major.should.equal(1);
     adbVersion.minor.should.equal(0);
     adbVersion.patch.should.equal(39);
-    // verify adb exec is called once, since we are caching the result
+    mocks.adb.verify();
+  });
+  it('should cache adb results', async () => {
+    let memoizeFunc = adb.getAdbVersion;
+    memoizeFunc.cache = new _.memoize.Cache();
+    mocks.adb.expects("adbExec")
+      .once()
+      .withExactArgs('version')
+      .returns("Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android");
+    await adb.getAdbVersion();
     await adb.getAdbVersion();
     mocks.adb.verify();
   });

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -122,8 +122,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     mocks.adb.verify();
   });
   it('should cache adb results', async () => {
-    let memoizeFunc = adb.getAdbVersion;
-    memoizeFunc.cache = new _.memoize.Cache();
+    adb.getAdbVersion.cache = new _.memoize.Cache();
     mocks.adb.expects("adbExec")
       .once()
       .withExactArgs('version')

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -114,7 +114,10 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
       .returns("Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android");
     let adbVersion = await adb.getAdbVersion();
     adbVersion.versionString.should.equal("1.0.39");
-    adbVersion.versionFloat.should.be.within(1.039, 1.039);
+    adbVersion.versionFloat.should.be.within(1.0, 1.0);
+    adbVersion.major.should.equal(1);
+    adbVersion.minor.should.equal(0);
+    adbVersion.patch.should.equal(39);
     // verify adb exec is called once, since we are caching the result
     await adb.getAdbVersion();
     mocks.adb.verify();

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -114,7 +114,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
       .returns("Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android");
     let adbVersion = await adb.getAdbVersion();
     adbVersion.versionString.should.equal("1.0.39");
-    adbVersion.versionFloat.should.be.within(1.0, 1.0);
+    adbVersion.versionFloat.should.be.within(1.039, 1.039);
     // verify adb exec is called once, since we are caching the result
     await adb.getAdbVersion();
     mocks.adb.verify();

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -107,6 +107,18 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
 }));
 
 describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
+  it('should return adb version', async () => {
+    mocks.adb.expects("adbExec")
+      .once()
+      .withExactArgs('version')
+      .returns("Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android");
+    let version = await adb.getAdbVersion();
+    version.should.equal("1.0.39");
+    // verify adb exec is called once, since we are caching the result
+    await adb.getAdbVersion();
+    adb.adbVersion.should.equal("1.0.39");
+    mocks.adb.verify();
+  });
   it('fileExists should return true for if ls returns', async () => {
     mocks.adb.expects("ls")
       .once().withExactArgs('foo')


### PR DESCRIPTION
Add a method to get adb version. Newer versions of adb added a lot of methods for emulators so in order to use those methods we should verify a minimum version of adb. This can also help us in the future to deprecate old version of adb to use with appium. 