### PR TITLE
Add option to full reinstall on upgrade

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -328,15 +328,14 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, fullReinstal
     return;
   }
 
-  if (!await this.isAppInstalled(pkg)) {
-    await this.install(apk, false, timeout);
-    return;
-  }
-
   if (fullReinstall) {
     // uninstall first, then install
     log.debug(`Uninstalling and re-installing '${pkg}'`);
     await this.uninstallApk(pkg);
+  }
+
+  if (!await this.isAppInstalled(pkg)) {
+    log.debug(`App '${apk}' not installed. Installing`);
     await this.install(apk, false, timeout);
     return;
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -311,11 +311,13 @@ apkUtilsMethods.install = async function (apk, replace = true, timeout = 60000) 
  * @param {string} apk - The full path to the local package.
  * @param {?string} pkg - The name of the installed package. The method will
  *                        perform faster if it is set.
- * @param {number} timeout [60000] - The number of milliseconds to wait until
+ * @param {?boolean} fullReinstall - If true, uninstalls and re-installs the application
+ *                                   if it is already on the device.
+ * @param {?number} timeout [60000] - The number of milliseconds to wait until
  *                                   installation is completed.
  * @throws {error} If an unexpected error happens during install.
  */
-apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60000) {
+apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, fullReinstall = false, timeout = 60000) {
   let apkInfo = null;
   if (!pkg) {
     apkInfo = await this.getApkInfo(apk);
@@ -325,32 +327,43 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60
     log.warn(`Cannot read the package name of ${apk}. Assuming correct app version is already installed`);
     return;
   }
+
   if (!await this.isAppInstalled(pkg)) {
     await this.install(apk, false, timeout);
     return;
   }
+
+  if (fullReinstall) {
+    // uninstall first, then install
+    log.debug(`Uninstalling and re-installing '${pkg}'`);
+    await this.uninstallApk(pkg);
+    await this.install(apk, false, timeout);
+    return;
+  }
+
   const pkgInfo = await this.getPackageInfo(pkg);
   const pkgVersionCode = pkgInfo.versionCode;
   if (!apkInfo) {
     apkInfo = await this.getApkInfo(apk);
   }
   const apkVersionCode = apkInfo.versionCode;
+
   if (_.isUndefined(apkVersionCode) || _.isUndefined(pkgVersionCode)) {
-    log.warn(`Cannot read version codes of ${apk} and/or ${pkg}. Assuming correct app version is already installed`);
+    log.warn(`Cannot read version codes of '${apk}' and/or '${pkg}'. Assuming correct app version is already installed`);
     return;
   }
   if (pkgVersionCode >= apkVersionCode) {
-    log.debug(`The installed "${pkg}" package does not require upgrade (${pkgVersionCode} >= ${apkVersionCode})`);
+    log.debug(`The installed '${pkg}' package does not require upgrade (${pkgVersionCode} >= ${apkVersionCode})`);
     return;
   }
-  log.debug(`The installed "${pkg}" package is older than ${apk} (${pkgVersionCode} < ${apkVersionCode}). ` +
+  log.debug(`The installed '${pkg}' package is older than '${apk}' (${pkgVersionCode} < ${apkVersionCode}). ` +
             `Executing upgrade`);
   try {
     await this.install(apk, true, timeout);
   } catch (err) {
-    log.warn(`Cannot upgrade ${pkg} because of "${err.message}". Trying full reinstall`);
+    log.warn(`Cannot upgrade '${pkg}' because of '${err.message}'. Trying full reinstall`);
     if (!await this.uninstallApk(pkg)) {
-      log.errorAndThrow(`"${pkg}" package cannot be uninstalled`);
+      log.errorAndThrow(`'${pkg}' package cannot be uninstalled`);
     }
     await this.install(apk, false, timeout);
   }

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -592,6 +592,13 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
+    it('should execute uninstall then install if fullReinstall set', async () => {
+      mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns();
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(false);
+      mocks.adb.expects('install').withArgs(apkPath, false).once().returns(true);
+      await adb.installOrUpgrade(apkPath, pkgId, true);
+      mocks.adb.verify();
+    });
     it('should return if the same package version is already installed', async () => {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         versionCode: 1


### PR DESCRIPTION
Add flag to make `installOrUpgrade` force uninstall and then install. This is needed for some cases of the settings app. In that case, we don't care about whether we save any state or data.