### PR TITLE
Make getApiLevel to return number instead of string

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -53,14 +53,18 @@ methods.initZipAlign = async function () {
 /**
  * Retrieve the API level of the device under test.
  *
- * @return {string} The API level as integer number, for example 21 for
+ * @return {number} The API level as integer number, for example 21 for
  *                  Android Lollipop. The result of this method is cached, so all the further
  * calls return the same value as the first one.
  */
 methods.getApiLevel = async function () {
-  if (!this._apiLevel) {
+  if (!_.isNumber(this._apiLevel)) {
     try {
-      this._apiLevel = await this.getDeviceProperty('ro.build.version.sdk');
+      const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
+      this._apiLevel = parseInt(strOutput.trim(), 10);
+      if (isNaN(this._apiLevel)) {
+        throw new Error(`The actual output "${strOutput}" cannot be converted to an integer`);
+      }
     } catch (e) {
       log.errorAndThrow(`Error getting device API level. Original error: ${e.message}`);
     }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -58,7 +58,7 @@ methods.initZipAlign = async function () {
  * calls return the same value as the first one.
  */
 methods.getApiLevel = async function () {
-  if (!_.isNumber(this._apiLevel)) {
+  if (!_.isInteger(this._apiLevel)) {
     try {
       const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
       this._apiLevel = parseInt(strOutput.trim(), 10);

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -69,7 +69,7 @@ emuMethods.fingerprint = async function (fingerprintId) {
   }
   // the method used only works for API level 23 and above
   let level = await this.getApiLevel();
-  if (parseInt(level, 10) < 23) {
+  if (level < 23) {
     log.errorAndThrow(`Device API Level must be >= 23. Current Api level '${level}'`);
   }
   await this.adbExecEmu(['finger', 'touch', fingerprintId]);

--- a/test/functional/adb-emu-commands-e2e-specs.js
+++ b/test/functional/adb-emu-commands-e2e-specs.js
@@ -21,7 +21,7 @@ describe('adb emu commands', () => {
 
     // the test here only works if we have API level 23 or above
     // it will also fail on emulators
-    if (parseInt(await adb.getApiLevel(), 10) < 23 || !process.env.REAL_DEVICE) {
+    if (await adb.getApiLevel() < 23 || !process.env.REAL_DEVICE) {
       this.skip();
     }
   });

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -16,6 +16,7 @@ const platformVersion = process.env.PLATFORM_VERSION || '4.3';
 
 let apiLevel = process.env.API_LEVEL ||
                API_LEVEL_MAP[parseFloat(platformVersion).toString()];
+apiLevel = parseInt(apiLevel, 10);
 
 let MOCHA_TIMEOUT = process.env.TRAVIS ? 240000 : 60000;
 let MOCHA_LONG_TIMEOUT = MOCHA_TIMEOUT * 10;

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -28,7 +28,7 @@ describe('System calls', function () {
     (await adb.isDeviceConnected()).should.be.true;
   });
   it('shell should execute command in adb shell ', async () => {
-    (await adb.shell(['getprop', 'ro.build.version.sdk'])).should.equal(apiLevel);
+    (await adb.shell(['getprop', 'ro.build.version.sdk'])).should.equal(`${apiLevel}`);
   });
   it('getConnectedEmulators should get all connected emulators', async () => {
     (await adb.getConnectedEmulators()).length.should.be.above(0);

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -11,7 +11,7 @@ import { withMocks } from 'appium-test-support';
 
 chai.use(chaiAsPromised);
 const should = chai.should();
-const apiLevel = '21',
+const apiLevel = 21,
       platformVersion = '4.4.4',
       language = 'en',
       country = 'US',
@@ -48,7 +48,7 @@ describe('adb commands', () => {
       it('should call shell with correct args', async () => {
         mocks.adb.expects("getDeviceProperty")
           .once().withExactArgs('ro.build.version.sdk')
-          .returns(apiLevel);
+          .returns(`${apiLevel}`);
         (await adb.getApiLevel()).should.equal(apiLevel);
         mocks.adb.verify();
       });

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -349,7 +349,7 @@ describe('Apk-utils', () => {
     it('should call getApiLevel and shell with correct arguments', async () => {
       mocks.adb.expects('getApiLevel')
         .once().withExactArgs()
-        .returns('17');
+        .returns(17);
       mocks.adb.expects('shell')
         .once().withExactArgs(cmd)
         .returns('');
@@ -359,7 +359,7 @@ describe('Apk-utils', () => {
     it('should call getApiLevel and shell with correct arguments', async () => {
       mocks.adb.expects('getApiLevel')
         .twice()
-        .returns('17');
+        .returns(17);
       mocks.adb.expects('shell')
         .onCall(0)
         .returns('Error: Activity class foo does not exist');
@@ -374,7 +374,7 @@ describe('Apk-utils', () => {
 
       mocks.adb.expects('getApiLevel')
         .once().withExactArgs()
-        .returns('17');
+        .returns(17);
       mocks.adb.expects('shell')
         .once().withExactArgs(cmdWithInnerClass)
         .returns('');


### PR DESCRIPTION
I see that in many places people wrongly consider the returned value of getApiLevel is an integer number and perform string-to-number comparison, which never works properly (though throws no warnings/errors with JS). This PR unifies the stuff and makes the method to always return a number. The change should not be a problem for client libs, since `parseInt(x, 10)` will work properly if x is already an integer.