### PR TITLE
Add emulator power methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,4 +156,7 @@ console.log(await adb.getPIDsByName('m.android.phone'));
 - `uninstallApk`
 - `installFromDevicePath`
 - `install`
-- `fingerprint` (ApiLevel >=23)
+- `fingerprint` (ApiLevel >=23 | emulator only)
+- `powerAC` (emulator only)
+- `powerCapacity` (emulator only)
+- `powerOFF` (emulator only)

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ console.log(await adb.getPIDsByName('m.android.phone'));
 - `installFromDevicePath`
 - `install`
 - `fingerprint` (ApiLevel >=23 | emulator only)
+- `sendSMS` (emulator only)
+- `rotate` (emulator only)
 - `powerAC` (emulator only)
 - `powerCapacity` (emulator only)
 - `powerOFF` (emulator only)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -43,4 +43,7 @@ await adb.powerOFF();
 await adb.sendSMS(4509, "Hello Appium");
 ```
 
-<img src="static/send-sms-screen.png" width="200" />
+<details>
+  <summary></summary>
+  <img src="static/send-sms-screen.png" width="200" />
+</details>

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -85,3 +85,9 @@ await adb.sendSMS(phoneNumber, message);
   <summary></summary>
   <img src="static/send-sms-screen.png" width="200" />
 </details>
+
+# rotate
+
+```javascript
+await adb.rotate();
+```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -16,6 +16,27 @@ await adb.getAdbVersion();
 }
 ```
 
+# powerAC
+
+```javascript
+let state = 'off';
+await adb.powerAC(state);
+```
+Possible values:
+ * on
+ * off
+
+# powerCapacity
+```javascript
+let batteryPercent = 50;
+await adb.powerAC(batteryPercent);
+```
+
+# powerOFF
+```javascript
+await adb.powerOFF();
+```
+
 # sendSMS
 
 ```javascript

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -2,6 +2,9 @@ import log from '../logger.js';
 import _ from 'lodash';
 
 const PHONE_NUMBER_PATTERN = /^[\+]?[(]?[0-9]*[)]?[-\s\.]?[0-9]*[-\s\.]?[0-9]{2,}$/im;
+const POWER_AC_ON = 'on';
+const POWER_AC_OFF = 'off';
+const POWER_AC_STATES = [POWER_AC_ON, POWER_AC_OFF];
 let emuMethods = {};
 
 emuMethods.isEmulatorConnected = async function () {
@@ -31,6 +34,25 @@ emuMethods.rotate = async function () {
   await this.adbExecEmu(['rotate']);
 };
 
+emuMethods.powerAC = async function (state = 'on') {
+  if (POWER_AC_STATES.indexOf(state) === -1) {
+    log.errorAndThrow(`Wrong power AC state sent ${state}`);
+  }
+  await this.adbExecEmu(['power', 'ac', state]);
+};
+
+emuMethods.powerCapacity = async function (percent = 100) {
+  if (!parseInt(percent) || percent < 0 || percent > 100) {
+    log.errorAndThrow(`Wrong power percent: ${percent}`);
+  }
+  await this.adbExecEmu(['power', 'capacity', parseInt(percent)]);
+};
+
+emuMethods.powerOFF = async function () {
+  await this.powerAC(POWER_AC_OFF);
+  await this.powerCapacity(0);
+};
+
 emuMethods.sendSMS = async function (phoneNumber, message = '') {
   message = message.trim();
   if (message === "") {
@@ -42,5 +64,8 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
   }
   await this.adbExecEmu(['sms', 'send', phoneNumber, message]);
 };
+
+emuMethods.POWER_AC_ON = POWER_AC_ON;
+emuMethods.POWER_AC_OFF = POWER_AC_OFF;
 
 export default emuMethods;

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -4,11 +4,9 @@ import _ from 'lodash';
 const PHONE_NUMBER_PATTERN = /^[\+]?[(]?[0-9]*[)]?[-\s\.]?[0-9]*[-\s\.]?[0-9]{2,}$/im;
 
 let emuMethods = {};
-emuMethods.POWER_AC_ON = 'on';
-emuMethods.POWER_AC_OFF = 'off';
 emuMethods.POWER_AC_STATES = {
-  'POWER_AC_ON': emuMethods.POWER_AC_ON,
-  'POWER_AC_OFF': emuMethods.POWER_AC_OFF
+  'POWER_AC_ON': 'on',
+  'POWER_AC_OFF': 'off'
 };
 
 emuMethods.isEmulatorConnected = async function () {
@@ -40,7 +38,7 @@ emuMethods.rotate = async function () {
 
 emuMethods.powerAC = async function (state = 'on') {
   if (_.values(emuMethods.POWER_AC_STATES).indexOf(state) === -1) {
-    log.errorAndThrow(`Wrong power AC state sent '${state}', possible values: [${emuMethods.POWER_AC_ON}, ${emuMethods.POWER_AC_OFF}]`);
+    log.errorAndThrow(`Wrong power AC state sent '${state}', possible values: ${JSON.stringify(this.POWER_AC_STATES)}]`);
   }
   await this.adbExecEmu(['power', 'ac', state]);
 };
@@ -54,7 +52,7 @@ emuMethods.powerCapacity = async function (percent = 100) {
 };
 
 emuMethods.powerOFF = async function () {
-  await this.powerAC(emuMethods.POWER_AC_OFF);
+  await this.powerAC(emuMethods.POWER_AC_STATES.POWER_AC_OFF);
   await this.powerCapacity(0);
 };
 

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -5,8 +5,8 @@ const PHONE_NUMBER_PATTERN = /^[\+]?[(]?[0-9]*[)]?[-\s\.]?[0-9]*[-\s\.]?[0-9]{2,
 
 let emuMethods = {};
 emuMethods.POWER_AC_STATES = {
-  'POWER_AC_ON': 'on',
-  'POWER_AC_OFF': 'off'
+  POWER_AC_ON: 'on',
+  POWER_AC_OFF: 'off'
 };
 
 emuMethods.isEmulatorConnected = async function () {
@@ -38,7 +38,7 @@ emuMethods.rotate = async function () {
 
 emuMethods.powerAC = async function (state = 'on') {
   if (_.values(emuMethods.POWER_AC_STATES).indexOf(state) === -1) {
-    log.errorAndThrow(`Wrong power AC state sent '${state}', possible values: ${JSON.stringify(this.POWER_AC_STATES)}]`);
+    log.errorAndThrow(`Wrong power AC state sent '${state}'. Supported values: ${_.values(emuMethods.POWER_AC_STATES)}]`);
   }
   await this.adbExecEmu(['power', 'ac', state]);
 };

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -2,10 +2,14 @@ import log from '../logger.js';
 import _ from 'lodash';
 
 const PHONE_NUMBER_PATTERN = /^[\+]?[(]?[0-9]*[)]?[-\s\.]?[0-9]*[-\s\.]?[0-9]{2,}$/im;
-const POWER_AC_ON = 'on';
-const POWER_AC_OFF = 'off';
-const POWER_AC_STATES = [POWER_AC_ON, POWER_AC_OFF];
+
 let emuMethods = {};
+emuMethods.POWER_AC_ON = 'on';
+emuMethods.POWER_AC_OFF = 'off';
+emuMethods.POWER_AC_STATES = {
+  'POWER_AC_ON': emuMethods.POWER_AC_ON,
+  'POWER_AC_OFF': emuMethods.POWER_AC_OFF
+};
 
 emuMethods.isEmulatorConnected = async function () {
   let emulators = await this.getConnectedEmulators();
@@ -35,21 +39,22 @@ emuMethods.rotate = async function () {
 };
 
 emuMethods.powerAC = async function (state = 'on') {
-  if (POWER_AC_STATES.indexOf(state) === -1) {
-    log.errorAndThrow(`Wrong power AC state sent ${state}`);
+  if (_.values(emuMethods.POWER_AC_STATES).indexOf(state) === -1) {
+    log.errorAndThrow(`Wrong power AC state sent '${state}', possible values: [${emuMethods.POWER_AC_ON}, ${emuMethods.POWER_AC_OFF}]`);
   }
   await this.adbExecEmu(['power', 'ac', state]);
 };
 
 emuMethods.powerCapacity = async function (percent = 100) {
-  if (!parseInt(percent) || percent < 0 || percent > 100) {
-    log.errorAndThrow(`Wrong power percent: ${percent}`);
+  percent = parseInt(percent, 10);
+  if (_.isNaN(percent) || percent < 0 || percent > 100) {
+    log.errorAndThrow(`The percentage value should be valid integer between 0 and 100`);
   }
-  await this.adbExecEmu(['power', 'capacity', parseInt(percent)]);
+  await this.adbExecEmu(['power', 'capacity', percent]);
 };
 
 emuMethods.powerOFF = async function () {
-  await this.powerAC(POWER_AC_OFF);
+  await this.powerAC(emuMethods.POWER_AC_OFF);
   await this.powerCapacity(0);
 };
 
@@ -64,8 +69,5 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
   }
   await this.adbExecEmu(['sms', 'send', phoneNumber, message]);
 };
-
-emuMethods.POWER_AC_ON = POWER_AC_ON;
-emuMethods.POWER_AC_OFF = POWER_AC_OFF;
 
 export default emuMethods;

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -45,7 +45,7 @@ emuMethods.powerAC = async function (state = 'on') {
 
 emuMethods.powerCapacity = async function (percent = 100) {
   percent = parseInt(percent, 10);
-  if (_.isNaN(percent) || percent < 0 || percent > 100) {
+  if (isNaN(percent) || percent < 0 || percent > 100) {
     log.errorAndThrow(`The percentage value should be valid integer between 0 and 100`);
   }
   await this.adbExecEmu(['power', 'capacity', percent]);

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -134,7 +134,7 @@ describe('adb emulator commands', () => {
         await adb.powerCapacity(50);
         mocks.adb.verify();
       });
-    })),
+    }));
     describe("sendSMS", withMocks({adb}, (mocks) => {
       it("should throw exception on invalid phoneNumber", async () => {
         await adb.sendSMS("+549341312345678").should.eventually.be.rejectedWith("Sending an SMS requires a message");

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -84,6 +84,57 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
     }));
+    describe("power methods", withMocks({adb}, (mocks) => {
+      it("should throw exception on invalid power ac state", async () => {
+        await adb.powerAC('dead').should.eventually.be.rejectedWith("Wrong power AC state");
+        mocks.adb.verify();
+      });
+      it("should set the power ac off", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "power", "ac", adb.POWER_AC_OFF])
+          .returns();
+        await adb.powerAC('off');
+        mocks.adb.verify();
+      });
+      it("should set the power ac on", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "power", "ac", adb.POWER_AC_ON])
+          .returns();
+        await adb.powerAC('on');
+        mocks.adb.verify();
+      });
+      it("should throw exception on invalid power battery percent", async () => {
+        await adb.powerCapacity(-1).should.eventually.be.rejectedWith("Wrong power percent");
+        await adb.powerCapacity("a").should.eventually.be.rejectedWith("Wrong power percent");
+        await adb.powerCapacity(500).should.eventually.be.rejectedWith("Wrong power percent");
+        mocks.adb.verify();
+      });
+      it("should set the power capacity", async () => {
+        mocks.adb.expects("isEmulatorConnected")
+          .once().withExactArgs()
+          .returns(true);
+        mocks.adb.expects("resetTelnetAuthToken")
+          .once().withExactArgs()
+          .returns();
+        mocks.adb.expects("adbExec")
+          .once().withExactArgs(["emu", "power", "capacity", 50])
+          .returns();
+        await adb.powerCapacity(50);
+        mocks.adb.verify();
+      });
+    })),
     describe("sendSMS", withMocks({adb}, (mocks) => {
       it("should throw exception on invalid phoneNumber", async () => {
         await adb.sendSMS("+549341312345678").should.eventually.be.rejectedWith("Sending an SMS requires a message");

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -116,9 +116,9 @@ describe('adb emulator commands', () => {
         mocks.adb.verify();
       });
       it("should throw exception on invalid power battery percent", async () => {
-        await adb.powerCapacity(-1).should.eventually.be.rejectedWith("Wrong power percent");
-        await adb.powerCapacity("a").should.eventually.be.rejectedWith("Wrong power percent");
-        await adb.powerCapacity(500).should.eventually.be.rejectedWith("Wrong power percent");
+        await adb.powerCapacity(-1).should.eventually.be.rejectedWith("should be valid integer between 0 and 100");
+        await adb.powerCapacity("a").should.eventually.be.rejectedWith("should be valid integer between 0 and 100");
+        await adb.powerCapacity(500).should.eventually.be.rejectedWith("should be valid integer between 0 and 100");
         mocks.adb.verify();
       });
       it("should set the power capacity", async () => {
@@ -129,9 +129,19 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "power", "capacity", 50])
+          .once().withExactArgs(["emu", "power", "capacity", 0])
           .returns();
-        await adb.powerCapacity(50);
+        await adb.powerCapacity(0);
+        mocks.adb.verify();
+      });
+      it("should call methods to power off the emulator", async () => {
+        mocks.adb.expects("powerAC")
+          .once().withExactArgs('off')
+          .returns();
+        mocks.adb.expects("powerCapacity")
+          .once().withExactArgs(0)
+          .returns();
+        await adb.powerOFF();
         mocks.adb.verify();
       });
     }));

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -97,7 +97,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "power", "ac", adb.POWER_AC_OFF])
+          .once().withExactArgs(["emu", "power", "ac", adb.POWER_AC_STATES.POWER_AC_OFF])
           .returns();
         await adb.powerAC('off');
         mocks.adb.verify();
@@ -110,7 +110,7 @@ describe('adb emulator commands', () => {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects("adbExec")
-          .once().withExactArgs(["emu", "power", "ac", adb.POWER_AC_ON])
+          .once().withExactArgs(["emu", "power", "ac", adb.POWER_AC_STATES.POWER_AC_ON])
           .returns();
         await adb.powerAC('on');
         mocks.adb.verify();


### PR DESCRIPTION
Add methods to change power in emulators
* _powerAC_ sets the state of the battery charger to connected or not
* _powerCapacity_ sets the battery percentage
* _powerOFF_ drains the battery so the emulator turns off. Another way of killing the emulator besides `adb emu kill`