### PR TITLE
move root, unroot into their own methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,5 @@ console.log(await adb.getPIDsByName('m.android.phone'));
 - `gsmCall` (emulator only)
 - `gsmSignal` (emulator only)
 - `gsmVoice` (emulator only)
+- `root`
+- `unroot`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -91,3 +91,15 @@ await adb.sendSMS(phoneNumber, message);
 ```javascript
 await adb.rotate();
 ```
+
+# root
+
+```javascript
+await adb.root();
+```
+
+# unroot
+
+```javascript
+await adb.unroot();
+```

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -572,8 +572,8 @@ systemCallMethods.root = async function () {
 systemCallMethods.unroot = async function () {
   try {
     await exec(this.executable.path, ['unroot']);
-  } catch (err) {
     this.adbdRooted = false;
+  } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
   }
 };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -557,21 +557,19 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
 };
 
 systemCallMethods.root = async function () {
-  try {
-    let process = await exec(this.executable.path, ['root']);
-    return !!process.code;
-  } catch (err) {
-    log.warn(`Unable to root adb daemon: '${err.message}'. Continuing`);
+  let process = await exec(this.executable.path, ['root']);
+  if (process.code !== 0) {
+    log.warn(`Unable to root adb daemon: '${process.stderr.message}'. Continuing`);
   }
+  return !process.code;
 };
 
 systemCallMethods.unroot = async function () {
-  try {
-    let process = await exec(this.executable.path, ['unroot']);
-    return !!process.code;
-  } catch (err) {
-    log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
+  let process = await exec(this.executable.path, ['unroot']);
+  if (process.code !== 0) {
+    log.warn(`Unable to unroot adb daemon: '${process.stderr.message}'. Continuing`);
   }
+  return !process.code;
 };
 
 systemCallMethods.fileExists = async function (remotePath) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -559,16 +559,20 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
 systemCallMethods.root = async function () {
   try {
     await exec(this.executable.path, ['root']);
+    return true;
   } catch (err) {
     log.warn(`Unable to root adb daemon: '${err.message}'. Continuing`);
+    return false;
   }
 };
 
 systemCallMethods.unroot = async function () {
   try {
     await exec(this.executable.path, ['unroot']);
+    return true;
   } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
+    return false;
   }
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -557,19 +557,19 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
 };
 
 systemCallMethods.root = async function () {
-  let process = await exec(this.executable.path, ['root']);
-  if (process.code !== 0) {
-    log.warn(`Unable to root adb daemon: '${process.stderr.message}'. Continuing`);
+  try {
+    await exec(this.executable.path, ['root']);
+  } catch (err) {
+    log.warn(`Unable to root adb daemon: '${err.message}'. Continuing`);
   }
-  return !process.code;
 };
 
 systemCallMethods.unroot = async function () {
-  let process = await exec(this.executable.path, ['unroot']);
-  if (process.code !== 0) {
-    log.warn(`Unable to unroot adb daemon: '${process.stderr.message}'. Continuing`);
+  try {
+    await exec(this.executable.path, ['unroot']);
+  } catch (err) {
+    log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
   }
-  return !process.code;
 };
 
 systemCallMethods.fileExists = async function (remotePath) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -8,9 +8,7 @@ import { sleep, retry, retryInterval } from 'asyncbox';
 import _ from 'lodash';
 
 
-let systemCallMethods = {
-  adbdRooted : false
-};
+let systemCallMethods = {};
 
 const DEFAULT_ADB_EXEC_TIMEOUT = 20000; // in milliseconds
 const DEFAULT_ADB_REBOOT_RETRIES = 90;
@@ -554,16 +552,14 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
       }
     });
   } finally {
-    if (this.adbdRooted) {
-      this.unroot();
-    }
+    this.unroot();
   }
 };
 
 systemCallMethods.root = async function () {
   try {
-    await exec(this.executable.path, ['root']);
-    this.adbdRooted = true;
+    let process = await exec(this.executable.path, ['root']);
+    return !!process.code;
   } catch (err) {
     log.warn(`Unable to root adb daemon: '${err.message}'. Continuing`);
   }
@@ -571,8 +567,8 @@ systemCallMethods.root = async function () {
 
 systemCallMethods.unroot = async function () {
   try {
-    await exec(this.executable.path, ['unroot']);
-    this.adbdRooted = false;
+    let process = await exec(this.executable.path, ['unroot']);
+    return !!process.code;
   } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
   }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -8,7 +8,9 @@ import { sleep, retry, retryInterval } from 'asyncbox';
 import _ from 'lodash';
 
 
-let systemCallMethods = {};
+let systemCallMethods = {
+  adbdRooted : false
+};
 
 const DEFAULT_ADB_EXEC_TIMEOUT = 20000; // in milliseconds
 const DEFAULT_ADB_REBOOT_RETRIES = 90;
@@ -524,7 +526,6 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
 };
 
 systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES) {
-  let adbdRooted = false;
   try {
     try {
       await this.shell(['stop']);
@@ -535,8 +536,7 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
       // this device needs adb to be running as root to stop.
       // so try to restart the daemon
       log.debug('Device requires adb to be running as root in order to reboot. Restarting daemon');
-      await exec(this.executable.path, ['root']);
-      adbdRooted = true;
+      await this.root();
       await this.shell(['stop']);
     }
     await B.delay(2000); // let the emu finish stopping;
@@ -554,13 +554,27 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
       }
     });
   } finally {
-    if (adbdRooted) {
-      try {
-        await exec(this.executable.path, ['unroot']);
-      } catch (err) {
-        log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
-      }
+    if (this.adbdRooted) {
+      this.unroot();
     }
+  }
+};
+
+systemCallMethods.root = async function () {
+  try {
+    await exec(this.executable.path, ['root']);
+    this.adbdRooted = true;
+  } catch (err) {
+    log.warn(`Unable to root adb daemon: '${err.message}'. Continuing`);
+  }
+};
+
+systemCallMethods.unroot = async function () {
+  try {
+    await exec(this.executable.path, ['unroot']);
+  } catch (err) {
+    this.adbdRooted = false;
+    log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
   }
 };
 

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -165,7 +165,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
   it('reboot should restart adbd as root if necessary', async () => {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['root'])
-      .returns();
+      .returns(false);
     mocks.adb.expects("shell")
       .twice().withExactArgs(['stop'])
       .onFirstCall()

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -9,7 +9,7 @@ import _ from 'lodash';
 
 chai.use(chaiAsPromised);
 const adb = new ADB();
-adb.executable.path = '/Users/vruno/Library/Android/sdk/platform-tools/adb';
+adb.executable.path = 'adb_path';
 const avdName = 'AVD_NAME';
 
 describe('System calls', withMocks({teen_process}, (mocks) => {

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -108,26 +108,6 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
 }));
 
 describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
-  it('root', async () => {
-    mocks.teen_process.expects("exec")
-      .once().withExactArgs(adb.executable.path, ['root'])
-      .returns({stdout:undefined, stderr: "", code:1});
-    (await adb.root()).should.equal(false);
-    mocks.teen_process.expects("exec")
-      .once().withExactArgs(adb.executable.path, ['root'])
-      .returns({stdout:"", stderr: undefined, code:0});
-    (await adb.root()).should.equal(true);
-  });
-  it('unroot', async () => {
-    mocks.teen_process.expects("exec")
-      .once().withExactArgs(adb.executable.path, ['unroot'])
-      .returns({stdout:undefined, stderr: "", code:1});
-    (await adb.unroot()).should.equal(false);
-    mocks.teen_process.expects("exec")
-      .once().withExactArgs(adb.executable.path, ['unroot'])
-      .returns({stdout:"", stderr: undefined, code:0});
-    (await adb.unroot()).should.equal(true);
-  });
   it('should return adb version', async () => {
     mocks.adb.expects("adbExec")
       .once()

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -165,7 +165,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
   it('reboot should restart adbd as root if necessary', async () => {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['root'])
-      .returns({stdout:"restarting adbd as root", stderr: undefined, code:0});
+      .returns();
     mocks.adb.expects("shell")
       .twice().withExactArgs(['stop'])
       .onFirstCall()

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -9,7 +9,7 @@ import _ from 'lodash';
 
 chai.use(chaiAsPromised);
 const adb = new ADB();
-adb.executable.path = 'adb_path';
+adb.executable.path = '/Users/vruno/Library/Android/sdk/platform-tools/adb';
 const avdName = 'AVD_NAME';
 
 describe('System calls', withMocks({teen_process}, (mocks) => {
@@ -108,6 +108,26 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
 }));
 
 describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
+  it('root', async () => {
+    mocks.teen_process.expects("exec")
+      .once().withExactArgs(adb.executable.path, ['root'])
+      .returns({stdout:undefined, stderr: "", code:1});
+    (await adb.root()).should.equal(false);
+    mocks.teen_process.expects("exec")
+      .once().withExactArgs(adb.executable.path, ['root'])
+      .returns({stdout:"", stderr: undefined, code:0});
+    (await adb.root()).should.equal(true);
+  });
+  it('unroot', async () => {
+    mocks.teen_process.expects("exec")
+      .once().withExactArgs(adb.executable.path, ['unroot'])
+      .returns({stdout:undefined, stderr: "", code:1});
+    (await adb.unroot()).should.equal(false);
+    mocks.teen_process.expects("exec")
+      .once().withExactArgs(adb.executable.path, ['unroot'])
+      .returns({stdout:"", stderr: undefined, code:0});
+    (await adb.unroot()).should.equal(true);
+  });
   it('should return adb version', async () => {
     mocks.adb.expects("adbExec")
       .once()
@@ -164,7 +184,8 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
   });
   it('reboot should restart adbd as root if necessary', async () => {
     mocks.teen_process.expects("exec")
-      .once().withExactArgs(adb.executable.path, ['root']);
+      .once().withExactArgs(adb.executable.path, ['root'])
+      .returns({stdout:"restarting adbd as root", stderr: undefined, code:0});
     mocks.adb.expects("shell")
       .twice().withExactArgs(['stop'])
       .onFirstCall()


### PR DESCRIPTION
Move `root`, `unroot` into their own methods so we can call them before running _adb shell_ commands that need to be root. 