### PR TITLE
Escape ampersand in URIs

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -41,7 +41,7 @@ apkUtilsMethods.startUri = async function (uri, pkg) {
   }
   try {
     let args = ["am", "start", "-W", "-a", "android.intent.action.VIEW", "-d",
-                uri, pkg];
+                uri.replace(/&/g, '\\&'), pkg];
     await this.shell(args);
   } catch (e) {
     log.errorAndThrow(`Error attempting to start URI. Original error: ${e}`);


### PR DESCRIPTION
... so we can use URIs with multiple query parameters. 