### PR TITLE
Make sure adb logcat resolves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,11 @@ before_script:
   - $(npm bin)/android-emu-travis-pre
 
   # npm stuff
-  - npm install -g gulp
-  - npm install -g mocha
   - npm install
 
   # make sure emulator started
   - $(npm bin)/android-emu-travis-post
 script:
-  - gulp eslint && mocha -t 900000 -R spec $RECURSIVE build/test/$TEST
+  - npm run lint && npm run mocha -- -t 900000 -R spec $RECURSIVE build/test/$TEST
 after_success:
   - gulp coveralls

--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -30,10 +30,7 @@ class Logcat {
         log.error(`Logcat terminated with code ${code}, signal ${signal}`);
         this.proc = null;
         if (!started) {
-          log.warn('Logcat not started. Log capture before exit:');
-          for (let line of this.logs) {
-            log.warn(`    ${line}`);
-          }
+          log.warn('Logcat not started. Continuing');
           resolve();
         }
       });

--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -13,13 +13,29 @@ class Logcat {
   }
 
   startCapture () {
-    return new Promise(async (resolve, reject) => {
-      log.debug("Starting logcat capture");
+    let started = false;
+    return new Promise(async (_resolve, _reject) => {
+      const resolve = function (...args) {
+        started = true;
+        _resolve(...args);
+      };
+      const reject = function (...args) {
+        started = true;
+        _reject(...args);
+      };
+
+      log.debug('Starting logcat capture');
       this.proc = new SubProcess(this.adb.path, this.adb.defaultArgs.concat(['logcat', '-v', 'threadtime']));
-      await this.proc.start(0);
       this.proc.on('exit', (code, signal) => {
         log.error(`Logcat terminated with code ${code}, signal ${signal}`);
         this.proc = null;
+        if (!started) {
+          log.warn('Logcat not started. Log capture before exit:');
+          for (let line of this.logs) {
+            log.warn(`    ${line}`);
+          }
+          resolve();
+        }
       });
       this.proc.on('lines-stderr', (lines) => {
         for (let line of lines) {
@@ -37,6 +53,7 @@ class Logcat {
           this.outputHandler(line);
         }
       });
+      await this.proc.start(0);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "prepublish": "gulp prepublish",
     "test": "gulp once",
-    "watch": "gulp",
+    "watch": "gulp watch",
+    "build": "gulp transpile",
+    "mocha": "mocha",
+    "e2e-test": "gulp e2e-test",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "lint": "gulp eslint"
   },

--- a/test/unit/logcat-specs.js
+++ b/test/unit/logcat-specs.js
@@ -38,5 +38,17 @@ describe('logcat', async () => {
       await logcat.startCapture().should.eventually.be.rejectedWith('Logcat');
       mocks.teen_process.verify();
     });
+    it('should correctly call subprocess and should resolve promise if it fails on startup', async () => {
+      let conn = new events.EventEmitter();
+      conn.start = () => { };
+      mocks.teen_process.expects("SubProcess")
+        .once().withExactArgs('dummyPath', ['logcat', '-v', 'threadtime'])
+        .returns(conn);
+      setTimeout(function () {
+        conn.emit('lines-stderr', ['something']);
+      }, 0);
+      await logcat.startCapture().should.eventually.not.be.rejectedWith('Logcat');
+      mocks.teen_process.verify();
+    });
   }));
 });


### PR DESCRIPTION
Currently, if `adb logcat` fails with a startup error like "execvp", we reject the promise and throw in the calling code. But if startup fails for any other reason we do nothing, and the promise is never resolved or rejected, so the session hangs.

So, keep track of whether we've started, so that we can log that it failed in this condition, and resolve the promise. Things will work fine but there will be no logcat capture.

Should fix https://github.com/appium/appium/issues/8743