### PR TITLE
Add emulator gsm methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,6 @@ console.log(await adb.getPIDsByName('m.android.phone'));
 - `installFromDevicePath`
 - `install`
 - `fingerprint` (ApiLevel >=23)
+- `gsmCall` (emulator only)
+- `gsmSignal` (emulator only)
+- `gsmVoice` (emulator only)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -19,7 +19,8 @@ await adb.getAdbVersion();
 # gsmCall
 ```javascript
 let action = 'call';
-await adb.gsmCall(4509, action);
+let phoneNumber = 4509;
+await adb.gsmCall(phoneNumber, action);
 ```
 
 Possible values:
@@ -54,7 +55,9 @@ Possible values:
 # sendSMS
 
 ```javascript
-await adb.sendSMS(4509, "Hello Appium");
+let phoneNumber = 4509;
+let message = "Hello Appium"
+await adb.sendSMS(phoneNumber, message);
 ```
 
 <img src="static/send-sms-screen.png" width="200" />

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -16,6 +16,41 @@ await adb.getAdbVersion();
 }
 ```
 
+# gsmCall
+```javascript
+let action = 'call';
+await adb.gsmCall(4509, action);
+```
+
+Possible values:
+ * call
+ * accept
+ * hold
+ * cancel
+
+# gsmSignal
+```javascript
+let signalStrengh = 0;
+await adb.gsmSignal(signalStrengh);
+```
+Possible values: 0..4
+
+# gsmVoice
+```javascript
+let state = 'roaming';
+await adb.gsmVoice(state);
+```
+
+Possible values:
+
+ * unregistered
+ * home
+ * roaming
+ * searching
+ * denied
+ * off (unregistered alias)
+ * on (home alias)
+
 # sendSMS
 
 ```javascript

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -5,19 +5,19 @@ const PHONE_NUMBER_PATTERN = /^[\+]?[(]?[0-9]*[)]?[-\s\.]?[0-9]*[-\s\.]?[0-9]{2,
 
 let emuMethods = {};
 emuMethods.GSM_CALL_ACTIONS = {
-  'GSM_CALL' : 'call',
-  'GSM_ACCEPT': 'accept',
-  'GSM_CANCEL': 'cancel',
-  'GSM_HOLD': 'hold'
+  GSM_CALL : 'call',
+  GSM_ACCEPT: 'accept',
+  GSM_CANCEL: 'cancel',
+  GSM_HOLD: 'hold'
 };
 emuMethods.GSM_VOICE_STATES = {
-  'GSM_VOICE_UNREGISTERED': 'unregistered',
-  'GSM_VOICE_HOME': 'home',
-  'GSM_VOICE_ROAMING': 'roaming',
-  'GSM_VOICE_SEARCHING': 'searching',
-  'GSM_VOICE_DENIED': 'denied',
-  'GSM_VOICE_OFF': 'off',
-  'GSM_VOICE_ON': 'on'
+  GSM_VOICE_UNREGISTERED: 'unregistered',
+  GSM_VOICE_HOME: 'home',
+  GSM_VOICE_ROAMING: 'roaming',
+  GSM_VOICE_SEARCHING: 'searching',
+  GSM_VOICE_DENIED: 'denied',
+  GSM_VOICE_OFF: 'off',
+  GSM_VOICE_ON: 'on'
 };
 emuMethods.GSM_SIGNAL_STRENGTHS = [0, 1, 2, 3, 4];
 
@@ -63,7 +63,7 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
 
 emuMethods.gsmCall = async function (phoneNumber, action = '') {
   if (_.values(emuMethods.GSM_CALL_ACTIONS).indexOf(action) === -1) {
-    log.errorAndThrow(`Invalid gsm action param ${action}`);
+    log.errorAndThrow(`Invalid gsm action param ${action}. Supported values: ${_.values(emuMethods.GSM_CALL_ACTIONS)}`);
   }
   phoneNumber = `${phoneNumber}`.replace(/\s*/, "");
   if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
@@ -75,7 +75,7 @@ emuMethods.gsmCall = async function (phoneNumber, action = '') {
 emuMethods.gsmSignal = async function (strength = 4) {
   strength = parseInt(strength, 10);
   if (emuMethods.GSM_SIGNAL_STRENGTHS.indexOf(strength) === -1) {
-    log.errorAndThrow(`Invalid signal strength param ${strength}`);
+    log.errorAndThrow(`Invalid signal strength param ${strength}. Supported values: ${_.values(emuMethods.GSM_SIGNAL_STRENGTHS)}`);
   }
   log.info('gsm signal-profile <strength> changes the reported strength on next (15s) update.');
   await this.adbExecEmu(['gsm', 'signal-profile', strength]);
@@ -84,7 +84,7 @@ emuMethods.gsmSignal = async function (strength = 4) {
 emuMethods.gsmVoice = async function (state = 'on') {
   // gsm voice <state> allows you to change the state of your GPRS connection
   if (_.values(emuMethods.GSM_VOICE_STATES).indexOf(state) === -1) {
-    log.errorAndThrow(`Invalid gsm voice state param ${state}`);
+    log.errorAndThrow(`Invalid gsm voice state param ${state}. Supported values: ${_.values(emuMethods.GSM_VOICE_STATES)}`);
   }
   await this.adbExecEmu(['gsm', 'voice', state]);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -56,7 +56,7 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
   }
   phoneNumber = `${phoneNumber}`.replace(/\s*/, "");
   if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
-    log.errorAndThrow(`Invalid phoneNumber param ${phoneNumber}`);
+    log.errorAndThrow(`Invalid sendSMS phoneNumber param ${phoneNumber}`);
   }
   await this.adbExecEmu(['sms', 'send', phoneNumber, message]);
 };
@@ -67,7 +67,7 @@ emuMethods.gsmCall = async function (phoneNumber, action = '') {
   }
   phoneNumber = `${phoneNumber}`.replace(/\s*/, "");
   if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
-    log.errorAndThrow(`Invalid phoneNumber param ${phoneNumber}`);
+    log.errorAndThrow(`Invalid gsmCall phoneNumber param ${phoneNumber}`);
   }
   await this.adbExecEmu(['gsm', action, phoneNumber]);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -6,7 +6,23 @@ const GSM_CALL = 'call';
 const GSM_ACCEPT = 'accept';
 const GSM_CANCEL = 'cancel';
 const GSM_HOLD = 'hold';
-const GSM_CALL_ACTIONS = [GSM_CALL, GSM_ACCEPT, GSM_CANCEL, GSM_HOLD];
+const GSM_CALL_ACTIONS = [
+  GSM_CALL, GSM_ACCEPT,
+  GSM_CANCEL, GSM_HOLD
+];
+const GSM_VOICE_UNREGISTERED = 'unregistered';
+const GSM_VOICE_HOME = 'home';
+const GSM_VOICE_ROAMING = 'roaming';
+const GSM_VOICE_SEARCHING = 'searching';
+const GSM_VOICE_DENIED = 'denied';
+const GSM_VOICE_OFF = 'off';
+const GSM_VOICE_ON = 'on';
+const GSM_VOICE_STATES = [
+  GSM_VOICE_UNREGISTERED, GSM_VOICE_HOME,
+  GSM_VOICE_ROAMING, GSM_VOICE_SEARCHING,
+  GSM_VOICE_DENIED, GSM_VOICE_OFF,
+  GSM_VOICE_ON
+];
 let emuMethods = {};
 
 emuMethods.isEmulatorConnected = async function () {
@@ -48,7 +64,7 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
   await this.adbExecEmu(['sms', 'send', phoneNumber, message]);
 };
 
-emuMethods.gsmCall =  async function (phoneNumber, action = '') {
+emuMethods.gsmCall = async function (phoneNumber, action = '') {
   if (GSM_CALL_ACTIONS.indexOf(action) === -1) {
     log.errorAndThrow(`Invalid gsm action param ${action}`);
   }
@@ -59,10 +75,34 @@ emuMethods.gsmCall =  async function (phoneNumber, action = '') {
   await this.adbExecEmu(['gsm', action, phoneNumber]);
 };
 
-emuMethods.GSM_CALL_ACTIONS = GSM_CALL_ACTIONS;
+emuMethods.gsmSignal = async function (strength = 4) {
+  if (!(strength in [0, 1, 2, 3, 4])) {
+    log.errorAndThrow(`Invalid signal strength param ${strength}`);
+  }
+  log.info('gsm signal-profile <strength> changes the reported strength on next (15s) update.');
+  await this.adbExecEmu(['gsm', 'signal-profile', strength]);
+};
+
+emuMethods.gsmVoice = async function (state = 'on') {
+  // gsm voice <state> allows you to change the state of your GPRS connection
+  if (GSM_VOICE_STATES.indexOf(state) === -1) {
+    log.errorAndThrow(`Invalid gsm voice state param ${state}`);
+  }
+  await this.adbExecEmu(['gsm', 'voice', state]);
+};
+
 emuMethods.GSM_CALL = GSM_CALL;
 emuMethods.GSM_ACCEPT = GSM_ACCEPT;
 emuMethods.GSM_CANCEL = GSM_CANCEL;
 emuMethods.GSM_HOLD = GSM_HOLD;
+emuMethods.GSM_CALL_ACTIONS = GSM_CALL_ACTIONS;
+emuMethods.GSM_VOICE_UNREGISTERED = GSM_VOICE_UNREGISTERED;
+emuMethods.GSM_VOICE_HOME = GSM_VOICE_HOME;
+emuMethods.GSM_VOICE_ROAMING = GSM_VOICE_ROAMING;
+emuMethods.GSM_VOICE_SEARCHING = GSM_VOICE_SEARCHING;
+emuMethods.GSM_VOICE_DENIED = GSM_VOICE_DENIED;
+emuMethods.GSM_VOICE_OFF = GSM_VOICE_OFF;
+emuMethods.GSM_VOICE_ON = GSM_VOICE_ON;
+emuMethods.GSM_VOICE_STATES = GSM_VOICE_STATES;
 
 export default emuMethods;

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -23,6 +23,7 @@ const GSM_VOICE_STATES = [
   GSM_VOICE_DENIED, GSM_VOICE_OFF,
   GSM_VOICE_ON
 ];
+const GSM_SIGNAL_STRENGTH = [0, 1, 2, 3, 4];
 let emuMethods = {};
 
 emuMethods.isEmulatorConnected = async function () {
@@ -76,7 +77,7 @@ emuMethods.gsmCall = async function (phoneNumber, action = '') {
 };
 
 emuMethods.gsmSignal = async function (strength = 4) {
-  if (!(strength in [0, 1, 2, 3, 4])) {
+  if (!(strength in GSM_SIGNAL_STRENGTH)) {
     log.errorAndThrow(`Invalid signal strength param ${strength}`);
   }
   log.info('gsm signal-profile <strength> changes the reported strength on next (15s) update.');

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -2,6 +2,11 @@ import log from '../logger.js';
 import _ from 'lodash';
 
 const PHONE_NUMBER_PATTERN = /^[\+]?[(]?[0-9]*[)]?[-\s\.]?[0-9]*[-\s\.]?[0-9]{2,}$/im;
+const GSM_CALL = 'call';
+const GSM_ACCEPT = 'accept';
+const GSM_CANCEL = 'cancel';
+const GSM_HOLD = 'hold';
+const GSM_CALL_ACTIONS = [GSM_CALL, GSM_ACCEPT, GSM_CANCEL, GSM_HOLD];
 let emuMethods = {};
 
 emuMethods.isEmulatorConnected = async function () {
@@ -42,5 +47,22 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
   }
   await this.adbExecEmu(['sms', 'send', phoneNumber, message]);
 };
+
+emuMethods.gsmCall =  async function (phoneNumber, action = '') {
+  if (GSM_CALL_ACTIONS.indexOf(action) === -1) {
+    log.errorAndThrow(`Invalid gsm action param ${action}`);
+  }
+  phoneNumber = `${phoneNumber}`.replace(/\s*/, "");
+  if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
+    log.errorAndThrow(`Invalid phoneNumber param ${phoneNumber}`);
+  }
+  await this.adbExecEmu(['gsm', action, phoneNumber]);
+};
+
+emuMethods.GSM_CALL_ACTIONS = GSM_CALL_ACTIONS;
+emuMethods.GSM_CALL = GSM_CALL;
+emuMethods.GSM_ACCEPT = GSM_ACCEPT;
+emuMethods.GSM_CANCEL = GSM_CANCEL;
+emuMethods.GSM_HOLD = GSM_HOLD;
 
 export default emuMethods;

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -73,7 +73,8 @@ emuMethods.gsmCall = async function (phoneNumber, action = '') {
 };
 
 emuMethods.gsmSignal = async function (strength = 4) {
-  if (!(strength in emuMethods.GSM_SIGNAL_STRENGTHS)) {
+  strength = parseInt(strength, 10);
+  if (emuMethods.GSM_SIGNAL_STRENGTHS.indexOf(strength) === -1) {
     log.errorAndThrow(`Invalid signal strength param ${strength}`);
   }
   log.info('gsm signal-profile <strength> changes the reported strength on next (15s) update.');

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -2,29 +2,25 @@ import log from '../logger.js';
 import _ from 'lodash';
 
 const PHONE_NUMBER_PATTERN = /^[\+]?[(]?[0-9]*[)]?[-\s\.]?[0-9]*[-\s\.]?[0-9]{2,}$/im;
-const GSM_CALL = 'call';
-const GSM_ACCEPT = 'accept';
-const GSM_CANCEL = 'cancel';
-const GSM_HOLD = 'hold';
-const GSM_CALL_ACTIONS = [
-  GSM_CALL, GSM_ACCEPT,
-  GSM_CANCEL, GSM_HOLD
-];
-const GSM_VOICE_UNREGISTERED = 'unregistered';
-const GSM_VOICE_HOME = 'home';
-const GSM_VOICE_ROAMING = 'roaming';
-const GSM_VOICE_SEARCHING = 'searching';
-const GSM_VOICE_DENIED = 'denied';
-const GSM_VOICE_OFF = 'off';
-const GSM_VOICE_ON = 'on';
-const GSM_VOICE_STATES = [
-  GSM_VOICE_UNREGISTERED, GSM_VOICE_HOME,
-  GSM_VOICE_ROAMING, GSM_VOICE_SEARCHING,
-  GSM_VOICE_DENIED, GSM_VOICE_OFF,
-  GSM_VOICE_ON
-];
-const GSM_SIGNAL_STRENGTH = [0, 1, 2, 3, 4];
+
 let emuMethods = {};
+emuMethods.GSM_CALL_ACTIONS = {
+  'GSM_CALL' : 'call',
+  'GSM_ACCEPT': 'accept',
+  'GSM_CANCEL': 'cancel',
+  'GSM_HOLD': 'hold'
+};
+emuMethods.GSM_VOICE_STATES = {
+  'GSM_VOICE_UNREGISTERED': 'unregistered',
+  'GSM_VOICE_HOME': 'home',
+  'GSM_VOICE_ROAMING': 'roaming',
+  'GSM_VOICE_SEARCHING': 'searching',
+  'GSM_VOICE_DENIED': 'denied',
+  'GSM_VOICE_OFF': 'off',
+  'GSM_VOICE_ON': 'on'
+};
+emuMethods.GSM_SIGNAL_STRENGTHS = [0, 1, 2, 3, 4];
+
 
 emuMethods.isEmulatorConnected = async function () {
   let emulators = await this.getConnectedEmulators();
@@ -66,7 +62,7 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
 };
 
 emuMethods.gsmCall = async function (phoneNumber, action = '') {
-  if (GSM_CALL_ACTIONS.indexOf(action) === -1) {
+  if (_.values(emuMethods.GSM_CALL_ACTIONS).indexOf(action) === -1) {
     log.errorAndThrow(`Invalid gsm action param ${action}`);
   }
   phoneNumber = `${phoneNumber}`.replace(/\s*/, "");
@@ -77,7 +73,7 @@ emuMethods.gsmCall = async function (phoneNumber, action = '') {
 };
 
 emuMethods.gsmSignal = async function (strength = 4) {
-  if (!(strength in GSM_SIGNAL_STRENGTH)) {
+  if (!(strength in emuMethods.GSM_SIGNAL_STRENGTHS)) {
     log.errorAndThrow(`Invalid signal strength param ${strength}`);
   }
   log.info('gsm signal-profile <strength> changes the reported strength on next (15s) update.');
@@ -86,24 +82,10 @@ emuMethods.gsmSignal = async function (strength = 4) {
 
 emuMethods.gsmVoice = async function (state = 'on') {
   // gsm voice <state> allows you to change the state of your GPRS connection
-  if (GSM_VOICE_STATES.indexOf(state) === -1) {
+  if (_.values(emuMethods.GSM_VOICE_STATES).indexOf(state) === -1) {
     log.errorAndThrow(`Invalid gsm voice state param ${state}`);
   }
   await this.adbExecEmu(['gsm', 'voice', state]);
 };
-
-emuMethods.GSM_CALL = GSM_CALL;
-emuMethods.GSM_ACCEPT = GSM_ACCEPT;
-emuMethods.GSM_CANCEL = GSM_CANCEL;
-emuMethods.GSM_HOLD = GSM_HOLD;
-emuMethods.GSM_CALL_ACTIONS = GSM_CALL_ACTIONS;
-emuMethods.GSM_VOICE_UNREGISTERED = GSM_VOICE_UNREGISTERED;
-emuMethods.GSM_VOICE_HOME = GSM_VOICE_HOME;
-emuMethods.GSM_VOICE_ROAMING = GSM_VOICE_ROAMING;
-emuMethods.GSM_VOICE_SEARCHING = GSM_VOICE_SEARCHING;
-emuMethods.GSM_VOICE_DENIED = GSM_VOICE_DENIED;
-emuMethods.GSM_VOICE_OFF = GSM_VOICE_OFF;
-emuMethods.GSM_VOICE_ON = GSM_VOICE_ON;
-emuMethods.GSM_VOICE_STATES = GSM_VOICE_STATES;
 
 export default emuMethods;

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -109,6 +109,26 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
     }));
+    describe("gsm signal method", withMocks({adb}, (mocks) => {
+      it("should throw exception on invalid strength", async () => {
+        await adb.gsmSignal(5).should.eventually.be.rejectedWith("Invalid signal strength");
+        mocks.adb.verify();
+      });
+      it("should call adbExecEmu with the correct args", async () => {
+        let signalStrength = 0;
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", 'signal-profile', signalStrength])
+          .returns();
+        await adb.gsmSignal(signalStrength);
+        mocks.adb.verify();
+      });
+    }));
     describe("gsm call methods", withMocks({adb}, (mocks) => {
       it("should throw exception on invalid action", async () => {
         await adb.gsmCall("+549341312345678").should.eventually.be.rejectedWith("Invalid gsm action");
@@ -172,6 +192,103 @@ describe('adb emulator commands', () => {
           .once().withExactArgs(["emu", "gsm", adb.GSM_HOLD, "4509"])
           .returns();
         await adb.gsmCall(phoneNumber, "hold");
+        mocks.adb.verify();
+      });
+    }));
+    describe("gsm voice method", withMocks({adb}, (mocks) => {
+      it("should throw exception on invalid strength", async () => {
+        await adb.gsmVoice('weird').should.eventually.be.rejectedWith("Invalid gsm voice state");
+        mocks.adb.verify();
+      });
+      it("should set gsm voice to unregistered", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_UNREGISTERED])
+          .returns();
+        await adb.gsmVoice("unregistered");
+        mocks.adb.verify();
+      });
+      it("should set gsm voice to home", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_HOME])
+          .returns();
+        await adb.gsmVoice("home");
+        mocks.adb.verify();
+      });
+      it("should set gsm voice to roaming", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_ROAMING])
+          .returns();
+        await adb.gsmVoice("roaming");
+        mocks.adb.verify();
+      });
+      it("should set gsm voice to searching", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_SEARCHING])
+          .returns();
+        await adb.gsmVoice("searching");
+        mocks.adb.verify();
+      });
+      it("should set gsm voice to denied", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_DENIED])
+          .returns();
+        await adb.gsmVoice("denied");
+        mocks.adb.verify();
+      });
+      it("should set gsm voice to off", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_OFF])
+          .returns();
+        await adb.gsmVoice("off");
+        mocks.adb.verify();
+      });
+      it("should set gsm voice to on", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_ON])
+          .returns();
+        await adb.gsmVoice("on");
         mocks.adb.verify();
       });
     }));

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -147,7 +147,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", adb.GSM_CALL, "4509"])
+          .once().withExactArgs(["emu", "gsm", adb.GSM_CALL_ACTIONS.GSM_CALL, "4509"])
           .returns();
         await adb.gsmCall(phoneNumber, "call");
         mocks.adb.verify();
@@ -161,7 +161,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", adb.GSM_ACCEPT, "4509"])
+          .once().withExactArgs(["emu", "gsm", adb.GSM_CALL_ACTIONS.GSM_ACCEPT, "4509"])
           .returns();
         await adb.gsmCall(phoneNumber, "accept");
         mocks.adb.verify();
@@ -175,7 +175,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", adb.GSM_CANCEL, "4509"])
+          .once().withExactArgs(["emu", "gsm", adb.GSM_CALL_ACTIONS.GSM_CANCEL, "4509"])
           .returns();
         await adb.gsmCall(phoneNumber, "cancel");
         mocks.adb.verify();
@@ -189,7 +189,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", adb.GSM_HOLD, "4509"])
+          .once().withExactArgs(["emu", "gsm", adb.GSM_CALL_ACTIONS.GSM_HOLD, "4509"])
           .returns();
         await adb.gsmCall(phoneNumber, "hold");
         mocks.adb.verify();
@@ -208,7 +208,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_UNREGISTERED])
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_STATES.GSM_VOICE_UNREGISTERED])
           .returns();
         await adb.gsmVoice("unregistered");
         mocks.adb.verify();
@@ -221,7 +221,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_HOME])
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_STATES.GSM_VOICE_HOME])
           .returns();
         await adb.gsmVoice("home");
         mocks.adb.verify();
@@ -234,7 +234,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_ROAMING])
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_STATES.GSM_VOICE_ROAMING])
           .returns();
         await adb.gsmVoice("roaming");
         mocks.adb.verify();
@@ -247,7 +247,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_SEARCHING])
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_STATES.GSM_VOICE_SEARCHING])
           .returns();
         await adb.gsmVoice("searching");
         mocks.adb.verify();
@@ -260,7 +260,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_DENIED])
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_STATES.GSM_VOICE_DENIED])
           .returns();
         await adb.gsmVoice("denied");
         mocks.adb.verify();
@@ -273,7 +273,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_OFF])
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_STATES.GSM_VOICE_OFF])
           .returns();
         await adb.gsmVoice("off");
         mocks.adb.verify();
@@ -286,7 +286,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_ON])
+          .once().withExactArgs(["emu", "gsm", "voice", adb.GSM_VOICE_STATES.GSM_VOICE_ON])
           .returns();
         await adb.gsmVoice("on");
         mocks.adb.verify();

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -90,7 +90,7 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
       it("should throw exception on invalid phoneNumber", async () => {
-        await adb.sendSMS("00549341a312345678", 'Hello Appium').should.eventually.be.rejectedWith("Invalid phoneNumber");
+        await adb.sendSMS("00549341a312345678", 'Hello Appium').should.eventually.be.rejectedWith("Invalid sendSMS phoneNumber");
         mocks.adb.verify();
       });
       it("should call adbExec with the correct args", async () => {
@@ -135,7 +135,7 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
       it("should throw exception on invalid phoneNumber", async () => {
-        await adb.gsmCall("+5493413a12345678", "call").should.eventually.be.rejectedWith("Invalid phoneNumber");
+        await adb.gsmCall("+5493413a12345678", "call").should.eventually.be.rejectedWith("Invalid gsmCall phoneNumber");
         mocks.adb.verify();
       });
       it("should set the correct method for making gsm call", async () => {

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -85,7 +85,7 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("sendSMS", withMocks({adb}, (mocks) => {
-      it("should throw exception on invalid phoneNumber", async () => {
+      it("should throw exception on invalid message", async () => {
         await adb.sendSMS("+549341312345678").should.eventually.be.rejectedWith("Sending an SMS requires a message");
         mocks.adb.verify();
       });
@@ -106,6 +106,72 @@ describe('adb emulator commands', () => {
           .once().withExactArgs(["emu", "sms", "send", "4509", "Hello Appium"])
           .returns();
         await adb.sendSMS(phoneNumber, message);
+        mocks.adb.verify();
+      });
+    }));
+    describe("gsm call methods", withMocks({adb}, (mocks) => {
+      it("should throw exception on invalid action", async () => {
+        await adb.gsmCall("+549341312345678").should.eventually.be.rejectedWith("Invalid gsm action");
+        mocks.adb.verify();
+      });
+      it("should throw exception on invalid phoneNumber", async () => {
+        await adb.gsmCall("+5493413a12345678", "call").should.eventually.be.rejectedWith("Invalid phoneNumber");
+        mocks.adb.verify();
+      });
+      it("should set the correct method for making gsm call", async () => {
+        let phoneNumber = 4509;
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", adb.GSM_CALL, "4509"])
+          .returns();
+        await adb.gsmCall(phoneNumber, "call");
+        mocks.adb.verify();
+      });
+      it("should set the correct method for accepting gsm call", async () => {
+        let phoneNumber = 4509;
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", adb.GSM_ACCEPT, "4509"])
+          .returns();
+        await adb.gsmCall(phoneNumber, "accept");
+        mocks.adb.verify();
+      });
+      it("should set the correct method for refusing gsm call", async () => {
+        let phoneNumber = 4509;
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", adb.GSM_CANCEL, "4509"])
+          .returns();
+        await adb.gsmCall(phoneNumber, "cancel");
+        mocks.adb.verify();
+      });
+      it("should set the correct method for holding gsm call", async () => {
+        let phoneNumber = 4509;
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "gsm", adb.GSM_HOLD, "4509"])
+          .returns();
+        await adb.gsmCall(phoneNumber, "hold");
         mocks.adb.verify();
       });
     }));


### PR DESCRIPTION
Add GSM methods supported by emulators
* gsmCall
* gsmSignal
* gsmVoice

with this methods we can emulate phone calls, change the signal strength and the state of the gprs connection.