### PR TITLE
Support start activities that contain an inner class

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -41,6 +41,8 @@ apkUtilsMethods.startApp = async function (startAppOptions = {}) {
       log.errorAndThrow("activity and pkg is required for launching application");
     }
     startAppOptions = _.clone(startAppOptions);
+    startAppOptions.activity = startAppOptions.activity.replace('$', '\\$');
+
     // initializing defaults
     _.defaults(startAppOptions, {
       waitPkg: startAppOptions.pkg,

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -131,7 +131,6 @@ describe('apk utils', function () {
         .be.rejectedWith('Activity');
     });
   });
-
   it('should start activity when start activity is an inner class', async () => {
     await adb.install(contactManagerPath);
     await adb.startApp({pkg: 'com.android.settings',
@@ -140,9 +139,7 @@ describe('apk utils', function () {
     let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
     appPackage.should.equal('com.android.settings');
     appActivity.should.equal('.Settings$NotificationAppListActivity');
-
   });
-
   it('getFocusedPackageAndActivity should be able get package and activity', async () => {
     await adb.install(contactManagerPath);
     await adb.startApp({pkg: 'com.example.android.contactmanager',

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -131,6 +131,18 @@ describe('apk utils', function () {
         .be.rejectedWith('Activity');
     });
   });
+
+  it('should start activity when start activity is an inner class', async () => {
+    await adb.install(contactManagerPath);
+    await adb.startApp({pkg: 'com.android.settings',
+      activity: '.Settings$NotificationAppListActivity'});
+
+    let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
+    appPackage.should.equal('com.android.settings');
+    appActivity.should.equal('.Settings$NotificationAppListActivity');
+
+  });
+
   it('getFocusedPackageAndActivity should be able get package and activity', async () => {
     await adb.install(contactManagerPath);
     await adb.startApp({pkg: 'com.example.android.contactmanager',

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -354,6 +354,19 @@ describe('Apk-utils', () => {
       (await adb.startApp(startAppOptions));
       mocks.adb.verify();
     });
+    it('should call getApiLevel and shell with correct arguments when activity is inner class', async () => {
+      const startAppOptionsWithInnerClass = { pkg: 'pkg', activity: 'act$InnerAct'},
+            cmdWithInnerClass = ['am', 'start', '-W', '-n', 'pkg/act\\$InnerAct', '-S'];
+
+      mocks.adb.expects('getApiLevel')
+        .once().withExactArgs()
+        .returns('17');
+      mocks.adb.expects('shell')
+        .once().withExactArgs(cmdWithInnerClass)
+        .returns('');
+      (await adb.startApp(startAppOptionsWithInnerClass));
+      mocks.adb.verify();
+    });
   }));
   describe('getDeviceLanguage', withMocks({adb}, (mocks) => {
     it('should call shell one time with correct args and return language when API < 23', async () => {


### PR DESCRIPTION
Hopefully fixing appium/appium#8359 (more details there), whereby you can't specify an inner class as the start activity, because every thing from the dollar onwards gets clipped. Fix is just to escape the dollar (awfully similar to my last PR!)