### PR TITLE
Add ensure current locale

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -490,10 +490,41 @@ apkUtilsMethods.setDeviceLocale = async function (locale) {
 };
 
 /**
+ * Make sure current device locale is expected or not.
+ *
+ * @param {string} language - Language. The language field is case insensitive, but Locale always canonicalizes to lower case.
+ * @param {string} country - Country. The language field is case insensitive, but Locale always canonicalizes to lower case.
+ *
+ * @return {bool} If current locale is language and country as arguments, return true.
+ */
+apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
+  if (!_.isString(language) && !_.isString(country)) {
+    log.warn('validateLocale requires language or country');
+    return;
+  }
+
+  if (await this.getApiLevel() < 23) {
+    const curLanguage = await this.getDeviceLanguage();
+    const curCountry = await this.getDeviceCountry();
+    if (language.toLowerCase() === curLanguage.toLowerCase() && country.toLowerCase() === curCountry.toLowerCase()) {
+      return true;
+    }
+  } else {
+    const curLocale = await this.getDeviceLocale();
+    if (`${language}-${country}`.toLowerCase() === curLocale.toLowerCase())  {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
  * Set the locale name of the device under test.
  *
- * @param {string} language - Language. format: [a-zA-Z]{2,8}. e.g. en, ja : https://developer.android.com/reference/java/util/Locale.html
- * @param {string} country - Country. format: [a-zA-Z]{2} | [0-9]{3}. e.g. US, JP : https://developer.android.com/reference/java/util/Locale.html
+ * @param {string} language - Language. The language field is case insensitive, but Locale always canonicalizes to lower case.
+ *                            format: [a-zA-Z]{2,8}. e.g. en, ja : https://developer.android.com/reference/java/util/Locale.html
+ * @param {string} country - Country. The country (region) field is case insensitive, but Locale always canonicalizes to upper case.
+ *                            format: [a-zA-Z]{2} | [0-9]{3}. e.g. US, JP : https://developer.android.com/reference/java/util/Locale.html
  */
 apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
   let hasLanguage = language && _.isString(language);
@@ -509,12 +540,12 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
   if (apiLevel < 23) {
     let curLanguage = await this.getDeviceLanguage();
     let curCountry = await this.getDeviceCountry();
-    if (hasLanguage && language !== curLanguage) {
-      await this.setDeviceLanguage(language);
+    if (hasLanguage && language.toLowerCase() !== curLanguage.toLowerCase()) {
+      await this.setDeviceLanguage(language.toLowerCase());
       wasSettingChanged = true;
     }
-    if (hasCountry && country !== curCountry) {
-      await this.setDeviceCountry(country);
+    if (hasCountry && country.toUpperCase() !== curCountry.toUpperCase()) {
+      await this.setDeviceCountry(country.toUpperCase());
       wasSettingChanged = true;
     }
   } else {
@@ -527,11 +558,11 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
       } else if (!hasLanguage) {
         locale = country;
       } else {
-        locale = `${language}-${country}`;
+        locale = `${language.toLowerCase()}-${country.toUpperCase()}`;
       }
 
       log.debug(`Current locale: '${curLocale}'; requested locale: '${locale}'`);
-      if (locale !== curLocale) {
+      if (locale.toLowerCase() !== curLocale.toLowerCase()) {
         await this.setDeviceSysLocale(locale);
         wasSettingChanged = true;
       }
@@ -543,8 +574,8 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
       }
 
       log.debug(`Current locale: '${curLocale}'; requested locale: '${language}-${country}'`);
-      if (`${language}-${country}` !== curLocale) {
-        await this.setDeviceSysLocaleViaSettingApp(language, country);
+      if (`${language}-${country}`.toLowerCase() !== curLocale.toLowerCase()) {
+        await this.setDeviceSysLocaleViaSettingApp(language.toLowerCase(), country.toUpperCase());
       }
     }
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -495,12 +495,12 @@ apkUtilsMethods.setDeviceLocale = async function (locale) {
  * @param {string} language - Language. The language field is case insensitive, but Locale always canonicalizes to lower case.
  * @param {string} country - Country. The language field is case insensitive, but Locale always canonicalizes to lower case.
  *
- * @return {bool} If current locale is language and country as arguments, return true.
+ * @return {boolean} If current locale is language and country as arguments, return true.
  */
 apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
   if (!_.isString(language) && !_.isString(country)) {
     log.warn('validateLocale requires language or country');
-    return;
+    return false;
   }
 
   if (await this.getApiLevel() < 23) {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -499,19 +499,19 @@ apkUtilsMethods.setDeviceLocale = async function (locale) {
  */
 apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
   if (!_.isString(language) && !_.isString(country)) {
-    log.warn('validateLocale requires language or country');
+    log.warn('ensureCurrentLocale requires language or country');
     return false;
   }
 
   if (await this.getApiLevel() < 23) {
-    const curLanguage = await this.getDeviceLanguage();
-    const curCountry = await this.getDeviceCountry();
-    if (language.toLowerCase() === curLanguage.toLowerCase() && country.toLowerCase() === curCountry.toLowerCase()) {
+    const curLanguage = (await this.getDeviceLanguage()).toLowerCase();
+    const curCountry = (await this.getDeviceCountry()).toLowerCase();
+    if (language.toLowerCase() === curLanguage && country.toLowerCase() === curCountry) {
       return true;
     }
   } else {
-    const curLocale = await this.getDeviceLocale();
-    if (`${language}-${country}`.toLowerCase() === curLocale.toLowerCase())  {
+    const curLocale = (await this.getDeviceLocale()).toLowerCase();
+    if (`${language}-${country}`.toLowerCase() === curLocale)  {
       return true;
     }
   }
@@ -538,13 +538,13 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
   let apiLevel = await this.getApiLevel();
 
   if (apiLevel < 23) {
-    let curLanguage = await this.getDeviceLanguage();
-    let curCountry = await this.getDeviceCountry();
-    if (hasLanguage && language.toLowerCase() !== curLanguage.toLowerCase()) {
+    let curLanguage = (await this.getDeviceLanguage()).toLowerCase();
+    let curCountry = (await this.getDeviceCountry()).toUpperCase();
+    if (hasLanguage && language.toLowerCase() !== curLanguage) {
       await this.setDeviceLanguage(language.toLowerCase());
       wasSettingChanged = true;
     }
-    if (hasCountry && country.toUpperCase() !== curCountry.toUpperCase()) {
+    if (hasCountry && country.toUpperCase() !== curCountry) {
       await this.setDeviceCountry(country.toUpperCase());
       wasSettingChanged = true;
     }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -503,15 +503,18 @@ apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
     return false;
   }
 
+  const lowLanguage = language.toLowerCase();
+  const lowCountry = country.toLowerCase();
+
   if (await this.getApiLevel() < 23) {
     const curLanguage = (await this.getDeviceLanguage()).toLowerCase();
     const curCountry = (await this.getDeviceCountry()).toLowerCase();
-    if (language.toLowerCase() === curLanguage && country.toLowerCase() === curCountry) {
+    if (lowLanguage === curLanguage && lowCountry === curCountry) {
       return true;
     }
   } else {
     const curLocale = (await this.getDeviceLocale()).toLowerCase();
-    if (`${language}-${country}`.toLowerCase() === curLocale)  {
+    if (`${lowLanguage}-${lowCountry}` === curLocale)  {
       return true;
     }
   }
@@ -540,13 +543,19 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
   if (apiLevel < 23) {
     let curLanguage = (await this.getDeviceLanguage()).toLowerCase();
     let curCountry = (await this.getDeviceCountry()).toUpperCase();
-    if (hasLanguage && language.toLowerCase() !== curLanguage) {
-      await this.setDeviceLanguage(language.toLowerCase());
-      wasSettingChanged = true;
+    if (hasLanguage) {
+      const lang = language.toLowerCase();
+      if (lang !== curLanguage) {
+        await this.setDeviceLanguage(lang);
+        wasSettingChanged = true;
+      }
     }
-    if (hasCountry && country.toUpperCase() !== curCountry) {
-      await this.setDeviceCountry(country.toUpperCase());
-      wasSettingChanged = true;
+    if (hasCountry) {
+      const coun = country.toUpperCase();
+      if (coun !== curCountry) {
+        await this.setDeviceCountry(coun);
+        wasSettingChanged = true;
+      }
     }
   } else {
     let curLocale = await this.getDeviceLocale();

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -540,20 +540,21 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
   let wasSettingChanged = false;
   let apiLevel = await this.getApiLevel();
 
+  language = (language || '').toLowerCase();
+  country = (country || '').toUpperCase();
+
   if (apiLevel < 23) {
     let curLanguage = (await this.getDeviceLanguage()).toLowerCase();
     let curCountry = (await this.getDeviceCountry()).toUpperCase();
     if (hasLanguage) {
-      const lang = language.toLowerCase();
-      if (lang !== curLanguage) {
-        await this.setDeviceLanguage(lang);
+      if (language !== curLanguage) {
+        await this.setDeviceLanguage(language);
         wasSettingChanged = true;
       }
     }
     if (hasCountry) {
-      const coun = country.toUpperCase();
-      if (coun !== curCountry) {
-        await this.setDeviceCountry(coun);
+      if (country !== curCountry) {
+        await this.setDeviceCountry(country);
         wasSettingChanged = true;
       }
     }
@@ -567,7 +568,7 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
       } else if (!hasLanguage) {
         locale = country;
       } else {
-        locale = `${language.toLowerCase()}-${country.toUpperCase()}`;
+        locale = `${language}-${country}`;
       }
 
       log.debug(`Current locale: '${curLocale}'; requested locale: '${locale}'`);
@@ -584,7 +585,7 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
 
       log.debug(`Current locale: '${curLocale}'; requested locale: '${language}-${country}'`);
       if (`${language}-${country}`.toLowerCase() !== curLocale.toLowerCase()) {
-        await this.setDeviceSysLocaleViaSettingApp(language.toLowerCase(), country.toUpperCase());
+        await this.setDeviceSysLocaleViaSettingApp(language, country);
       }
     }
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -546,17 +546,13 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country) {
   if (apiLevel < 23) {
     let curLanguage = (await this.getDeviceLanguage()).toLowerCase();
     let curCountry = (await this.getDeviceCountry()).toUpperCase();
-    if (hasLanguage) {
-      if (language !== curLanguage) {
-        await this.setDeviceLanguage(language);
-        wasSettingChanged = true;
-      }
+    if (hasLanguage && language !== curLanguage) {
+      await this.setDeviceLanguage(language);
+      wasSettingChanged = true;
     }
-    if (hasCountry) {
-      if (country !== curCountry) {
-        await this.setDeviceCountry(country);
-        wasSettingChanged = true;
-      }
+    if (hasCountry && country !== curCountry) {
+      await this.setDeviceCountry(country);
+      wasSettingChanged = true;
     }
   } else {
     let curLocale = await this.getDeviceLocale();

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -482,6 +482,34 @@ describe('Apk-utils', () => {
       mocks.adb.verify();
     });
   }));
+  describe('ensureCurrentLocale', withMocks({adb}, (mocks) => {
+    it('should return true when API 22', async() => {
+      mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
+      mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");
+      mocks.adb.expects("getDeviceCountry").withExactArgs().once().returns("FR");
+      (await adb.ensureCurrentLocale('FR', 'fr')).should.be.true;
+      mocks.adb.verify();
+    });
+    it('should return false when API 22', async() => {
+      mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
+      mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");
+      mocks.adb.expects("getDeviceCountry").withExactArgs().once().returns("FR");
+      (await adb.ensureCurrentLocale('en', 'US')).should.be.false;
+      mocks.adb.verify();
+    });
+    it('should return true when API 23', async() => {
+      mocks.adb.expects("getApiLevel").withExactArgs().once().returns(23);
+      mocks.adb.expects("getDeviceLocale").withExactArgs().once().returns("fr-FR");
+      (await adb.ensureCurrentLocale('fr', 'fr')).should.be.true;
+      mocks.adb.verify();
+    });
+    it('should return false when API 23', async() => {
+      mocks.adb.expects("getApiLevel").withExactArgs().once().returns(23);
+      mocks.adb.expects("getDeviceLocale").withExactArgs().once().returns("fr-FR");
+      (await adb.ensureCurrentLocale('en', 'us')).should.be.false;
+      mocks.adb.verify();
+    });
+  }));
   describe('setDeviceLocale', withMocks({adb}, (mocks) => {
     it('should not call setDeviceLanguageCountry because of empty', async() => {
       mocks.adb.expects('setDeviceLanguageCountry').never();
@@ -549,7 +577,7 @@ describe('Apk-utils', () => {
       mocks.adb.expects('setDeviceCountry').never();
       mocks.adb.expects('setDeviceLocale').never();
       mocks.adb.expects('reboot').never();
-      await adb.setDeviceLanguageCountry(language, country);
+      await adb.setDeviceLanguageCountry(language.toLowerCase(), country.toLowerCase());
       mocks.adb.verify();
     });
     it('should set locale when API is 23', async () => {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -495,7 +495,7 @@ describe('Apk-utils', () => {
     });
     it('should return false when API 22', async() => {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
-      mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");
+      mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("");
       mocks.adb.expects("getDeviceCountry").withExactArgs().once().returns("FR");
       (await adb.ensureCurrentLocale('en', 'US')).should.be.false;
       mocks.adb.verify();
@@ -508,7 +508,7 @@ describe('Apk-utils', () => {
     });
     it('should return false when API 23', async() => {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(23);
-      mocks.adb.expects("getDeviceLocale").withExactArgs().once().returns("fr-FR");
+      mocks.adb.expects("getDeviceLocale").withExactArgs().once().returns("");
       (await adb.ensureCurrentLocale('en', 'us')).should.be.false;
       mocks.adb.verify();
     });
@@ -560,7 +560,7 @@ describe('Apk-utils', () => {
       mocks.adb.expects("getDeviceLanguage").withExactArgs()
           .once().returns("fr");
       mocks.adb.expects("getDeviceCountry").withExactArgs()
-          .once().returns("FR");
+          .once().returns("");
       mocks.adb.expects("setDeviceLanguage").withExactArgs(language)
           .once().returns("");
       mocks.adb.expects("setDeviceCountry").withExactArgs(country)

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -483,6 +483,9 @@ describe('Apk-utils', () => {
     });
   }));
   describe('ensureCurrentLocale', withMocks({adb}, (mocks) => {
+    it('should return false if no arguments', async() => {
+      (await adb.ensureCurrentLocale()).should.be.false;
+    });
     it('should return true when API 22', async() => {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
       mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");


### PR DESCRIPTION
ref: https://github.com/appium/appium-android-driver/commit/7094439c7ba19a533f7e3fcd446d35f2e4fb9009#diff-97eeab6ebf462ba97a11ee0221ddaf13R102

I've implemented check current locale method in `appium-adb`.
After merging this method, I'll call `ensureCurrentLocale` from `appium-android-driver`'s `ensureDeviceLocale` method.