### PR TITLE
Set root, unroot for api 26

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -707,8 +707,16 @@ methods.getDeviceProperty = async function (property) {
 };
 
 methods.setDeviceProperty = async function (prop, val) {
+  if (this.getApiLevel() >= 26 ) {
+    log.debug(`Android O need to be on adb root to run setprop`);
+    await this.root();
+  }
   log.debug(`Setting device property '${prop}' to '${val}'`);
   await this.shell(['setprop', prop, val]);
+  if (this.getApiLevel() >= 26 ) {
+    log.debug(`Removing adb root for setprop`);
+    await this.unroot();
+  }
 };
 
 methods.getDeviceSysLanguage = async function () {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -709,7 +709,7 @@ methods.getDeviceProperty = async function (property) {
 methods.setDeviceProperty = async function (prop, val) {
   let apiLevel = await this.getApiLevel(), err;
   if (apiLevel >= 26 ) {
-    log.debug(`Android O need to be on adb root to run setprop`);
+    log.debug(`Running adb root, Android O needs adb to be rooted to setDeviceProperty`);
     await this.root();
   }
   log.debug(`Setting device property '${prop}' to '${val}'`);
@@ -719,7 +719,7 @@ methods.setDeviceProperty = async function (prop, val) {
     err = e;
   }
   if (apiLevel >= 26 ) {
-    log.debug(`Removing adb root for setprop`);
+    log.debug(`Removing adb root for setDeviceProperty`);
     await this.unroot();
   }
   if (!_.isUndefined(err)) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -707,13 +707,14 @@ methods.getDeviceProperty = async function (property) {
 };
 
 methods.setDeviceProperty = async function (prop, val) {
-  if (this.getApiLevel() >= 26 ) {
+  let apiLevel = await this.getApiLevel();
+  if (apiLevel >= 26 ) {
     log.debug(`Android O need to be on adb root to run setprop`);
     await this.root();
   }
   log.debug(`Setting device property '${prop}' to '${val}'`);
   await this.shell(['setprop', prop, val]);
-  if (this.getApiLevel() >= 26 ) {
+  if (apiLevel >= 26 ) {
     log.debug(`Removing adb root for setprop`);
     await this.unroot();
   }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -724,7 +724,7 @@ methods.setDeviceProperty = async function (prop, val) {
     await this.unroot();
   }
   if (_.isError(err)) {
-    log.errorAndThrow(`Error trying to set device property. Original error: ${err.message}`);
+    throw new Error(err);
   }
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -723,9 +723,7 @@ methods.setDeviceProperty = async function (prop, val) {
     log.debug(`Removing adb root for setDeviceProperty`);
     await this.unroot();
   }
-  if (_.isError(err)) {
-    throw err;
-  }
+  if (err) throw err; // eslint-disable-line curly  
 };
 
 methods.getDeviceSysLanguage = async function () {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -722,7 +722,7 @@ methods.setDeviceProperty = async function (prop, val) {
     log.debug(`Removing adb root for setDeviceProperty`);
     await this.unroot();
   }
-  if (!_.isError(err)) {
+  if (_.isError(err)) {
     log.errorAndThrow(`Error trying to set device property. Original error: ${err.message}`);
   }
 };

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -707,12 +707,13 @@ methods.getDeviceProperty = async function (property) {
 };
 
 methods.setDeviceProperty = async function (prop, val) {
-  let apiLevel = await this.getApiLevel(), err;
+  let apiLevel = await this.getApiLevel();
   if (apiLevel >= 26 ) {
     log.debug(`Running adb root, Android O needs adb to be rooted to setDeviceProperty`);
     await this.root();
   }
   log.debug(`Setting device property '${prop}' to '${val}'`);
+  let err;
   try {
     await this.shell(['setprop', prop, val]);
   } catch (e) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -707,16 +707,23 @@ methods.getDeviceProperty = async function (property) {
 };
 
 methods.setDeviceProperty = async function (prop, val) {
-  let apiLevel = await this.getApiLevel();
+  let apiLevel = await this.getApiLevel(), err;
   if (apiLevel >= 26 ) {
     log.debug(`Android O need to be on adb root to run setprop`);
     await this.root();
   }
   log.debug(`Setting device property '${prop}' to '${val}'`);
-  await this.shell(['setprop', prop, val]);
+  try {
+    await this.shell(['setprop', prop, val]);
+  } catch (e) {
+    err = e;
+  }
   if (apiLevel >= 26 ) {
     log.debug(`Removing adb root for setprop`);
     await this.unroot();
+  }
+  if (!_.isUndefined(err)) {
+    log.errorAndThrow(`Error trying to set device property. Original error: ${err.message}`);
   }
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -724,7 +724,7 @@ methods.setDeviceProperty = async function (prop, val) {
     await this.unroot();
   }
   if (_.isError(err)) {
-    throw new Error(err);
+    throw err;
   }
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -722,7 +722,7 @@ methods.setDeviceProperty = async function (prop, val) {
     log.debug(`Removing adb root for setDeviceProperty`);
     await this.unroot();
   }
-  if (!_.isUndefined(err)) {
+  if (!_.isError(err)) {
     log.errorAndThrow(`Error trying to set device property. Original error: ${err.message}`);
   }
 };

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -143,6 +143,30 @@ describe('adb commands', () => {
         mocks.adb.verify();
       });
     }));
+    describe('setDeviceProperty', withMocks({adb}, (mocks) => {
+      it('should call setprop with correct args without root', async () => {
+        mocks.adb.expects("getApiLevel")
+          .once().returns(21);
+        mocks.adb.expects("shell")
+          .withExactArgs(['setprop', 'persist.sys.locale', locale])
+          .returns("");
+        await adb.setDeviceProperty('persist.sys.locale', locale);
+        mocks.adb.verify();
+      });
+      it('should call setprop with correct args with root', async () => {
+        mocks.adb.expects("getApiLevel")
+          .once().returns(26);
+        mocks.adb.expects("root")
+          .once().returns("");
+        mocks.adb.expects("shell")
+          .withExactArgs(['setprop', 'persist.sys.locale', locale])
+          .returns("");
+        mocks.adb.expects("unroot")
+          .once().returns("");
+        await adb.setDeviceProperty('persist.sys.locale', locale);
+        mocks.adb.verify();
+      });
+    }));
     describe('availableIMEs', withMocks({adb}, (mocks) => {
       it('should call shell with correct args', async () => {
         mocks.adb.expects("shell")

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -410,6 +410,8 @@ describe('Apk-utils', () => {
   }));
   describe('setDeviceLanguage', withMocks({adb}, (mocks) => {
     it('should call shell one time with correct args when API < 23', async () => {
+      mocks.adb.expects("getApiLevel")
+        .once().returns(21);
       mocks.adb.expects("shell")
         .once().withExactArgs(['setprop', 'persist.sys.language', language])
         .returns("");
@@ -438,6 +440,8 @@ describe('Apk-utils', () => {
   }));
   describe('setDeviceCountry', withMocks({adb}, (mocks) => {
     it('should call shell one time with correct args', async () => {
+      mocks.adb.expects("getApiLevel")
+        .once().returns(21);
       mocks.adb.expects("shell")
         .once().withExactArgs(['setprop', 'persist.sys.country', country])
         .returns("");
@@ -466,6 +470,8 @@ describe('Apk-utils', () => {
   }));
   describe('setDeviceLocale', withMocks({adb}, (mocks) => {
     it('should call shell one time with correct args', async () => {
+      mocks.adb.expects("getApiLevel")
+        .once().returns(21);
       mocks.adb.expects("shell")
         .once().withExactArgs(['setprop', 'persist.sys.locale', locale])
         .returns("");


### PR DESCRIPTION
On Android O(api 26) i'm seeing setprop is failing is adb is not root. I modified setDeviceProperty method to set root, unroot in order to use setprop. 