### PR TITLE
Rely on failure to uninstall app

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -311,13 +311,11 @@ apkUtilsMethods.install = async function (apk, replace = true, timeout = 60000) 
  * @param {string} apk - The full path to the local package.
  * @param {?string} pkg - The name of the installed package. The method will
  *                        perform faster if it is set.
- * @param {?boolean} fullReinstall - If true, uninstalls and re-installs the application
- *                                   if it is already on the device.
  * @param {?number} timeout [60000] - The number of milliseconds to wait until
  *                                   installation is completed.
  * @throws {error} If an unexpected error happens during install.
  */
-apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, fullReinstall = false, timeout = 60000) {
+apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60000) {
   let apkInfo = null;
   if (!pkg) {
     apkInfo = await this.getApkInfo(apk);
@@ -326,12 +324,6 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, fullReinstal
   if (!pkg) {
     log.warn(`Cannot read the package name of ${apk}. Assuming correct app version is already installed`);
     return;
-  }
-
-  if (fullReinstall) {
-    // uninstall first, then install
-    log.debug(`Uninstalling and re-installing '${pkg}'`);
-    await this.uninstallApk(pkg);
   }
 
   if (!await this.isAppInstalled(pkg)) {


### PR DESCRIPTION
Rather than uninstall _a priori_, rely on uninstalling if there is an error in installing.

This means we don't need the `forceUninstall` parameter. This is technically a breaking change, but there is only one place where this method is used, so we can just fix that when the time comes.