### PR TITLE
Optimize logcat output collection

### DIFF
--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -4,14 +4,17 @@ import B from 'bluebird';
 
 
 const log = logger.getLogger('Logcat');
+const MAX_BUFFER_SIZE = 10000;
+
 
 class Logcat {
   constructor (opts = {}) {
     this.adb = opts.adb;
     this.debug = opts.debug;
     this.debugTrace = opts.debugTrace;
+    this.maxBufferSize = opts.maxBufferSize || MAX_BUFFER_SIZE;
     this.logs = [];
-    this.logsSinceLastRequest = [];
+    this.logIdxSinceLastRequest = 0;
   }
 
   startCapture () {
@@ -58,18 +61,25 @@ class Logcat {
 
   outputHandler (output, prefix = '') {
     output = output.trim();
-    if (output) {
-      let outputObj = {
-        timestamp: Date.now(),
-        level: 'ALL',
-        message: output
-      };
-      this.logs.push(outputObj);
-      this.logsSinceLastRequest.push(outputObj);
-      let isTrace = /W\/Trace/.test(output);
-      if (this.debug && (!isTrace || this.debugTrace)) {
-        log.debug(prefix + output);
+    if (!output) {
+      return;
+    }
+
+    if (this.logs.length >= this.maxBufferSize) {
+      this.logs.shift();
+      if (this.logIdxSinceLastRequest > 0) {
+        --this.logIdxSinceLastRequest;
       }
+    }
+    const outputObj = {
+      timestamp: Date.now(),
+      level: 'ALL',
+      message: output,
+    };
+    this.logs.push(outputObj);
+    const isTrace = /W\/Trace/.test(output);
+    if (this.debug && (!isTrace || this.debugTrace)) {
+      log.debug(prefix + output);
     }
   }
 
@@ -85,9 +95,12 @@ class Logcat {
   }
 
   getLogs () {
-    let logs = this.logsSinceLastRequest;
-    this.logsSinceLastRequest = [];
-    return logs;
+    if (this.logIdxSinceLastRequest < this.logs.length) {
+      const result = this.logs.slice(this.logIdxSinceLastRequest);
+      this.logIdxSinceLastRequest = this.logs.length;
+      return result;
+    }
+    return [];
   }
 
   getAllLogs () {


### PR DESCRIPTION
Currently logcat output is pushed into two arrays, which causes extra memory consumption. The fix only pushes the data into single buffer and remembers its recent index. Also, the maximum size of the buffer is limited to 10k.

See https://github.com/appium/appium/issues/9727 for more details.