### PR TITLE
use newest sdk emulator cli

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -51,6 +51,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function (binaryName) {
   let binaryLoc = null;
   binaryName = this.getBinaryNameForOS(binaryName);
   let binaryLocs = [path.resolve(this.sdkRoot, "platform-tools", binaryName),
+                    path.resolve(this.sdkRoot, "emulator", binaryName),
                     path.resolve(this.sdkRoot, "tools", binaryName),
                     path.resolve(this.sdkRoot, "tools", "bin", binaryName)];
   // get subpaths for currently installed build tool directories


### PR DESCRIPTION
The newest android sdk have separated the emulator cli from tools, so we should check if this is available under the own emulator folder before checking on tools. 
