### PR TITLE
Fix restoration of ANDROID_HOME env variable

### DIFF
--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -23,17 +23,20 @@ describe('helpers', () => {
   }));
 
   describe('getAndroidPlatformAndPath', withMocks({fs, path}, (mocks) => {
+    let oldAndroidHome;
+    beforeEach(function () {
+      oldAndroidHome = process.env.ANDROID_HOME;
+    });
+    afterEach(function () {
+      process.env.ANDROID_HOME = oldAndroidHome;
+    });
+
     it('should return null if no ANDROID_HOME is set', async () => {
-      let oldAndroidHome = process.env.ANDROID_HOME;
       delete process.env.ANDROID_HOME;
 
       await getAndroidPlatformAndPath().should.eventually.be.rejectedWith(/ANDROID_HOME environment variable was not exported/);
-
-      process.env.ANDROID_HOME = oldAndroidHome;
     });
-    // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-    it.skip('should get the latest available API', async () => {
-      let oldAndroidHome = process.env.ANDROID_HOME;
+    it('should get the latest available API', async () => {
       process.env.ANDROID_HOME = '/path/to/android/home';
       mocks.fs.expects('exists')
         .exactly(2)
@@ -51,7 +54,6 @@ describe('helpers', () => {
 
       mocks.fs.verify();
       mocks.path.verify();
-      process.env.ANDROID_HOME = oldAndroidHome;
     });
   }));
 

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -31,7 +31,7 @@ describe('helpers', () => {
       process.env.ANDROID_HOME = oldAndroidHome;
     });
 
-    it('should return null if no ANDROID_HOME is set', async () => {
+    it.skip('should return null if no ANDROID_HOME is set', async () => {
       delete process.env.ANDROID_HOME;
 
       await getAndroidPlatformAndPath().should.eventually.be.rejectedWith(/ANDROID_HOME environment variable was not exported/);

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -31,12 +31,12 @@ describe('helpers', () => {
       process.env.ANDROID_HOME = oldAndroidHome;
     });
 
-    it.skip('should return null if no ANDROID_HOME is set', async () => {
+    it('should return null if no ANDROID_HOME is set', async () => {
       delete process.env.ANDROID_HOME;
 
       await getAndroidPlatformAndPath().should.eventually.be.rejectedWith(/ANDROID_HOME environment variable was not exported/);
     });
-    it('should get the latest available API', async () => {
+    it.skip('should get the latest available API', async () => {
       process.env.ANDROID_HOME = '/path/to/android/home';
       mocks.fs.expects('exists')
         .exactly(2)


### PR DESCRIPTION
The previous approach was not very good as for a unit test, because it is not going to restore previously changed ANDROID_HOME variable if the test fails.