### PR TITLE
throw error on avd failing to launch

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -436,7 +436,7 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   });
   proc.on('exit', (code, signal) => {
     if (code !== 0) {
-      log.errorAndThrow(`[AVD OUTPUT] avd exit with code ${code}, signal ${signal}`);
+      log.errorAndThrow(`Emulator avd ${avdName} exit with code ${code}, signal ${signal}`);
     }
   });
   await retry(retryTimes, this.getRunningAVDWithRetry.bind(this), avdName, avdLaunchTimeout);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -434,6 +434,11 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   proc.on('output', (stdout, stderr) => {
     log.info(`[AVD OUTPUT] ${stdout || stderr}`);
   });
+  proc.on('exit', (code, signal) => {
+    if (code !== 0) {
+      log.errorAndThrow(`[AVD OUTPUT] avd exit with code ${code}, signal ${signal}`);
+    }
+  });
   await retry(retryTimes, this.getRunningAVDWithRetry.bind(this), avdName, avdLaunchTimeout);
   await this.waitForEmulatorReady(avdReadyTimeout);
   return proc;


### PR DESCRIPTION
Hey guys I've been playing around with avdArgs and I notice that when I put a wrong param the avd fail to launch with for ex. `unknown option --no-window` but the script continues without caring if the process exited with 1. Why are we waiting for the retry to throw an exception and not doing it immediately ? Is this a good approach to exit when the avd fails to launch ?