### PR TITLE
Match receiver names to Appium Settings v 2.3.0+

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -677,7 +677,7 @@ methods.setWifiState = async function (on, isEmulator = false) {
     await this.shell(['svc', 'wifi', on ? 'enable' : 'disable']);
   } else {
     await this.shell(['am', 'broadcast', '-a', `${SETTINGS_HELPER_ID}.wifi`,
-                      '-n', `${SETTINGS_HELPER_ID}/.receivers.WiFiStatusReceiver`,
+                      '-n', `${SETTINGS_HELPER_ID}/.receivers.WiFiConnectionSettingReceiver`,
                       '--es', 'setstatus', on ? 'enable' : 'disable']);
   }
 };
@@ -704,7 +704,7 @@ methods.setDataState = async function (on, isEmulator = false) {
     await this.shell(['svc', 'data', on ? 'enable' : 'disable']);
   } else {
     await this.shell(['am', 'broadcast', '-a', `${SETTINGS_HELPER_ID}.data_connection`,
-                      '-n', `${SETTINGS_HELPER_ID}/.receivers.DataConnectionStatusReceiver`,
+                      '-n', `${SETTINGS_HELPER_ID}/.receivers.DataConnectionSettingReceiver`,
                       '--es', 'setstatus', on ? 'enable' : 'disable']);
   }
 };

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -401,7 +401,7 @@ describe('adb commands', () => {
       it('should call shell with correct args for real device', async () => {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi',
-            '-n', 'io.appium.settings/.receivers.WiFiStatusReceiver',
+            '-n', 'io.appium.settings/.receivers.WiFiConnectionSettingReceiver',
             '--es', 'setstatus', 'enable'])
           .returns("");
         await adb.setWifiState(true);
@@ -435,7 +435,7 @@ describe('adb commands', () => {
       it('should call shell with correct args for real device', async () => {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection',
-            '-n', 'io.appium.settings/.receivers.DataConnectionStatusReceiver',
+            '-n', 'io.appium.settings/.receivers.DataConnectionSettingReceiver',
             '--es', 'setstatus', 'disable'])
           .returns("");
         await adb.setDataState(false);
@@ -453,7 +453,7 @@ describe('adb commands', () => {
       it('should call shell with correct args when turning only wifi on for real device', async () => {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi',
-            '-n', 'io.appium.settings/.receivers.WiFiStatusReceiver',
+            '-n', 'io.appium.settings/.receivers.WiFiConnectionSettingReceiver',
             '--es', 'setstatus', 'enable'])
           .returns("");
         await adb.setWifiAndData({wifi: true});
@@ -476,7 +476,7 @@ describe('adb commands', () => {
       it('should call shell with correct args when turning only data off for real device', async () => {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection',
-            '-n', 'io.appium.settings/.receivers.DataConnectionStatusReceiver',
+            '-n', 'io.appium.settings/.receivers.DataConnectionSettingReceiver',
             '--es', 'setstatus', 'disable'])
           .returns("");
         await adb.setWifiAndData({data: false});


### PR DESCRIPTION
Update receiver names, otherwise switching WiFi/Data state won't work properly