### PR TITLE
Add method to get/set gps location provider

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -190,6 +190,13 @@ methods.getReqPermissions = async function (pkg, cmdOutput = null) {
   return match[0].match(/android\.permission\.\w+/g) || [];
 };
 
+methods.getLocationProviders = async function () {
+  let stdout = await this.shell(['settings', 'get', 'secure', 'location_providers_allowed']);
+  return stdout.trim().split(',')
+    .filter((p) => { if (p !== "") { return p; } })
+    .map((p) => { return p.trim(); });
+};
+
 methods.stopAndClear = async function (pkg) {
   try {
     await this.forceStop(pkg);

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -193,12 +193,12 @@ methods.getReqPermissions = async function (pkg, cmdOutput = null) {
 methods.getLocationProviders = async function () {
   let stdout = await this.shell(['settings', 'get', 'secure', 'location_providers_allowed']);
   return stdout.trim().split(',')
-    .filter((p) => { if (p !== "") { return p; } })
-    .map((p) => { return p.trim(); });
+    .filter((p) => !!p)
+    .map((p) => p.trim());
 };
 
 methods.toggleGPSLocationProvider = async function (enabled) {
-  await this.shell(['settings', 'put', 'secure', 'location_providers_allowed', `${enabled === true ? "+":"-"}gps`]);
+  await this.shell(['settings', 'put', 'secure', 'location_providers_allowed', `${enabled ? "+":"-"}gps`]);
 };
 
 methods.stopAndClear = async function (pkg) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -193,12 +193,12 @@ methods.getReqPermissions = async function (pkg, cmdOutput = null) {
 methods.getLocationProviders = async function () {
   let stdout = await this.shell(['settings', 'get', 'secure', 'location_providers_allowed']);
   return stdout.trim().split(',')
-    .filter((p) => !!p)
-    .map((p) => p.trim());
+    .map((p) => p.trim())
+    .filter(Boolean);
 };
 
 methods.toggleGPSLocationProvider = async function (enabled) {
-  await this.shell(['settings', 'put', 'secure', 'location_providers_allowed', `${enabled ? "+":"-"}gps`]);
+  await this.shell(['settings', 'put', 'secure', 'location_providers_allowed', `${enabled ? "+" : "-"}gps`]);
 };
 
 methods.stopAndClear = async function (pkg) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -197,6 +197,10 @@ methods.getLocationProviders = async function () {
     .map((p) => { return p.trim(); });
 };
 
+methods.toggleGPSLocationProvider = async function (enabled) {
+  await this.shell(['settings', 'put', 'secure', 'location_providers_allowed', `${enabled === true ? "+":"-"}gps`]);
+};
+
 methods.stopAndClear = async function (pkg) {
   try {
     await this.forceStop(pkg);

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -89,6 +89,61 @@ describe('adb commands', () => {
         mocks.adb.verify();
       });
     }));
+    describe('getLocationProviders', withMocks({adb}, (mocks) => {
+      it('should call shell with correct args', async () => {
+        mocks.adb.expects("shell")
+          .once().withExactArgs(['settings', 'get', 'secure', 'location_providers_allowed'])
+          .returns('');
+        await adb.getLocationProviders();
+        mocks.adb.verify();
+      });
+      it('should return empty location_providers_allowed', async () => {
+        mocks.adb.expects("shell")
+          .once().withExactArgs(['settings', 'get', 'secure', 'location_providers_allowed'])
+          .returns('');
+        let providers = await adb.getLocationProviders();
+        providers.should.be.an('array');
+        providers.length.should.equal(0);
+        mocks.adb.verify();
+      });
+      it('should return one location_providers_allowed', async () => {
+        mocks.adb.expects("shell")
+          .once().withExactArgs(['settings', 'get', 'secure', 'location_providers_allowed'])
+          .returns('gps');
+        let providers = await adb.getLocationProviders();
+        providers.should.be.an('array');
+        providers.length.should.equal(1);
+        providers.should.include('gps');
+        mocks.adb.verify();
+      });
+      it('should return both location_providers_allowed', async () => {
+        mocks.adb.expects("shell")
+          .once().withExactArgs(['settings', 'get', 'secure', 'location_providers_allowed'])
+          .returns('gps ,wifi');
+        let providers = await adb.getLocationProviders();
+        providers.should.be.an('array');
+        providers.length.should.equal(2);
+        providers.should.include('gps');
+        providers.should.include('wifi');
+        mocks.adb.verify();
+      });
+    }));
+    describe('toggleGPSLocationProvider', withMocks({adb}, (mocks) => {
+      it('should call shell with correct args on gps enabled', async () => {
+        mocks.adb.expects("shell")
+          .once()
+          .withExactArgs(['settings', 'put', 'secure', 'location_providers_allowed', '+gps']);
+        await adb.toggleGPSLocationProvider(true);
+        mocks.adb.verify();
+      });
+      it('should call shell with correct args on gps disabled', async () => {
+        mocks.adb.expects("shell")
+          .once()
+          .withExactArgs(['settings', 'put', 'secure', 'location_providers_allowed', '-gps']);
+        await adb.toggleGPSLocationProvider(false);
+        mocks.adb.verify();
+      });
+    }));
     describe('setDeviceSysCountry', withMocks({adb}, (mocks) => {
       it('should call shell with correct args', async () => {
         mocks.adb.expects("shell")

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -90,14 +90,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getLocationProviders', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
-        mocks.adb.expects("shell")
-          .once().withExactArgs(['settings', 'get', 'secure', 'location_providers_allowed'])
-          .returns('');
-        await adb.getLocationProviders();
-        mocks.adb.verify();
-      });
-      it('should return empty location_providers_allowed', async () => {
+      it('should call shell with correct args and return empty location_providers_allowed', async () => {
         mocks.adb.expects("shell")
           .once().withExactArgs(['settings', 'get', 'secure', 'location_providers_allowed'])
           .returns('');
@@ -131,15 +124,10 @@ describe('adb commands', () => {
     describe('toggleGPSLocationProvider', withMocks({adb}, (mocks) => {
       it('should call shell with correct args on gps enabled', async () => {
         mocks.adb.expects("shell")
-          .once()
           .withExactArgs(['settings', 'put', 'secure', 'location_providers_allowed', '+gps']);
-        await adb.toggleGPSLocationProvider(true);
-        mocks.adb.verify();
-      });
-      it('should call shell with correct args on gps disabled', async () => {
         mocks.adb.expects("shell")
-          .once()
           .withExactArgs(['settings', 'put', 'secure', 'location_providers_allowed', '-gps']);
+        await adb.toggleGPSLocationProvider(true);
         await adb.toggleGPSLocationProvider(false);
         mocks.adb.verify();
       });


### PR DESCRIPTION
We can ensure gps toggle for emulators by calling adb with `adb shell settings put secure location_providers_allowed +gps`(tested on 4.4+). 
The idea is to change how we toggle gps specifically for emulators and also add a capability to enable/disable gps before launching an app. 