### PR TITLE
Simplify filesize regexp

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -620,8 +620,8 @@ systemCallMethods.fileSize = async function (remotePath) {
     if (files.length !== 1) {
       throw new Error(`Remote path is not a file`);
     }
-    // https://regex101.com/r/fOs4P4/2
-    let match = /\s(\d+)\s\d{4}-\d{2}-\d{2}/.exec(files[0]);
+    // https://regex101.com/r/fOs4P4/3
+    let match = /\s(\d+)\s+\d{4}-\d{2}-\d{2}/.exec(files[0]);
     if (!match || _.isNaN(parseInt(match[1], 10))) {
       throw new Error(`Unable to parse size from list output: '${files[0]}'`);
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -620,8 +620,8 @@ systemCallMethods.fileSize = async function (remotePath) {
     if (files.length !== 1) {
       throw new Error(`Remote path is not a file`);
     }
-    // https://regex101.com/r/fOs4P4/1
-    let match = /[-rwxd]{10}\s*\S*\s*\S*\s*\S*\s*(\d*)\s*\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s[\S\.]*/.exec(files[0]);
+    // https://regex101.com/r/fOs4P4/2
+    let match = /\s(\d+)\s\d{4}-\d{2}-\d{2}/.exec(files[0]);
     if (!match || _.isNaN(parseInt(match[1], 10))) {
       throw new Error(`Unable to parse size from list output: '${files[0]}'`);
     }

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -146,11 +146,19 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     list.should.deep.equal(['bar']);
     mocks.adb.verify();
   });
-  it('fileSize should return the file size', async function () {
+  it('fileSize should return the file size when digit is after permissions', async function () {
     let remotePath = '/sdcard/test.mp4';
     mocks.adb.expects('shell')
       .once().withExactArgs(['ls', '-la', remotePath])
       .returns(`-rw-rw---- 1 root sdcard_rw 39571 2017-06-23 07:33 ${remotePath}`);
+    let size = await adb.fileSize(remotePath);
+    size.should.eql(39571);
+  });
+  it('fileSize should return the file size when digit is not after permissions', async function () {
+    let remotePath = '/sdcard/test.mp4';
+    mocks.adb.expects('shell')
+      .once().withExactArgs(['ls', '-la', remotePath])
+      .returns(`-rw-rw---- root sdcard_rw 39571 2017-06-23 07:33 ${remotePath}`);
     let size = await adb.fileSize(remotePath);
     size.should.eql(39571);
   });


### PR DESCRIPTION
Different versions of Android apparently have different formats of `ls -la` output, so reduce the regexp to checking file size and date, which appear to always be next to each other.

In regard to https://github.com/appium/appium/issues/8800