### PR TITLE
Stop skipping tests

### DIFF
--- a/test/unit/logcat-specs.js
+++ b/test/unit/logcat-specs.js
@@ -12,8 +12,7 @@ describe('logcat', async () => {
   let adb = {path: 'dummyPath', defaultArgs: []};
   let logcat = new Logcat({adb, debug: false, debugTrace: false});
   describe('startCapture', withMocks({teen_process}, (mocks) => {
-    // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-    it.skip('should correctly call subprocess and should resolve promise', async () => {
+    it('should correctly call subprocess and should resolve promise', async () => {
       let conn = new events.EventEmitter();
       conn.start = () => { };
       mocks.teen_process.expects("SubProcess")
@@ -27,8 +26,7 @@ describe('logcat', async () => {
       logs.should.have.length.above(0);
       mocks.teen_process.verify();
     });
-    // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-    it.skip('should correctly call subprocess and should reject promise', async () => {
+    it('should correctly call subprocess and should reject promise', async () => {
       let conn = new events.EventEmitter();
       conn.start = () => { };
       mocks.teen_process.expects("SubProcess")
@@ -40,8 +38,7 @@ describe('logcat', async () => {
       await logcat.startCapture().should.eventually.be.rejectedWith('Logcat');
       mocks.teen_process.verify();
     });
-    // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-    it.skip('should correctly call subprocess and should resolve promise if it fails on startup', async () => {
+    it('should correctly call subprocess and should resolve promise if it fails on startup', async () => {
       let conn = new events.EventEmitter();
       conn.start = () => { };
       mocks.teen_process.expects("SubProcess")

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -13,8 +13,7 @@ adb.executable.path = 'adb_path';
 const avdName = 'AVD_NAME';
 
 describe('System calls', withMocks({teen_process}, (mocks) => {
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getConnectedDevices should get all connected devices', async () => {
+  it('getConnectedDevices should get all connected devices', async () => {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"List of devices attached \n emulator-5554	device"});
@@ -22,8 +21,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getConnectedDevices should get all connected devices which have valid udid', async () => {
+  it('getConnectedDevices should get all connected devices which have valid udid', async () => {
     let stdoutValue = "List of devices attached \n" +
                       "adb server version (32) doesn't match this client (36); killing...\n" +
                       "* daemon started successfully *\n" +
@@ -36,8 +34,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getConnectedDevices should fail when adb devices returns unexpected output', async () => {
+  it('getConnectedDevices should fail when adb devices returns unexpected output', async () => {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"foobar"});
@@ -45,8 +42,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
                                    .rejectedWith("Unexpected output while trying to get devices");
     mocks.teen_process.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getDevicesWithRetry should fail when there are no connected devices', async function () {
+  it('getDevicesWithRetry should fail when there are no connected devices', async function () {
     this.timeout(20000);
     mocks.teen_process.expects("exec")
       .atLeast(2).withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
@@ -55,8 +51,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
                                        .rejectedWith("Could not find a connected Android device.");
     mocks.teen_process.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getDevicesWithRetry should fail when adb devices returns unexpected output', async () => {
+  it('getDevicesWithRetry should fail when adb devices returns unexpected output', async () => {
     mocks.teen_process.expects("exec")
       .atLeast(2).withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"foobar"});
@@ -64,8 +59,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
                                        .rejectedWith("Could not find a connected Android device.");
     mocks.teen_process.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getDevicesWithRetry should get all connected devices', async () => {
+  it('getDevicesWithRetry should get all connected devices', async () => {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"List of devices attached \n emulator-5554	device"});
@@ -73,8 +67,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getDevicesWithRetry should get all connected devices second time', async () => {
+  it('getDevicesWithRetry should get all connected devices second time', async () => {
     mocks.teen_process.expects("exec")
       .onCall(0)
       .returns({stdout:"Foobar"});
@@ -85,8 +78,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getDevicesWithRetry should fail when exec throws an error', async () => {
+  it('getDevicesWithRetry should fail when exec throws an error', async () => {
     mocks.teen_process.expects("exec")
       .atLeast(2)
       .throws("Error foobar");
@@ -110,16 +102,14 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     adb.emulatorPort.should.equal(5554);
   });
   describe('createSubProcess', () => {
-    // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-    it.skip('should return an instance of SubProcess', () => {
+    it('should return an instance of SubProcess', () => {
       adb.createSubProcess([]).should.be.an.instanceof(teen_process.SubProcess);
     });
   });
 }));
 
 describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('should return adb version', async () => {
+  it('should return adb version', async () => {
     mocks.adb.expects("adbExec")
       .once()
       .withExactArgs('version')
@@ -132,8 +122,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     adbVersion.patch.should.equal(39);
     mocks.adb.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('should cache adb results', async () => {
+  it('should cache adb results', async () => {
     adb.getAdbVersion.cache = new _.memoize.Cache();
     mocks.adb.expects("adbExec")
       .once()
@@ -143,16 +132,14 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     await adb.getAdbVersion();
     mocks.adb.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('fileExists should return true for if ls returns', async () => {
+  it('fileExists should return true for if ls returns', async () => {
     mocks.adb.expects("ls")
       .once().withExactArgs('foo')
       .returns(['bar']);
     await adb.fileExists("foo").should.eventually.equal(true);
     mocks.adb.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('ls should return list', async () => {
+  it('ls should return list', async () => {
     mocks.adb.expects("shell")
       .once().withExactArgs(['ls', 'foo'])
       .returns('bar');
@@ -160,8 +147,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     list.should.deep.equal(['bar']);
     mocks.adb.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('fileSize should return the file size when digit is after permissions', async function () {
+  it('fileSize should return the file size when digit is after permissions', async function () {
     let remotePath = '/sdcard/test.mp4';
     mocks.adb.expects('shell')
       .once().withExactArgs(['ls', '-la', remotePath])
@@ -169,8 +155,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     let size = await adb.fileSize(remotePath);
     size.should.eql(39571);
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('fileSize should return the file size when digit is not after permissions', async function () {
+  it('fileSize should return the file size when digit is not after permissions', async function () {
     let remotePath = '/sdcard/test.mp4';
     mocks.adb.expects('shell')
       .once().withExactArgs(['ls', '-la', remotePath])
@@ -178,8 +163,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     let size = await adb.fileSize(remotePath);
     size.should.eql(39571);
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('reboot should call stop and start using shell', async () => {
+  it('reboot should call stop and start using shell', async () => {
     mocks.adb.expects("shell")
       .once().withExactArgs(['stop']);
     mocks.adb.expects("setDeviceProperty")
@@ -195,8 +179,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     mocks.adb.verify();
     mocks.B.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('reboot should restart adbd as root if necessary', async () => {
+  it('reboot should restart adbd as root if necessary', async () => {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['root'])
       .returns(false);
@@ -218,8 +201,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     mocks.adb.verify();
     mocks.B.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getRunningAVD should get connected avd', async () => {
+  it('getRunningAVD should get connected avd', async () => {
     let udid = 'emulator-5554';
     let port = 5554;
     let emulator = {udid, port};
@@ -236,8 +218,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     (await adb.getRunningAVD(avdName)).should.equal(emulator);
     mocks.adb.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getRunningAVD should return null when expected avd is not connected', async () => {
+  it('getRunningAVD should return null when expected avd is not connected', async () => {
     let udid = 'emulator-5554';
     let port = 5554;
     let emulator = {udid, port};
@@ -252,8 +233,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     chai.expect(await adb.getRunningAVD(avdName)).to.be.null;
     mocks.adb.verify();
   });
-  // Because of  ExpectationError: Unexpected call: resolve(...) on Travis
-  it.skip('getRunningAVD should return null when no avd is connected', async () => {
+  it('getRunningAVD should return null when no avd is connected', async () => {
     mocks.adb.expects("getConnectedEmulators")
       .once().withExactArgs()
       .returns([]);


### PR DESCRIPTION
Undo the skipping of the tests done in https://github.com/appium/appium-adb/pull/272 which never should have been merged.

In general, massive quarantining of tests is the **wrong way to go about things**. This means that all subsequent commits were not tested. In this case it was _one_ unit test that was the cause of all the rest failing, and relatively little work was needed to figure that out and get to a solution.