### PR TITLE
Sort build-tools subfolders by modification time rather than by name

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,23 +12,6 @@ const androidPlatforms = ['android-4.2', 'android-17', 'android-4.3', 'android-1
                           'android-23', 'android-6.0', 'android-N', 'android-24',
                           'android-25'];
 
-async function getDirectories (rootPath) {
-  let files = await fs.readdir(rootPath);
-  let dirs = [];
-  for (let file of files) {
-    let pathString = path.resolve(rootPath, file);
-    if ((await fs.lstat(pathString)).isDirectory()) {
-      dirs.push(file);
-    }
-  }
-  // It is not a clean way to sort it, but in this case would work fine because
-  // we have numerics and alphanumeric
-  // will return some thing like this
-  // ["17.0.0", "18.0.1", "19.0.0", "19.0.1", "19.1.0", "20.0.0",
-  //  "android-4.2.2", "android-4.3", "android-4.4"]
-  return dirs.sort();
-}
-
 async function getAndroidPlatformAndPath () {
   const androidHome = process.env.ANDROID_HOME;
   if (!_.isString(androidHome)) {
@@ -242,7 +225,7 @@ const getSdkToolsVersion = _.memoize(async function getSdkToolsVersion () {
   log.warn(`Cannot parse "Pkg.Revision" value from ${propertiesPath}`);
 });
 
-export { getDirectories, getAndroidPlatformAndPath, unzipFile, assertZipArchive,
+export { getAndroidPlatformAndPath, unzipFile, assertZipArchive,
          getIMEListFromOutput, getJavaForOs, isShowingLockscreen, isCurrentFocusOnKeyguard,
          getSurfaceOrientation, isScreenOnFully, buildStartCmd, getJavaHome,
          rootDir, androidPlatforms, getSdkToolsVersion, getApksignerForOs };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -2,7 +2,7 @@ import path from 'path';
 import log from '../logger.js';
 import B from 'bluebird';
 import { system, fs } from 'appium-support';
-import { getDirectories, getSdkToolsVersion } from '../helpers';
+import { getSdkToolsVersion } from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval } from 'asyncbox';
 import _ from 'lodash';
@@ -83,20 +83,17 @@ systemCallMethods.getBinaryFromSdkRoot = _.memoize(async function (binaryName) {
                     path.resolve(this.sdkRoot, "tools", binaryName),
                     path.resolve(this.sdkRoot, "tools", "bin", binaryName)];
   // get subpaths for currently installed build tool directories
-  let buildToolDirs = await getDirectories(path.resolve(this.sdkRoot, "build-tools"));
-  const buildDirsByMTime = {};
-  for (const buildToolDir of buildToolDirs) {
-    const fullPath = path.resolve(this.sdkRoot, "build-tools", buildToolDir);
-    const {mtimeMs} = await fs.stat(fullPath);
-    buildDirsByMTime[mtimeMs] = buildToolDir;
-  }
-  // the newest version goes first
-  const sortedMtimes = _.keys(buildDirsByMTime).sort().reverse();
-  buildToolDirs = sortedMtimes.map(x => buildDirsByMTime[x]);
-  log.info(`Found the following build-tools folders (the newest comes first): ` +
-           `${buildToolDirs.map(x => path.resolve(this.sdkRoot, 'build-tools', x))}`);
-  for (let versionDir of buildToolDirs) {
-    binaryLocs.push(path.resolve(this.sdkRoot, "build-tools", versionDir, binaryName));
+
+  let buildToolDirs = await fs.glob(path.resolve(this.sdkRoot, 'build-tools', '*') + path.sep, {absolute: true});
+  if (buildToolDirs.length) {
+    const pairs = await B.map(async (dir) => [(await fs.stat(dir)).mtimeMs, dir]);
+    buildToolDirs = pairs
+      .sort((a, b) => a[0] > b[0])
+      .map((pair) => pair[1]);
+    log.info(`Found the following 'build-tools' folders (the newest comes first): ${buildToolDirs}`);
+    buildToolDirs.map(x => binaryLocs.push(path.resolve(x, binaryName)));
+  } else {
+    log.info(`Found zero 'build-tools' folders`);
   }
   for (let loc of binaryLocs) {
     if (await fs.exists(loc)) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -86,7 +86,7 @@ systemCallMethods.getBinaryFromSdkRoot = _.memoize(async function (binaryName) {
 
   let buildToolDirs = await fs.glob(path.resolve(this.sdkRoot, 'build-tools', '*') + path.sep, {absolute: true});
   if (buildToolDirs.length) {
-    const pairs = await B.map(async (dir) => [(await fs.stat(dir)).mtimeMs, dir]);
+    const pairs = await B.map(buildToolDirs, async (dir) => [(await fs.stat(dir)).mtimeMs, dir]);
     buildToolDirs = pairs
       .sort((a, b) => a[0] > b[0])
       .map((pair) => pair[1]);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -6,7 +6,6 @@ import { getDirectories, getSdkToolsVersion } from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval } from 'asyncbox';
 import _ from 'lodash';
-import semver from 'semver';
 
 
 let systemCallMethods = {};
@@ -85,8 +84,17 @@ systemCallMethods.getBinaryFromSdkRoot = _.memoize(async function (binaryName) {
                     path.resolve(this.sdkRoot, "tools", "bin", binaryName)];
   // get subpaths for currently installed build tool directories
   let buildToolDirs = await getDirectories(path.resolve(this.sdkRoot, "build-tools"));
+  const buildDirsByMTime = {};
+  for (const buildToolDir of buildToolDirs) {
+    const fullPath = path.resolve(this.sdkRoot, "build-tools", buildToolDir);
+    const {mtime} = await fs.stat(fullPath);
+    buildDirsByMTime[mtime] = buildToolDir;
+  }
   // the newest version goes first
-  buildToolDirs.sort(semver.rcompare);
+  const sortedMtimes = _.keys(buildDirsByMTime).sort().reverse();
+  buildToolDirs = sortedMtimes.map(x => buildDirsByMTime[x]);
+  log.info(`Found the following build-tools folders (the newest comes first): ` +
+           `${buildToolDirs.map(x => path.resolve(this.sdkRoot, 'build-tools', x))}`);
   for (let versionDir of buildToolDirs) {
     binaryLocs.push(path.resolve(this.sdkRoot, "build-tools", versionDir, binaryName));
   }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -91,7 +91,7 @@ systemCallMethods.getBinaryFromSdkRoot = _.memoize(async function (binaryName) {
       .sort((a, b) => a[0] > b[0])
       .map((pair) => pair[1]);
     log.info(`Found the following 'build-tools' folders (the newest comes first): ${buildToolDirs}`);
-    buildToolDirs.map(x => binaryLocs.push(path.resolve(x, binaryName)));
+    _.forEach(buildToolDirs, (dir) => binaryLocs.push(path.resolve(dir, binaryName)));
   } else {
     log.info(`Found zero 'build-tools' folders`);
   }
@@ -101,10 +101,9 @@ systemCallMethods.getBinaryFromSdkRoot = _.memoize(async function (binaryName) {
       break;
     }
   }
-  if (binaryLoc === null) {
-    throw new Error(`Could not find ${binaryName} in ${binaryLocs}, ` +
-                    `or supported build-tools under ${this.sdkRoot} ` +
-                    `do you have the Android SDK installed at this location?`);
+  if (_.isNull(binaryLoc)) {
+    throw new Error(`Could not find ${binaryName} in ${binaryLocs}. ` +
+                    `Do you have the Android SDK installed at '${this.sdkRoot}'?`);
   }
   binaryLoc = binaryLoc.trim();
   log.info(`Using ${binaryName} from ${binaryLoc}`);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -87,8 +87,8 @@ systemCallMethods.getBinaryFromSdkRoot = _.memoize(async function (binaryName) {
   const buildDirsByMTime = {};
   for (const buildToolDir of buildToolDirs) {
     const fullPath = path.resolve(this.sdkRoot, "build-tools", buildToolDir);
-    const {mtime} = await fs.stat(fullPath);
-    buildDirsByMTime[mtime] = buildToolDir;
+    const {mtimeMs} = await fs.stat(fullPath);
+    buildDirsByMTime[mtimeMs] = buildToolDir;
   }
   // the newest version goes first
   const sortedMtimes = _.keys(buildDirsByMTime).sort().reverse();

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "bluebird": "^3.4.7",
     "lodash": "^4.0.0",
     "source-map-support": "^0.4.8",
-    "teen_process": "^1.11.0",
-    "semver": "^5.4.1"
+    "teen_process": "^1.11.0"
   },
   "pre-commit": [
     "precommit-msg",

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -1,28 +1,12 @@
-import { getDirectories, getAndroidPlatformAndPath,
+import { getAndroidPlatformAndPath,
          buildStartCmd, isShowingLockscreen } from '../../lib/helpers';
 import { withMocks } from 'appium-test-support';
 import { fs } from 'appium-support';
 import path from 'path';
 import _ from 'lodash';
-import B from 'bluebird';
 
 
 describe('helpers', () => {
-  describe('getDirectories', withMocks({fs}, (mocks) => {
-    it('should sort the directories', async () => {
-      let rootPath = '/path/to/root';
-      let directories = ['c', 'b', 'a', '1', '2'];
-      mocks.fs.expects('readdir')
-        .once().withExactArgs(rootPath)
-        .returns(directories);
-      mocks.fs.expects('lstat')
-        .exactly(5)
-        .returns(B.resolve({isDirectory: () => {return true;}}));
-      (await getDirectories(rootPath)).should.eql(['1', '2', 'a', 'b', 'c']);
-      mocks.fs.verify();
-    });
-  }));
-
   describe('getAndroidPlatformAndPath', withMocks({fs}, (mocks) => {
     let oldAndroidHome;
     let oldResolve;


### PR DESCRIPTION
Addresses issues similar to https://github.com/appium/appium/issues/9926 where build-tools folder name might not match to the common naming pattern. 
  