### PR TITLE
Fix return value on getAndroidPlatformAndPath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - ANDROID_EMU_TARGET=android-21
     - ANDROID_EMU_ABI=armeabi-v7a
   matrix:
-    - TEST=unit
+    - TEST=unit START_EMU=0
     - TEST=functional RECURSIVE=--recursive
 before_script:
   # node stuff

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
     - ANDROID_EMU_NAME=test
     - ANDROID_EMU_TARGET=android-21
     - ANDROID_EMU_ABI=armeabi-v7a
+    - ANDROID_AVD=test
+    - PLATFORM_VERSION=5.0.2
   matrix:
     - TEST=unit START_EMU=0
     - TEST=functional RECURSIVE=--recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,25 +14,39 @@ android:
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
     - sys-img-armeabi-v7a-android-22
-    - sys-img-armeabi-v7a-android-17
 env:
-  - _FORCE_LOGS=1 TEST=unit
-  - _FORCE_LOGS=1 TEST=functional PLATFORM_VERSION=5.0.2 ANDROID_AVD=test
+  global:
+    - _FORCE_LOGS=1
+    - DEVICE=android
+    - MOCHA_TIMEOUT=360000
+    - RECURSIVE=
+    - START_EMU=1
+    - ANDROID_EMU_NAME=test
+    - ANDROID_EMU_TARGET=android-21
+    - ANDROID_EMU_ABI=armeabi-v7a
+  matrix:
+    - TEST=unit
+    - TEST=functional RECURSIVE=--recursive
 before_script:
   # node stuff
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
   - nvm install 4
+  - node --version
+  - npm --version
+  - npm install appium-test-support # get the travis emu scripts
+
+  # android stuff
+  - android list targets
+  - $(npm bin)/android-emu-travis-pre
+
+  # npm stuff
   - npm install -g gulp
   - npm install -g mocha
   - npm install
 
-  # android stuff
-  - android list targets
-  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
+  # make sure emulator started
+  - $(npm bin)/android-emu-travis-post
 script:
-  - gulp eslint && DEVICE=android mocha -t 900000 -R spec build/test/$TEST
+  - gulp eslint && mocha -t 900000 -R spec $RECURSIVE build/test/$TEST
 after_success:
   - gulp coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
 before_script:
   # node stuff
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-  - nvm install 4
+  - nvm install 6
   - node --version
   - npm --version
   - npm install appium-test-support # get the travis emu scripts

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -32,8 +32,7 @@ async function getDirectories (rootPath) {
 async function getAndroidPlatformAndPath () {
   const androidHome = process.env.ANDROID_HOME;
   if (!_.isString(androidHome)) {
-    log.error("ANDROID_HOME environment variable was not exported!");
-    return {platform: null, platformPath: null};
+    log.errorAndThrow("ANDROID_HOME environment variable was not exported");
   }
 
   // get the latest platform and path

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -32,8 +32,8 @@ async function getDirectories (rootPath) {
 async function getAndroidPlatformAndPath () {
   const androidHome = process.env.ANDROID_HOME;
   if (!_.isString(androidHome)) {
-    log.error("ANDROID_HOME was not exported!");
-    return null;
+    log.error("ANDROID_HOME environment variable was not exported!");
+    return {platform: null, platformPath: null};
   }
 
   // get the latest platform and path
@@ -44,7 +44,7 @@ async function getAndroidPlatformAndPath () {
       return {platform, platformPath};
     }
   }
-  return null;
+  return {platform: null, platformPath: null};
 }
 
 async function unzipFile (zipPath) {

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -123,7 +123,7 @@ manifestMethods.compileManifest = async function (manifest, manifestPackage, tar
   log.debug(`Compiling manifest ${manifest}`);
   let {platform, platformPath} = await getAndroidPlatformAndPath();
   if (!platform) {
-    return new Error("Required platform doesn't exist (API level >= 17)");
+    throw new Error("Required platform doesn't exist (API level >= 17)");
   }
   log.debug('Compiling manifest.');
   try {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "devDependencies": {
     "appium-gulp-plugins": "^1.3.12",
-    "appium-test-support": "0.0.5",
+    "appium-test-support": "0.2.0",
     "babel-eslint": "^6.1.0",
     "chai": "^3.0.0",
     "chai-as-promised": "^6.0.0",

--- a/test/functional/helpers-specs-e2e-specs.js
+++ b/test/functional/helpers-specs-e2e-specs.js
@@ -20,8 +20,7 @@ describe('Helpers', () => {
     // temp setting android_home to null.
     delete process.env.ANDROID_HOME;
 
-    let result = await getAndroidPlatformAndPath();
-    result.should.eql({platform: null, platformPath: null});
+    await getAndroidPlatformAndPath().should.eventually.be.rejectedWith(/ANDROID_HOME environment variable was not exported/);
 
     // resetting ANDROID_HOME
     process.env.ANDROID_HOME = android_home;

--- a/test/functional/helpers-specs-e2e-specs.js
+++ b/test/functional/helpers-specs-e2e-specs.js
@@ -11,18 +11,18 @@ function getFixture (file) {
 }
 
 
-const should = chai.should(),
-      apkPath = path.resolve(rootDir, 'test',
-                             'fixtures', 'ContactManager.apk');
+const apkPath = path.resolve(rootDir, 'test', 'fixtures', 'ContactManager.apk');
 chai.use(chaiAsPromised);
 
 describe('Helpers', () => {
-  it('getAndroidPlatformAndPath should return null', async () => {
+  it('getAndroidPlatformAndPath should return empty object when no ANDROID_HOME is set', async () => {
     let android_home = process.env.ANDROID_HOME;
     // temp setting android_home to null.
-    process.env.ANDROID_HOME = null;
+    delete process.env.ANDROID_HOME;
+
     let result = await getAndroidPlatformAndPath();
-    should.not.exist(result);
+    result.should.eql({platform: null, platformPath: null});
+
     // resetting ANDROID_HOME
     process.env.ANDROID_HOME = android_home;
   });

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -64,7 +64,7 @@ describe('android-manifest', () => {
       let oldAndroidHome = process.env.ANDROID_HOME;
       delete process.env.ANDROID_HOME;
 
-      await adb.compileManifest().should.eventually.be.rejectedWith(/Required platform doesn't exist/);
+      await adb.compileManifest().should.eventually.be.rejectedWith(/ANDROID_HOME environment variable was not exported/);
 
       process.env.ANDROID_HOME = oldAndroidHome;
     });

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -59,4 +59,14 @@ describe('android-manifest', () => {
       mocks.adb.verify();
     });
   }));
+  describe('compileManifest', function () {
+    it('should throw an error if no ANDROID_HOME set', async function () {
+      let oldAndroidHome = process.env.ANDROID_HOME;
+      delete process.env.ANDROID_HOME;
+
+      await adb.compileManifest().should.eventually.be.rejectedWith(/Required platform doesn't exist/);
+
+      process.env.ANDROID_HOME = oldAndroidHome;
+    });
+  });
 });

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -3,11 +3,8 @@ import { getDirectories, getAndroidPlatformAndPath,
 import { withMocks } from 'appium-test-support';
 import { fs } from 'appium-support';
 import path from 'path';
-import chai from 'chai';
 import _ from 'lodash';
 
-
-const should = chai.should;
 
 describe('helpers', () => {
   describe('getDirectories', withMocks({fs}, (mocks) => {
@@ -27,7 +24,13 @@ describe('helpers', () => {
 
   describe('getAndroidPlatformAndPath', withMocks({fs, path}, (mocks) => {
     it('should return null if no ANDROID_HOME is set', async () => {
-      should(await getAndroidPlatformAndPath()).not.exist;
+      let oldAndroidHome = process.env.ANDROID_HOME;
+      delete process.env.ANDROID_HOME;
+
+      let result = await getAndroidPlatformAndPath();
+      result.should.eql({platform: null, platformPath: null});
+
+      process.env.ANDROID_HOME = oldAndroidHome;
     });
     it('should get the latest available API', async () => {
       let oldAndroidHome = process.env.ANDROID_HOME;

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -27,8 +27,7 @@ describe('helpers', () => {
       let oldAndroidHome = process.env.ANDROID_HOME;
       delete process.env.ANDROID_HOME;
 
-      let result = await getAndroidPlatformAndPath();
-      result.should.eql({platform: null, platformPath: null});
+      await getAndroidPlatformAndPath().should.eventually.be.rejectedWith(/ANDROID_HOME environment variable was not exported/);
 
       process.env.ANDROID_HOME = oldAndroidHome;
     });


### PR DESCRIPTION
Rather than returning `null`, which causes the calling code to fail, return an object whose properties are null.

Also fix the tests, since setting `process.env.ANDROID_HOME` to `null` is the wrong technique (from the [docs](https://nodejs.org/api/process.html#process_process_env): "Assigning a property on process.env will implicitly convert the value to a string.").