### PR TITLE
Support activities that are inner classes

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -127,7 +127,7 @@ apkUtilsMethods.waitForActivityOrNot = async function (pkg, activity, not,
   }
   log.debug(`Possible activities, to be checked: ${possibleActivityNames.join(', ')}`);
   let possibleActivityPatterns = possibleActivityNames.map((possibleActivityName) =>
-    new RegExp(`^${possibleActivityName.replace(/\./g, '\\.').replace(/\*/g, '.*?')}$`)
+    new RegExp(`^${possibleActivityName.replace(/\./g, '\\.').replace(/\*/g, '.*?').replace(/\$/g, '\\$')}$`)
   );
 
   while (Date.now() < endAt) {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -207,6 +207,15 @@ describe('Apk-utils', () => {
         .should.eventually.be.rejected;
       mocks.adb.verify();
     });
+    it('should be able to get an activity that is an inner class', async () => {
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+        .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
+          `ActivityRecord{2 u ${pkg}/.Settings$AppDrawOverlaySettingsActivity t181}}}`);
+
+      await adb.waitForActivityOrNot(pkg, '.Settings$AppDrawOverlaySettingsActivity', false);
+      mocks.adb.verify();
+    });
   }));
   describe('waitForActivity', withMocks({adb}, (mocks) => {
     it('should call waitForActivityOrNot with correct arguments', async () => {


### PR DESCRIPTION
...by escaping the dollar sign in the activity name. 

This was an issue for me as my app has the accept overlay dialog on start up, which is specified as the inner class com.android.settings.Settings$AppDrawOverlaySettingsActivity . The fix is just extending the regex set up to escape dollars, so they can be included in the activity name.