### PR TITLE
fix error case for api level 22-

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -510,22 +510,21 @@ apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
   const lowCountry = (country || '').toLowerCase();
 
   if (await this.getApiLevel() < 23) {
-    if (hasCountry && hasLanguage) {
-      const curLanguage = (await this.getDeviceLanguage()).toLowerCase();
-      const curCountry = (await this.getDeviceCountry()).toLowerCase();
-      if (lowLanguage === curLanguage && lowCountry === curCountry) {
+    let curLanguage, curCountry;
+    if (hasLanguage) {
+      curLanguage = (await this.getDeviceLanguage()).toLowerCase();
+      if (!hasCountry && lowLanguage === curLanguage) {
         return true;
       }
-    } else if (hasLanguage) {
-      const curLanguage = (await this.getDeviceLanguage()).toLowerCase();
-      if (lowLanguage === curLanguage) {
+    }
+    if (hasCountry) {
+      curCountry = (await this.getDeviceCountry()).toLowerCase();
+      if (!hasLanguage && lowCountry === curCountry) {
         return true;
       }
-    } else if (hasCountry) {
-      const curCountry = (await this.getDeviceCountry()).toLowerCase();
-      if (lowCountry === curCountry) {
-        return true;
-      }
+    }
+    if (lowLanguage === curLanguage && lowCountry === curCountry) {
+      return true;
     }
   } else {
     const curLocale = (await this.getDeviceLocale()).toLowerCase();

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -498,19 +498,34 @@ apkUtilsMethods.setDeviceLocale = async function (locale) {
  * @return {boolean} If current locale is language and country as arguments, return true.
  */
 apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
-  if (!_.isString(language) && !_.isString(country)) {
+  let hasLanguage = language && _.isString(language);
+  let hasCountry = country && _.isString(country);
+
+  if (!hasLanguage && !hasCountry) {
     log.warn('ensureCurrentLocale requires language or country');
     return false;
   }
 
-  const lowLanguage = language.toLowerCase();
-  const lowCountry = country.toLowerCase();
+  const lowLanguage = (language || '').toLowerCase();
+  const lowCountry = (country || '').toLowerCase();
 
   if (await this.getApiLevel() < 23) {
-    const curLanguage = (await this.getDeviceLanguage()).toLowerCase();
-    const curCountry = (await this.getDeviceCountry()).toLowerCase();
-    if (lowLanguage === curLanguage && lowCountry === curCountry) {
-      return true;
+    if (hasCountry && hasLanguage) {
+      const curLanguage = (await this.getDeviceLanguage()).toLowerCase();
+      const curCountry = (await this.getDeviceCountry()).toLowerCase();
+      if (lowLanguage === curLanguage && lowCountry === curCountry) {
+        return true;
+      }
+    } else if (hasLanguage) {
+      const curLanguage = (await this.getDeviceLanguage()).toLowerCase();
+      if (lowLanguage === curLanguage) {
+        return true;
+      }
+    } else if (hasCountry) {
+      const curCountry = (await this.getDeviceCountry()).toLowerCase();
+      if (lowCountry === curCountry) {
+        return true;
+      }
     }
   } else {
     const curLocale = (await this.getDeviceLocale()).toLowerCase();

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -498,8 +498,8 @@ apkUtilsMethods.setDeviceLocale = async function (locale) {
  * @return {boolean} If current locale is language and country as arguments, return true.
  */
 apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
-  let hasLanguage = language && _.isString(language);
-  let hasCountry = country && _.isString(country);
+  let hasLanguage = _.isString(language);
+  let hasCountry = _.isString(country);
 
   if (!hasLanguage && !hasCountry) {
     log.warn('ensureCurrentLocale requires language or country');

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -486,6 +486,20 @@ describe('Apk-utils', () => {
     it('should return false if no arguments', async() => {
       (await adb.ensureCurrentLocale()).should.be.false;
     });
+    it('should return true when API 22 and only language', async() => {
+      mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
+      mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");
+      mocks.adb.expects("getDeviceCountry").withExactArgs().never();
+      (await adb.ensureCurrentLocale("fr", null)).should.be.true;
+      mocks.adb.verify();
+    });
+    it('should return true when API 22 and only country', async() => {
+      mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
+      mocks.adb.expects("getDeviceCountry").withExactArgs().once().returns("FR");
+      mocks.adb.expects("getDeviceLanguage").withExactArgs().never();
+      (await adb.ensureCurrentLocale(null, "FR")).should.be.true;
+      mocks.adb.verify();
+    });
     it('should return true when API 22', async() => {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
       mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");


### PR DESCRIPTION
When I fixing https://github.com/appium/appium-uiautomator2-driver/pull/115/files, I found the following use case for API 22-.

```
await androidHelpers.ensureDeviceLocale(adb, null, initialLocale);
```

In this PR, I put control flows for the issue as same as `setDeviceLanguageCountry`.

After merging this PR, I'll publish new updating patch version.