### PR TITLE
Add retry to ensureCurrentLocale

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -498,41 +498,50 @@ apkUtilsMethods.setDeviceLocale = async function (locale) {
  * @return {boolean} If current locale is language and country as arguments, return true.
  */
 apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
-  let hasLanguage = _.isString(language);
-  let hasCountry = _.isString(country);
+  return await retryInterval(5, 1000, async () => {
+    try {
+      const hasLanguage = _.isString(language);
+      const hasCountry = _.isString(country);
 
-  if (!hasLanguage && !hasCountry) {
-    log.warn('ensureCurrentLocale requires language or country');
-    return false;
-  }
-
-  const lowLanguage = (language || '').toLowerCase();
-  const lowCountry = (country || '').toLowerCase();
-
-  if (await this.getApiLevel() < 23) {
-    let curLanguage, curCountry;
-    if (hasLanguage) {
-      curLanguage = (await this.getDeviceLanguage()).toLowerCase();
-      if (!hasCountry && lowLanguage === curLanguage) {
-        return true;
+      if (!hasLanguage && !hasCountry) {
+        log.warn('ensureCurrentLocale requires language or country');
+        return false;
       }
-    }
-    if (hasCountry) {
-      curCountry = (await this.getDeviceCountry()).toLowerCase();
-      if (!hasLanguage && lowCountry === curCountry) {
-        return true;
+
+      // get lower case versions of the strings
+      language = (language || '').toLowerCase();
+      country = (country || '').toLowerCase();
+
+      if (await this.getApiLevel() < 23) {
+        let curLanguage, curCountry;
+        if (hasLanguage) {
+          curLanguage = (await this.getDeviceLanguage()).toLowerCase();
+          if (!hasCountry && language === curLanguage) {
+            return true;
+          }
+        }
+        if (hasCountry) {
+          curCountry = (await this.getDeviceCountry()).toLowerCase();
+          if (!hasLanguage && country === curCountry) {
+            return true;
+          }
+        }
+        if (language === curLanguage && country === curCountry) {
+          return true;
+        }
+      } else {
+        const curLocale = (await this.getDeviceLocale()).toLowerCase();
+        if (`${language}-${country}` === curLocale)  {
+          return true;
+        }
       }
+      return false;
+    } catch (err) {
+      // if there has been an error, restart adb and retry
+      await this.restartAdb();
+      throw err;
     }
-    if (lowLanguage === curLanguage && lowCountry === curCountry) {
-      return true;
-    }
-  } else {
-    const curLocale = (await this.getDeviceLocale()).toLowerCase();
-    if (`${lowLanguage}-${lowCountry}` === curLocale)  {
-      return true;
-    }
-  }
-  return false;
+  });
 };
 
 /**

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -498,21 +498,23 @@ apkUtilsMethods.setDeviceLocale = async function (locale) {
  * @return {boolean} If current locale is language and country as arguments, return true.
  */
 apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
+  const hasLanguage = _.isString(language);
+  const hasCountry = _.isString(country);
+
+  if (!hasLanguage && !hasCountry) {
+    log.warn('ensureCurrentLocale requires language or country');
+    return false;
+  }
+
+  // get lower case versions of the strings
+  language = (language || '').toLowerCase();
+  country = (country || '').toLowerCase();
+
+  const apiLevel = await this.getApiLevel();
+
   return await retryInterval(5, 1000, async () => {
     try {
-      const hasLanguage = _.isString(language);
-      const hasCountry = _.isString(country);
-
-      if (!hasLanguage && !hasCountry) {
-        log.warn('ensureCurrentLocale requires language or country');
-        return false;
-      }
-
-      // get lower case versions of the strings
-      language = (language || '').toLowerCase();
-      country = (country || '').toLowerCase();
-
-      if (await this.getApiLevel() < 23) {
+      if (apiLevel < 23) {
         let curLanguage, curCountry;
         if (hasLanguage) {
           curLanguage = (await this.getDeviceLanguage()).toLowerCase();

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -540,6 +540,8 @@ apkUtilsMethods.ensureCurrentLocale = async function (language, country) {
       return false;
     } catch (err) {
       // if there has been an error, restart adb and retry
+      log.error(`Unable to check device localization: ${err.message}`);
+      log.debug('Restarting ADB and retrying...');
       await this.restartAdb();
       throw err;
     }


### PR DESCRIPTION
There are often failures in setting the language/locale after the fact, because adb gets disconnected (see https://github.com/appium/appium/issues/9987).

So add a retry if there is a failure, after restarting adb.