### PR TITLE
Clean up logging of avd output

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -438,7 +438,9 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   let proc = new SubProcess(emulatorBinaryPath, launchArgs);
   await proc.start(0);
   proc.on('output', (stdout, stderr) => {
-    log.info(`[AVD OUTPUT] ${stdout || stderr}`);
+    for (let line of (stdout || stderr || '').split('\n').filter(Boolean)) {
+      log.info(`[AVD OUTPUT] ${line}`);
+    }
   });
   proc.on('exit', (code, signal) => {
     if (code !== 0) {


### PR DESCRIPTION
Split multi-line avd output and log on individual lines.
At the moment we get logging like (see [this log](https://gist.github.com/vmaxim/79c608c0fc15ad9928fe7bd293f89648#file-appium_logs_2017-08-09-L83-L86)):
```
2017-08-09 05:58:57:293 - [ADB] [AVD OUTPUT] Hax is enabled
Hax ram_size 0x40000000
HAX is working and emulator runs in fast virt mode.

```
This PR will change it to:
```
2017-08-09 05:58:57:293 - [ADB] [AVD OUTPUT] Hax is enabled
2017-08-09 05:58:57:293 - [ADB] [AVD OUTPUT] Hax ram_size 0x40000000
2017-08-09 05:58:57:293 - [ADB] [AVD OUTPUT] HAX is working and emulator runs in fast virt mode.
```