### PR TITLE
Set receiver names explicitly for the case Appium Settings app is not running

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -679,6 +679,7 @@ methods.setWifiState = async function (on, isEmulator = false) {
     await this.shell(['svc', 'wifi', on ? 'enable' : 'disable']);
   } else {
     await this.shell(['am', 'broadcast', '-a', `${SETTINGS_HELPER_ID}.wifi`,
+                      '-n', `${SETTINGS_HELPER_ID}/.receivers.WiFiStatusReceiver`,
                       '--es', 'setstatus', on ? 'enable' : 'disable']);
   }
 };
@@ -705,6 +706,7 @@ methods.setDataState = async function (on, isEmulator = false) {
     await this.shell(['svc', 'data', on ? 'enable' : 'disable']);
   } else {
     await this.shell(['am', 'broadcast', '-a', `${SETTINGS_HELPER_ID}.data_connection`,
+                      '-n', `${SETTINGS_HELPER_ID}/.receivers.DataConnectionStatusReceiver`,
                       '--es', 'setstatus', on ? 'enable' : 'disable']);
   }
 };

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -400,7 +400,9 @@ describe('adb commands', () => {
     describe('setWifiState', withMocks({adb}, (mocks) => {
       it('should call shell with correct args for real device', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi', '--es', 'setstatus', 'enable'])
+          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi',
+            '-n', 'io.appium.settings/.receivers.WiFiStatusReceiver',
+            '--es', 'setstatus', 'enable'])
           .returns("");
         await adb.setWifiState(true);
         mocks.adb.verify();
@@ -432,7 +434,9 @@ describe('adb commands', () => {
     describe('setDataState', withMocks({adb}, (mocks) => {
       it('should call shell with correct args for real device', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection', '--es', 'setstatus', 'disable'])
+          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection', 
+            '-n', 'io.appium.settings/.receivers.DataConnectionStatusReceiver',
+            '--es', 'setstatus', 'disable'])
           .returns("");
         await adb.setDataState(false);
         mocks.adb.verify();
@@ -448,7 +452,9 @@ describe('adb commands', () => {
     describe('setWifiAndData', withMocks({adb}, (mocks) => {
       it('should call shell with correct args when turning only wifi on for real device', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi', '--es', 'setstatus', 'enable'])
+          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi',
+            '-n', 'io.appium.settings/.receivers.WiFiStatusReceiver',
+            '--es', 'setstatus', 'enable'])
           .returns("");
         await adb.setWifiAndData({wifi: true});
         mocks.adb.verify();
@@ -469,7 +475,9 @@ describe('adb commands', () => {
       });
       it('should call shell with correct args when turning only data off for real device', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection', '--es', 'setstatus', 'disable'])
+          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection', 
+            '-n', 'io.appium.settings/.receivers.DataConnectionStatusReceiver',
+            '--es', 'setstatus', 'disable'])
           .returns("");
         await adb.setWifiAndData({data: false});
         mocks.adb.verify();

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -434,7 +434,7 @@ describe('adb commands', () => {
     describe('setDataState', withMocks({adb}, (mocks) => {
       it('should call shell with correct args for real device', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection', 
+          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection',
             '-n', 'io.appium.settings/.receivers.DataConnectionStatusReceiver',
             '--es', 'setstatus', 'disable'])
           .returns("");
@@ -475,7 +475,7 @@ describe('adb commands', () => {
       });
       it('should call shell with correct args when turning only data off for real device', async () => {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection', 
+          .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection',
             '-n', 'io.appium.settings/.receivers.DataConnectionStatusReceiver',
             '--es', 'setstatus', 'disable'])
           .returns("");


### PR DESCRIPTION
This will hopefully address issues like https://github.com/appium/appium/issues/9132