### PR TITLE
Improve logging for packageAndLaunchActivityFromManifest

### DIFF
--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -101,7 +101,11 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function (localApk)
     log.debug(`badging act: ${apkActivity}`);
     return {apkPackage, apkActivity};
   } catch (e) {
-    log.errorAndThrow(`packageAndLaunchActivityFromManifest failed. Original error: ${e.message}`);
+    let stdErrInfo = "";
+    if (e.stderr) {
+      stdErrInfo = `\nStd err: ${e.stderr}`
+    }
+    log.errorAndThrow(`packageAndLaunchActivityFromManifest failed. Original error: ${e.message}` + stdErrInfo);
   }
 };
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -101,11 +101,8 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function (localApk)
     log.debug(`badging act: ${apkActivity}`);
     return {apkPackage, apkActivity};
   } catch (e) {
-    let stdErrInfo = "";
-    if (e.stderr) {
-      stdErrInfo = `\nStd err: ${e.stderr}`;
-    }
-    log.errorAndThrow(`packageAndLaunchActivityFromManifest failed. Original error: ${e.message}` + stdErrInfo);
+    log.errorAndThrow(`packageAndLaunchActivityFromManifest failed. Original error: ${e.message}` +
+                      (e.stderr ? `; StdErr: ${e.stderr}` : ''));
   }
 };
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -103,7 +103,7 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function (localApk)
   } catch (e) {
     let stdErrInfo = "";
     if (e.stderr) {
-      stdErrInfo = `\nStd err: ${e.stderr}`
+      stdErrInfo = `\nStd err: ${e.stderr}`;
     }
     log.errorAndThrow(`packageAndLaunchActivityFromManifest failed. Original error: ${e.message}` + stdErrInfo);
   }


### PR DESCRIPTION
When apk file is corrupted, `await exec(this.binaries.aapt, args);` line throws exception and appium-adb just says like `Error: packageAndLaunchActivityFromManifest failed. Original error: Command '***/aapt dump badging ***.apk' exited with code 1` without any problem details.

Of course the users can easily know more detailed message just running `***/aapt dump badging ***.apk` by themselves, but most users report this problem without doing so. (Actually my client sent me this error message without  aapt error detail)
So I want to include the std error detail to the error message to reduce the trouble shooting communication cost.