### PR TITLE
Handle error from running as root

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -225,6 +225,7 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         stdout = stdout.replace(linkerWarningRe, '').trim();
         return stdout;
       }
+
       throw new Error(`Error executing adbExec. Original error: '${e.message}'; ` +
                         `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
     }
@@ -558,7 +559,13 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
 
 systemCallMethods.root = async function () {
   try {
-    await exec(this.executable.path, ['root']);
+    let {stdout} = await exec(this.executable.path, ['root']);
+
+    // on real devices in some situations we get an error in the stdout
+    if (stdout.indexOf('adbd cannot run as root') !== -1) {
+      throw new Error(stdout.trim());
+    }
+
     return true;
   } catch (err) {
     log.warn(`Unable to root adb daemon: '${err.message}'. Continuing`);


### PR DESCRIPTION
Sometimes the `root` command fails but doesn't error out. So check the output to get the logging right.