### PR TITLE
killProcessByPID may work well with param -9

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1002,7 +1002,7 @@ methods.killProcessesByName = async function (name) {
  */
 methods.killProcessByPID = async function (pid) {
   log.debug(`Attempting to kill process ${pid}`);
-  return await this.shell(['kill', pid]);
+  return await this.shell(['kill', '-9', pid]);
 };
 
 /**


### PR DESCRIPTION
KILL PID may not close the uiautomator process on some devices like LENOVO K50-T5, add -9 may work well