### PR TITLE
Get rid of arrow functions in mocha aparatus

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "coverage": "gulp coveralls",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "REPORTER=dot gulp once",
-    "lint": "gulp eslint"
+    "lint": "gulp eslint",
+    "lint:fix": "gulp eslint --fix"
   },
   "repository": {
     "type": "git",
@@ -52,7 +53,7 @@
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
+    "eslint-config-appium": "^2.1.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-mocha": "^4.11.0",

--- a/test/adb-specs.js
+++ b/test/adb-specs.js
@@ -4,7 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
 
-describe.skip('ADB To be implemented methods', () => {
+describe.skip('ADB To be implemented methods', function () {
 
   //it('processFromManifest', async () => { });
   //it('packageAndLaunchActivityFromManifest', async () => { });
@@ -41,18 +41,18 @@ describe.skip('ADB To be implemented methods', () => {
 //  it('setEmulatorPort', async () => { });
 //  it('waitForDevice', async () => { });
 //  it('restartAdb', async () => { });
-  it('restart', async () => { });
-  it('stopLogcatstartLogcat', async () => { });
-  it('getLogcatLogs', async () => { });
-  it('getPIDsByName', async () => { });
-  it('killProcessesByName', async () => { });
-  it('killProcessByPID', async () => { });
+  it('restart', async function () { });
+  it('stopLogcatstartLogcat', async function () { });
+  it('getLogcatLogs', async function () { });
+  it('getPIDsByName', async function () { });
+  it('killProcessesByName', async function () { });
+  it('killProcessByPID', async function () { });
 //  it('startApp', async () => { });
   //it('isValidClass', async () => { });
-  it('broadcastProcessEnd', async () => { });
-  it('broadcast', async () => { });
-  it('endAndroidCoverage', async () => { });
-  it('androidCoverage', async () => { });
+  it('broadcastProcessEnd', async function () { });
+  it('broadcast', async function () { });
+  it('endAndroidCoverage', async function () { });
+  it('androidCoverage', async function () { });
 //  it('getFocusedPackageAndActivity', async () => { });
 //  it('waitForActivityOrNot', async () => { });
 //  it('waitForActivity', async () => { });
@@ -61,7 +61,7 @@ describe.skip('ADB To be implemented methods', () => {
 //  it('installRemote', async () => { });
 //  it('install', async () => { });
 //  it('mkdir', async () => { });
-  it('instrument', async () => { });
+  it('instrument', async function () { });
   // TODO should deprecate not used in appium
 //  it('checkAndSignApk', async () => { });
 //  it('forceStop', async () => { });
@@ -90,6 +90,6 @@ describe.skip('ADB To be implemented methods', () => {
 //  it('disableIME', async () => { });
 //  it('setIME', async () => { });
   //it('hasInternetPermissionFromManifest', async () => { });
-  it('reboot', async () => { });
+  it('reboot', async function () { });
 //  it('getAdbServerPort', async () => { });
 });

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -25,47 +25,47 @@ describe('adb commands', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let adb;
-  before(async () => {
+  before(async function () {
     adb = await ADB.createADB();
   });
-  it('getApiLevel should get correct api level', async () => {
+  it('getApiLevel should get correct api level', async function () {
     (await adb.getApiLevel()).should.equal(apiLevel);
   });
-  it('getPlatformVersion should get correct platform version', async () => {
+  it('getPlatformVersion should get correct platform version', async function () {
     (await adb.getPlatformVersion()).should.include(platformVersion);
   });
-  it('availableIMEs should get list of available IMEs', async () => {
+  it('availableIMEs should get list of available IMEs', async function () {
     (await adb.availableIMEs()).should.have.length.above(0);
   });
-  it('enabledIMEs should get list of enabled IMEs', async () => {
+  it('enabledIMEs should get list of enabled IMEs', async function () {
     (await adb.enabledIMEs()).should.have.length.above(0);
   });
-  it('defaultIME should get default IME', async () => {
+  it('defaultIME should get default IME', async function () {
     defaultIMEs.should.include(await adb.defaultIME());
   });
-  it('enableIME and disableIME should enable and disble IME', async () => {
+  it('enableIME and disableIME should enable and disble IME', async function () {
     await adb.disableIME(IME);
     (await adb.enabledIMEs()).should.not.include(IME);
     await adb.enableIME(IME);
     (await adb.enabledIMEs()).should.include(IME);
     await adb.enabledIMEs();
   });
-  it('processExists should be able to find ui process', async () => {
+  it('processExists should be able to find ui process', async function () {
     (await adb.processExists('com.android.systemui')).should.be.true;
   });
-  it('ping should return true', async () => {
+  it('ping should return true', async function () {
     (await adb.ping()).should.be.true;
   });
-  it('getPIDsByName should return pids', async () => {
+  it('getPIDsByName should return pids', async function () {
     (await adb.getPIDsByName('m.android.phone')).should.have.length.above(0);
   });
-  it('killProcessesByName should kill process', async () => {
+  it('killProcessesByName should kill process', async function () {
     await adb.install(contactManagerPath);
     await adb.startApp({pkg, activity});
     await adb.killProcessesByName(pkg);
     (await adb.getPIDsByName(pkg)).should.have.length(0);
   });
-  it('killProcessByPID should kill process', async () => {
+  it('killProcessByPID should kill process', async function () {
     await adb.install(contactManagerPath);
     await adb.startApp({pkg, activity});
     let pids = await adb.getPIDsByName(pkg);
@@ -98,41 +98,41 @@ describe('adb commands', function () {
 
     ['us', 'en', 'ca_en'].should.contain(await adb.getDeviceLocale());
   });
-  it('should forward the port', async () => {
+  it('should forward the port', async function () {
     await adb.forwardPort(4724, 4724);
   });
-  it('should remove forwarded port', async () => {
+  it('should remove forwarded port', async function () {
     await adb.forwardPort(8200, 6790);
     (await adb.adbExec([`forward`, `--list`])).should.contain('tcp:8200');
     await adb.removePortForward(8200);
     (await adb.adbExec([`forward`, `--list`])).should.not.contain('tcp:8200');
 
   });
-  it('should start logcat from adb', async () => {
+  it('should start logcat from adb', async function () {
     await adb.startLogcat();
     let logs = adb.logcat.getLogs();
     logs.should.have.length.above(0);
     await adb.stopLogcat();
   });
-  it('should get model', async () => {
+  it('should get model', async function () {
     (await adb.getModel()).should.not.be.null;
   });
-  it('should get manufacturer', async () => {
+  it('should get manufacturer', async function () {
     (await adb.getManufacturer()).should.not.be.null;
   });
-  it('should get screen size', async () => {
+  it('should get screen size', async function () {
     (await adb.getScreenSize()).should.not.be.null;
   });
-  it('should get screen density', async() => {
+  it('should get screen density', async function () {
     (await adb.getScreenDensity()).should.not.be.null;
   });
-  it('should be able to toggle gps location provider', async () => {
+  it('should be able to toggle gps location provider', async function () {
     await adb.toggleGPSLocationProvider(true);
     (await adb.getLocationProviders()).should.include('gps');
     await adb.toggleGPSLocationProvider(false);
     (await adb.getLocationProviders()).should.not.include('gps');
   });
-  it('should be able to toogle airplane mode', async () => {
+  it('should be able to toogle airplane mode', async function () {
     await adb.setAirplaneMode(true);
     (await adb.isAirplaneModeOn()).should.be.true;
     await adb.setAirplaneMode(false);
@@ -146,15 +146,15 @@ describe('adb commands', function () {
     await adb.setWifiState(false);
     (await adb.isWifiOn()).should.be.false;
   });
-  it('should be able to turn off animation @skip-ci', async () => {
+  it('should be able to turn off animation @skip-ci', async function () {
     await adb.setAnimationState(false);
     (await adb.isAnimationOn()).should.be.false;
   });
-  it('should be able to turn on animation @skip-ci', async () => {
+  it('should be able to turn on animation @skip-ci', async function () {
     await adb.setAnimationState(true);
     (await adb.isAnimationOn()).should.be.true;
   });
-  it('should be able to set device locale via setting app @skip-ci', async () => {
+  it('should be able to set device locale via setting app @skip-ci', async function () {
     // Operation not allowed: java.lang.SecurityException: Package io.appium.settings has not requested permission android.permission.CHANGE_CONFIGURATION
     // is shown if the setting apk is not updated.
     await adb.grantPermission('io.appium.settings', 'android.permission.CHANGE_CONFIGURATION');
@@ -165,7 +165,7 @@ describe('adb commands', function () {
     await adb.setDeviceSysLocaleViaSettingApp('en', 'us');
     (await adb.getDeviceSysLocale()).should.equal('en-US');
   });
-  describe('app permissions', async () => {
+  describe('app permissions', async function () {
     before(async function () {
       let deviceApiLevel = await adb.getApiLevel();
       if (deviceApiLevel < 23) {
@@ -177,7 +177,7 @@ describe('adb commands', function () {
         await adb.uninstallApk('io.appium.android.apis');
       }
     });
-    it('should install and grant all permission', async () => {
+    it('should install and grant all permission', async function () {
       let apiDemos = path.resolve(rootDir, 'test',
           'fixtures', 'ApiDemos-debug.apk');
       await adb.install(apiDemos);
@@ -186,11 +186,11 @@ describe('adb commands', function () {
       let requestedPermissions = await adb.getReqPermissions('io.appium.android.apis');
       expect(await adb.getGrantedPermissions('io.appium.android.apis')).to.have.members(requestedPermissions);
     });
-    it('should revoke permission', async () => {
+    it('should revoke permission', async function () {
       await adb.revokePermission('io.appium.android.apis', 'android.permission.RECEIVE_SMS');
       expect(await adb.getGrantedPermissions('io.appium.android.apis')).to.not.have.members(['android.permission.RECEIVE_SMS']);
     });
-    it('should grant permission', async () => {
+    it('should grant permission', async function () {
       await adb.grantPermission('io.appium.android.apis', 'android.permission.RECEIVE_SMS');
       expect(await adb.getGrantedPermissions('io.appium.android.apis')).to.include.members(['android.permission.RECEIVE_SMS']);
     });

--- a/test/functional/adb-e2e-specs.js
+++ b/test/functional/adb-e2e-specs.js
@@ -5,12 +5,12 @@ import ADB from '../..';
 const should = chai.should();
 chai.use(chaiAsPromised);
 
-describe('ADB', () => {
-  it('should correctly return adb if present', async () => {
+describe('ADB', function () {
+  it('should correctly return adb if present', async function () {
     let adb = await ADB.createADB();
     should.exist(adb.executable.path);
   });
-  it('should correctly return adb from path when ANDROID_HOME is not set', async () => {
+  it('should correctly return adb from path when ANDROID_HOME is not set', async function () {
     let opts = {sdkRoot: ''};
     let adb = await ADB.createADB(opts);
     should.exist(adb.executable.path);
@@ -18,12 +18,12 @@ describe('ADB', () => {
   it.skip('should error out if binary not persent', async () => {
     // TODO write a negative test
   });
-  it('should initialize aapt', async () => {
+  it('should initialize aapt', async function () {
     let adb = new ADB();
     await adb.initAapt();
     adb.binaries.aapt.should.contain('aapt');
   });
-  it('should initialize zipAlign', async () => {
+  it('should initialize zipAlign', async function () {
     let adb = new ADB();
     await adb.initZipAlign();
     adb.binaries.zipalign.should.contain('zipalign');

--- a/test/functional/adb-emu-commands-e2e-specs.js
+++ b/test/functional/adb-emu-commands-e2e-specs.js
@@ -14,7 +14,7 @@ const pkg = 'com.example.fingerprint';
 const activity = '.MainActivity';
 const secretActivity = '.SecretActivity';
 
-describe('adb emu commands', () => {
+describe('adb emu commands', function () {
   let adb;
   before(async function () {
     adb = await ADB.createADB();
@@ -25,7 +25,7 @@ describe('adb emu commands', () => {
       this.skip();
     }
   });
-  it('fingerprint should open the secret activity on emitted valid finger touch event', async () => {
+  it('fingerprint should open the secret activity on emitted valid finger touch event', async function () {
     if (await adb.isAppInstalled(pkg)) {
       await adb.forceStop(pkg);
       await adb.uninstallApk(pkg);

--- a/test/functional/android-manifest-e2e-specs.js
+++ b/test/functional/android-manifest-e2e-specs.js
@@ -20,21 +20,21 @@ const contactManagerPath = path.resolve(rootDir, 'test',
 
 chai.use(chaiAsPromised);
 
-describe('Android-manifest', async () => {
+describe('Android-manifest', async function () {
   let adb;
-  before(async () => {
+  before(async function () {
     adb = await ADB.createADB();
   });
-  it('packageAndLaunchActivityFromManifest should parse package and Activity', async () => {
+  it('packageAndLaunchActivityFromManifest should parse package and Activity', async function () {
     let {apkPackage, apkActivity} = await adb.packageAndLaunchActivityFromManifest(contactManagerPath);
     apkPackage.should.equal('com.example.android.contactmanager');
     apkActivity.should.equal('com.example.android.contactmanager.ContactManager');
   });
-  it('hasInternetPermissionFromManifest should be true', async () => {
+  it('hasInternetPermissionFromManifest should be true', async function () {
     let flag = await adb.hasInternetPermissionFromManifest(contactMangerSelendroidPath);
     flag.should.be.true;
   });
-  it('hasInternetPermissionFromManifest should be false', async () => {
+  it('hasInternetPermissionFromManifest should be false', async function () {
     let flag = await adb.hasInternetPermissionFromManifest(contactManagerPath);
     flag.should.be.false;
   });
@@ -67,6 +67,6 @@ describe('Android-manifest', async () => {
   });
 });
 
-describe.skip('Android-manifest To be implemented methods', () => {
-  it('should return correct processFromManifest', async () => { });
+describe.skip('Android-manifest To be implemented methods', function () {
+  it('should return correct processFromManifest', async function () { });
 });

--- a/test/functional/apk-signing-e2e-specs.js
+++ b/test/functional/apk-signing-e2e-specs.js
@@ -19,26 +19,26 @@ const selendroidTestApp = path.resolve(rootDir, 'test',
 
 chai.use(chaiAsPromised);
 
-describe('Apk-signing', async () => {
+describe('Apk-signing', async function () {
   let adb,
       unsignApk = async (apk) => { await exec('java', ['-jar', unsignJar, apk]); };
 
-  before(async () => {
+  before(async function () {
     adb = await ADB.createADB();
   });
-  it('checkApkCert should return false for unsigned apk', async () => {
+  it('checkApkCert should return false for unsigned apk', async function () {
     await unsignApk(selendroidTestApp);
     (await adb.checkApkCert(selendroidTestApp, 'io.selendroid.testapp')).should.be.false;
   });
-  it('checkApkCert should return true for signed apk', async () => {
+  it('checkApkCert should return true for signed apk', async function () {
     (await adb.checkApkCert(contactManagerPath, 'com.example.android.contactmanager')).should.be.true;
   });
-  it('signWithDefaultCert should sign apk', async () => {
+  it('signWithDefaultCert should sign apk', async function () {
     await unsignApk(selendroidTestApp);
     (await adb.signWithDefaultCert(selendroidTestApp));
     (await adb.checkApkCert(selendroidTestApp, 'io.selendroid.testapp')).should.be.true;
   });
-  it('signWithCustomCert should sign apk with custom certificate', async () => {
+  it('signWithCustomCert should sign apk with custom certificate', async function () {
     await unsignApk(selendroidTestApp);
     adb.keystorePath = keystorePath;
     adb.keyAlias = keyAlias;

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -22,13 +22,13 @@ describe('apk utils', function () {
     appActivity.should.equal('.ContactManager');
   };
 
-  before(async () => {
+  before(async function () {
     adb = await ADB.createADB();
   });
-  it('should be able to check status of third party app', async () => {
+  it('should be able to check status of third party app', async function () {
     (await adb.isAppInstalled('com.android.phone')).should.be.true;
   });
-  it('should be able to install/remove app and detect its status', async () => {
+  it('should be able to install/remove app and detect its status', async function () {
     (await adb.isAppInstalled('foo')).should.be.false;
     await adb.install(contactManagerPath);
     (await adb.isAppInstalled('com.example.android.contactmanager')).should.be.true;
@@ -39,8 +39,8 @@ describe('apk utils', function () {
     await adb.push(contactManagerPath, deviceTempPath);
     await adb.installFromDevicePath(deviceTempPath + 'ContactManager.apk');
   });
-  describe('startUri', async () => {
-    it('should be able to start a uri', async () => {
+  describe('startUri', async function () {
+    it('should be able to start a uri', async function () {
       await adb.goToHome();
       let res = await adb.getFocusedPackageAndActivity();
       res.appPackage.should.not.equal('com.android.contacts');
@@ -57,21 +57,21 @@ describe('apk utils', function () {
       await adb.goToHome();
     });
   });
-  describe('startApp', async () => {
-    it('should be able to start', async () => {
+  describe('startApp', async function () {
+    it('should be able to start', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'ContactManager'});
       await assertPackageAndActivity();
 
     });
-    it('should throw error for wrong activity', async () => {
+    it('should throw error for wrong activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'ContactManage'}).should.eventually
                                                      .be.rejectedWith('Activity');
     });
-    it('should throw error for wrong wait activity', async () => {
+    it('should throw error for wrong wait activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'ContactManager',
@@ -79,42 +79,42 @@ describe('apk utils', function () {
                           waitDuration: 1000}).should.eventually
                                               .be.rejectedWith('foo');
     });
-    it('should start activity with wait activity', async () => {
+    it('should start activity with wait activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'ContactManager',
                           waitActivity: '.ContactManager'});
       await assertPackageAndActivity();
     });
-    it('should start activity when wait activity is a wildcard', async () => {
+    it('should start activity when wait activity is a wildcard', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'ContactManager',
                           waitActivity: '*'});
       await assertPackageAndActivity();
     });
-    it('should start activity when wait activity contains a wildcard', async () => {
+    it('should start activity when wait activity contains a wildcard', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'ContactManager',
                           waitActivity: '*.ContactManager'});
       await assertPackageAndActivity();
     });
-    it('should throw error for wrong activity when wait activity contains a wildcard', async () => {
+    it('should throw error for wrong activity when wait activity contains a wildcard', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'SuperManager',
                           waitActivity: '*.ContactManager'}).should.eventually
                                                             .be.rejectedWith('Activity');
     });
-    it('should throw error for wrong wait activity which contains wildcard', async () => {
+    it('should throw error for wrong wait activity which contains wildcard', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
                           activity: 'ContactManager',
                           waitActivity: '*.SuperManager'}).should.eventually
                                                           .be.rejectedWith('SuperManager');
     });
-    it('should start activity with comma separated wait packages list', async () => {
+    it('should start activity with comma separated wait packages list', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
         waitPkg: 'com.android.settings, com.example.android.contactmanager',
@@ -122,7 +122,7 @@ describe('apk utils', function () {
         waitActivity: '.ContactManager'});
       await assertPackageAndActivity();
     });
-    it('should throw error for wrong activity when packages provided as comma separated list', async () => {
+    it('should throw error for wrong activity when packages provided as comma separated list', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({pkg: 'com.example.android.contactmanager',
         waitPkg: 'com.android.settings, com.example.somethingelse',
@@ -131,7 +131,7 @@ describe('apk utils', function () {
         .be.rejectedWith('Activity');
     });
   });
-  it('should start activity when start activity is an inner class', async () => {
+  it('should start activity when start activity is an inner class', async function () {
     await adb.install(contactManagerPath);
     await adb.startApp({pkg: 'com.android.settings',
       activity: '.Settings$NotificationAppListActivity'});
@@ -140,13 +140,13 @@ describe('apk utils', function () {
     appPackage.should.equal('com.android.settings');
     appActivity.should.equal('.Settings$NotificationAppListActivity');
   });
-  it('getFocusedPackageAndActivity should be able get package and activity', async () => {
+  it('getFocusedPackageAndActivity should be able get package and activity', async function () {
     await adb.install(contactManagerPath);
     await adb.startApp({pkg: 'com.example.android.contactmanager',
                         activity: 'ContactManager'});
     await assertPackageAndActivity();
   });
-  it('extractStringsFromApk should get strings for default language', async () => {
+  it('extractStringsFromApk should get strings for default language', async function () {
     let {apkStrings} = await adb.extractStringsFromApk(contactManagerPath, null, '/tmp');
     apkStrings.save.should.equal('Save');
   });

--- a/test/functional/helpers-specs-e2e-specs.js
+++ b/test/functional/helpers-specs-e2e-specs.js
@@ -14,8 +14,8 @@ function getFixture (file) {
 const apkPath = path.resolve(rootDir, 'test', 'fixtures', 'ContactManager.apk');
 chai.use(chaiAsPromised);
 
-describe('Helpers', () => {
-  it('getAndroidPlatformAndPath should return empty object when no ANDROID_HOME is set', async () => {
+describe('Helpers', function () {
+  it('getAndroidPlatformAndPath should return empty object when no ANDROID_HOME is set', async function () {
     let android_home = process.env.ANDROID_HOME;
     // temp setting android_home to null.
     delete process.env.ANDROID_HOME;
@@ -26,7 +26,7 @@ describe('Helpers', () => {
     process.env.ANDROID_HOME = android_home;
   });
 
-  it('getAndroidPlatformAndPath should return platform and path for android', async () => {
+  it('getAndroidPlatformAndPath should return platform and path for android', async function () {
     let {platform, platformPath} = await getAndroidPlatformAndPath();
     platform.should.exist;
     platformPath.should.exist;
@@ -36,8 +36,8 @@ describe('Helpers', () => {
     await assertZipArchive(apkPath);
   });
 
-  describe('unzipFile', () => {
-    it('should unzip a .zip file', async () => {
+  describe('unzipFile', function () {
+    it('should unzip a .zip file', async function () {
       const temp = await tempDir.openDir();
       await fs.copyFile(getFixture('TestZip.zip'), path.resolve(temp, 'TestZip.zip'));
       await unzipFile(path.resolve(temp, 'TestZip.zip'));
@@ -45,7 +45,7 @@ describe('Helpers', () => {
       await fs.readFile(path.resolve(temp, 'TestZip', 'b.txt'), 'utf8').should.eventually.equal('Foobar');
     });
 
-    it('should unzip a .zip file (force isWindows to be true so we can test the internal zip library)', async () => {
+    it('should unzip a .zip file (force isWindows to be true so we can test the internal zip library)', async function () {
       const forceWindows = sinon.stub(system, 'isWindows', () => true);
       const temp = await tempDir.openDir();
       await fs.copyFile(getFixture('TestZip.zip'), path.resolve(temp, 'TestZip.zip'));

--- a/test/functional/logcat-e2e-specs.js
+++ b/test/functional/logcat-e2e-specs.js
@@ -25,7 +25,7 @@ describe('logcat', function () {
 
   let adb;
   let logcat;
-  before(async () => {
+  before(async function () {
     adb = await ADB.createADB();
   });
   afterEach(async function () {
@@ -34,7 +34,7 @@ describe('logcat', function () {
     }
   });
   describe('clearDeviceLogsOnStart = false', function () {
-    before(async () => {
+    before(async function () {
       logcat = new Logcat({
         adb: adb.executable,
         debug: false,
@@ -56,7 +56,7 @@ describe('logcat', function () {
     });
   });
   describe('clearDeviceLogsOnStart = true', function () {
-    before(async () => {
+    before(async function () {
       logcat = new Logcat({
         adb: adb.executable,
         debug: false,

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -10,33 +10,33 @@ describe('System calls', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let adb;
-  before(async () => {
+  before(async function () {
     adb = await ADB.createADB();
   });
-  it('getConnectedDevices should get devices', async () => {
+  it('getConnectedDevices should get devices', async function () {
     let devices = await adb.getConnectedDevices();
     devices.should.have.length.above(0);
   });
-  it('getDevicesWithRetry should get devices', async () => {
+  it('getDevicesWithRetry should get devices', async function () {
     let devices = await adb.getDevicesWithRetry();
     devices.should.have.length.above(0);
   });
-  it('adbExec should get devices when with devices', async () => {
+  it('adbExec should get devices when with devices', async function () {
     (await adb.adbExec("devices")).should.contain("List of devices attached");
   });
-  it('isDeviceConnected should be true', async () => {
+  it('isDeviceConnected should be true', async function () {
     (await adb.isDeviceConnected()).should.be.true;
   });
-  it('shell should execute command in adb shell ', async () => {
+  it('shell should execute command in adb shell ', async function () {
     (await adb.shell(['getprop', 'ro.build.version.sdk'])).should.equal(`${apiLevel}`);
   });
-  it('getConnectedEmulators should get all connected emulators', async () => {
+  it('getConnectedEmulators should get all connected emulators', async function () {
     (await adb.getConnectedEmulators()).length.should.be.above(0);
   });
-  it('getRunningAVD should get all connected avd', async () => {
+  it('getRunningAVD should get all connected avd', async function () {
     (await adb.getRunningAVD(avdName)).should.not.be.null;
   });
-  it('getRunningAVDWithRetry should get all connected avds', async () => {
+  it('getRunningAVDWithRetry should get all connected avds', async function () {
     (await adb.getRunningAVDWithRetry(avdName)).should.not.be.null;
   });
   // Skipping for now. Will unskip depending on how it behaves on CI

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -36,16 +36,16 @@ u0_a101   5078  3129  487404 37044 ffffffff b76ce565 S com.example.android.conta
       manufacturer = `unknown`,
       screenSize = `768x1280`;
 
-describe('adb commands', () => {
+describe('adb commands', function () {
   let adb = new ADB();
   let logcat = new Logcat({
     adb: adb.executable,
     debug: false,
     debugTrace: false
   });
-  describe('shell', () => {
+  describe('shell', function () {
     describe('getApiLevel', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("getDeviceProperty")
           .once().withExactArgs('ro.build.version.sdk')
           .returns(`${apiLevel}`);
@@ -54,7 +54,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getPlatformVersion', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("getDeviceProperty")
           .once().withExactArgs('ro.build.version.release')
           .returns(platformVersion);
@@ -63,7 +63,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getDeviceSysLanguage', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'persist.sys.language'])
           .returns(language);
@@ -72,7 +72,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setDeviceSysLanguage', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['setprop', 'persist.sys.language', language])
           .returns("");
@@ -81,7 +81,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getDeviceSysCountry', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'persist.sys.country'])
           .returns(country);
@@ -90,7 +90,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getLocationProviders', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args and return empty location_providers_allowed', async () => {
+      it('should call shell with correct args and return empty location_providers_allowed', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('secure', 'location_providers_allowed')
           .returns('');
@@ -99,7 +99,7 @@ describe('adb commands', () => {
         providers.length.should.equal(0);
         mocks.adb.verify();
       });
-      it('should return one location_providers_allowed', async () => {
+      it('should return one location_providers_allowed', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('secure', 'location_providers_allowed')
           .returns('gps');
@@ -109,7 +109,7 @@ describe('adb commands', () => {
         providers.should.include('gps');
         mocks.adb.verify();
       });
-      it('should return both location_providers_allowed', async () => {
+      it('should return both location_providers_allowed', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('secure', 'location_providers_allowed')
           .returns('gps ,wifi');
@@ -122,7 +122,7 @@ describe('adb commands', () => {
       });
     }));
     describe('toggleGPSLocationProvider', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args on gps enabled', async () => {
+      it('should call shell with correct args on gps enabled', async function () {
         mocks.adb.expects("setSetting")
           .withExactArgs('secure', 'location_providers_allowed', '+gps');
         mocks.adb.expects("setSetting")
@@ -133,7 +133,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setDeviceSysCountry', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['setprop', 'persist.sys.country', country])
           .returns("");
@@ -142,7 +142,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getDeviceSysLocale', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'persist.sys.locale'])
           .returns(locale);
@@ -151,7 +151,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setDeviceSysLocale', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['setprop', 'persist.sys.locale', locale])
           .returns("");
@@ -160,7 +160,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getDeviceProductLanguage', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'ro.product.locale.language'])
           .returns(language);
@@ -169,7 +169,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getDeviceProductCountry', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'ro.product.locale.region'])
           .returns(country);
@@ -178,7 +178,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getDeviceProductLocale', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'ro.product.locale'])
           .returns(locale);
@@ -187,7 +187,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setDeviceProperty', withMocks({adb}, (mocks) => {
-      it('should call setprop with correct args without root', async () => {
+      it('should call setprop with correct args without root', async function () {
         mocks.adb.expects("getApiLevel")
           .once().returns(21);
         mocks.adb.expects("shell")
@@ -196,7 +196,7 @@ describe('adb commands', () => {
         await adb.setDeviceProperty('persist.sys.locale', locale);
         mocks.adb.verify();
       });
-      it('should call setprop with correct args with root', async () => {
+      it('should call setprop with correct args with root', async function () {
         mocks.adb.expects("getApiLevel")
           .once().returns(26);
         mocks.adb.expects("root")
@@ -211,7 +211,7 @@ describe('adb commands', () => {
       });
     }));
     describe('availableIMEs', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['ime', 'list', '-a'])
           .returns(imeList);
@@ -220,7 +220,7 @@ describe('adb commands', () => {
       });
     }));
     describe('enabledIMEs', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['ime', 'list'])
           .returns(imeList);
@@ -230,7 +230,7 @@ describe('adb commands', () => {
     }));
     describe('defaultIME', withMocks({adb}, (mocks) => {
       let defaultIME = 'com.android.inputmethod.latin/.LatinIME';
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('secure', 'default_input_method')
           .returns(defaultIME);
@@ -239,7 +239,7 @@ describe('adb commands', () => {
       });
     }));
     describe('disableIME', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['ime', 'disable', IME])
           .returns("");
@@ -248,7 +248,7 @@ describe('adb commands', () => {
       });
     }));
     describe('enableIME', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['ime', 'enable', IME])
           .returns("");
@@ -257,7 +257,7 @@ describe('adb commands', () => {
       });
     }));
     describe('keyevent', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         let keycode = '29';
         let code = parseInt(keycode, 10);
         mocks.adb.expects("shell")
@@ -268,7 +268,7 @@ describe('adb commands', () => {
       });
     }));
     describe('inputText', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         let text = 'some text with spaces';
         let expectedText = 'some%stext%swith%sspaces';
         mocks.adb.expects("shell")
@@ -279,7 +279,7 @@ describe('adb commands', () => {
       });
     }));
     describe('clearTextField', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['input', 'keyevent', '67', '112', '67', '112', '67', '112', '67', '112'])
           .returns("");
@@ -288,7 +288,7 @@ describe('adb commands', () => {
       });
     }));
     describe('lock', withMocks({adb, log}, (mocks) => {
-      it('should call isScreenLocked, keyevent and errorAndThrow', async () => {
+      it('should call isScreenLocked, keyevent and errorAndThrow', async function () {
         mocks.adb.expects("isScreenLocked")
           .atLeast(2).returns(false);
         mocks.adb.expects("keyevent")
@@ -301,7 +301,7 @@ describe('adb commands', () => {
       });
     }));
     describe('back', withMocks({adb}, (mocks) => {
-      it('should call keyevent with correct args', async () => {
+      it('should call keyevent with correct args', async function () {
         mocks.adb.expects("keyevent")
           .once().withExactArgs(4)
           .returns("");
@@ -310,7 +310,7 @@ describe('adb commands', () => {
       });
     }));
     describe('goToHome', withMocks({adb}, (mocks) => {
-      it('should call keyevent with correct args', async () => {
+      it('should call keyevent with correct args', async function () {
         mocks.adb.expects("keyevent")
           .once().withExactArgs(3)
           .returns("");
@@ -319,7 +319,7 @@ describe('adb commands', () => {
       });
     }));
     describe.skip('isScreenLocked', withMocks({adb}, (mocks) => {
-      it('should call keyevent with correct args', async () => {
+      it('should call keyevent with correct args', async function () {
         mocks.adb.expects("keyevent")
           .once().withExactArgs(3)
           .returns("");
@@ -328,7 +328,7 @@ describe('adb commands', () => {
       });
     }));
     describe('isSoftKeyboardPresent', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args and should return false', async () => {
+      it('should call shell with correct args and should return false', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['dumpsys', 'input_method'])
           .returns("mInputShown=false");
@@ -337,7 +337,7 @@ describe('adb commands', () => {
         isKeyboardShown.should.be.false;
         mocks.adb.verify();
       });
-      it('should call shell with correct args and should return true', async () => {
+      it('should call shell with correct args and should return true', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['dumpsys', 'input_method'])
           .returns("mInputShown=true mIsInputViewShown=true");
@@ -348,14 +348,14 @@ describe('adb commands', () => {
       });
     }));
     describe('isAirplaneModeOn', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args and should be true', async () => {
+      it('should call shell with correct args and should be true', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('global', 'airplane_mode_on')
           .returns("1");
         (await adb.isAirplaneModeOn()).should.be.true;
         mocks.adb.verify();
       });
-      it('should call shell with correct args and should be false', async () => {
+      it('should call shell with correct args and should be false', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('global', 'airplane_mode_on')
           .returns("0");
@@ -364,7 +364,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setAirplaneMode', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("setSetting")
           .once().withExactArgs('global', 'airplane_mode_on', 1)
           .returns("");
@@ -373,7 +373,7 @@ describe('adb commands', () => {
       });
     }));
     describe('broadcastAirplaneMode', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args', async () => {
+      it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'android.intent.action.AIRPLANE_MODE', '--ez', 'state', 'true'])
           .returns("");
@@ -382,14 +382,14 @@ describe('adb commands', () => {
       });
     }));
     describe('isWifiOn', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args and should be true', async () => {
+      it('should call shell with correct args and should be true', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('global', 'wifi_on')
           .returns("1");
         (await adb.isWifiOn()).should.be.true;
         mocks.adb.verify();
       });
-      it('should call shell with correct args and should be false', async () => {
+      it('should call shell with correct args and should be false', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('global', 'wifi_on')
           .returns("0");
@@ -398,7 +398,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setWifiState', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args for real device', async () => {
+      it('should call shell with correct args for real device', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi',
             '-n', 'io.appium.settings/.receivers.WiFiConnectionSettingReceiver',
@@ -407,7 +407,7 @@ describe('adb commands', () => {
         await adb.setWifiState(true);
         mocks.adb.verify();
       });
-      it('should call shell with correct args for emulator', async () => {
+      it('should call shell with correct args for emulator', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'wifi', 'disable'])
           .returns("");
@@ -416,14 +416,14 @@ describe('adb commands', () => {
       });
     }));
     describe('isDataOn', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args and should be true', async () => {
+      it('should call shell with correct args and should be true', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('global', 'mobile_data')
           .returns("1");
         (await adb.isDataOn()).should.be.true;
         mocks.adb.verify();
       });
-      it('should call shell with correct args and should be false', async () => {
+      it('should call shell with correct args and should be false', async function () {
         mocks.adb.expects("getSetting")
           .once().withExactArgs('global', 'mobile_data')
           .returns("0");
@@ -432,7 +432,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setDataState', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args for real device', async () => {
+      it('should call shell with correct args for real device', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection',
             '-n', 'io.appium.settings/.receivers.DataConnectionSettingReceiver',
@@ -441,7 +441,7 @@ describe('adb commands', () => {
         await adb.setDataState(false);
         mocks.adb.verify();
       });
-      it('should call shell with correct args for emulator', async () => {
+      it('should call shell with correct args for emulator', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'data', 'enable'])
           .returns("");
@@ -450,7 +450,7 @@ describe('adb commands', () => {
       });
     }));
     describe('setWifiAndData', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args when turning only wifi on for real device', async () => {
+      it('should call shell with correct args when turning only wifi on for real device', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.wifi',
             '-n', 'io.appium.settings/.receivers.WiFiConnectionSettingReceiver',
@@ -459,21 +459,21 @@ describe('adb commands', () => {
         await adb.setWifiAndData({wifi: true});
         mocks.adb.verify();
       });
-      it('should call shell with correct args when turning only wifi off for emulator', async () => {
+      it('should call shell with correct args when turning only wifi off for emulator', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'wifi', 'disable'])
           .returns("");
         await adb.setWifiAndData({wifi: false}, true);
         mocks.adb.verify();
       });
-      it('should call shell with correct args when turning only data on for emulator', async () => {
+      it('should call shell with correct args when turning only data on for emulator', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'data', 'enable'])
           .returns("");
         await adb.setWifiAndData({data: true}, true);
         mocks.adb.verify();
       });
-      it('should call shell with correct args when turning only data off for real device', async () => {
+      it('should call shell with correct args when turning only data off for real device', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', 'io.appium.settings.data_connection',
             '-n', 'io.appium.settings/.receivers.DataConnectionSettingReceiver',
@@ -482,12 +482,12 @@ describe('adb commands', () => {
         await adb.setWifiAndData({data: false});
         mocks.adb.verify();
       });
-      it('should call shell with correct args when turning both wifi and data on for real device', async () => {
+      it('should call shell with correct args when turning both wifi and data on for real device', async function () {
         mocks.adb.expects("shell").twice().returns("");
         await adb.setWifiAndData({wifi: true, data: true});
         mocks.adb.verify();
       });
-      it('should call shell with correct args when turning both wifi and data off for emulator', async () => {
+      it('should call shell with correct args when turning both wifi and data off for emulator', async function () {
         mocks.adb.expects("shell").twice().returns("");
         await adb.setWifiAndData({wifi: false, data: false}, true);
         mocks.adb.verify();
@@ -497,12 +497,12 @@ describe('adb commands', () => {
       const adbArgs = ['am', 'broadcast', '-a', 'io.appium.settings.animation',
                       '-n', 'io.appium.settings/.receivers.AnimationSettingReceiver',
                       '--es', 'setstatus'];
-      it('should call shell with correct args to enable animation', async () => {
+      it('should call shell with correct args to enable animation', async function () {
         mocks.adb.expects("shell").once().withExactArgs(adbArgs.concat('enable'));
         await adb.setAnimationState(true);
         mocks.adb.verify();
       });
-      it('should call shell with correct args to disable animation', async () => {
+      it('should call shell with correct args to disable animation', async function () {
         mocks.adb.expects("shell").once().withExactArgs(adbArgs.concat('disable'));
         await adb.setAnimationState(false);
         mocks.adb.verify();
@@ -517,22 +517,22 @@ describe('adb commands', () => {
         mocks.adb.expects("getSetting").once().withExactArgs('global', 'window_animation_scale')
           .returns(window_scale);
       };
-      it('should return false if all animation settings are equal to zero', async () => {
+      it('should return false if all animation settings are equal to zero', async function () {
         await mockSetting("0.0", "0.0", "0.0");
         (await adb.isAnimationOn()).should.be.false;
         mocks.adb.verify();
       });
-      it('should return true if animator_duration_scale setting is NOT equal to zero', async () => {
+      it('should return true if animator_duration_scale setting is NOT equal to zero', async function () {
         await mockSetting("0.5", "0.0", "0.0");
         (await adb.isAnimationOn()).should.be.true;
         mocks.adb.verify();
       });
-      it('should return true if transition_animation_scale setting is NOT equal to zero', async () => {
+      it('should return true if transition_animation_scale setting is NOT equal to zero', async function () {
         await mockSetting("0.0", "0.5", "0.0");
         (await adb.isAnimationOn()).should.be.true;
         mocks.adb.verify();
       });
-      it('should return true if window_animation_scale setting is NOT equal to zero', async () => {
+      it('should return true if window_animation_scale setting is NOT equal to zero', async function () {
         await mockSetting("0.0", "0.0", "0.5");
         (await adb.isAnimationOn()).should.be.true;
         mocks.adb.verify();
@@ -542,7 +542,7 @@ describe('adb commands', () => {
       const adbArgs = ['am', 'broadcast', '-a', 'io.appium.settings.locale',
         '-n', 'io.appium.settings/.receivers.LocaleSettingReceiver',
         '--es', 'lang', 'en', '--es', 'country', 'US'];
-      it('should call shell with locale settings', async () => {
+      it('should call shell with locale settings', async function () {
         mocks.adb.expects("shell").once().withExactArgs(adbArgs);
         await adb.setDeviceSysLocaleViaSettingApp('en', 'US');
         mocks.adb.verify();
@@ -552,7 +552,7 @@ describe('adb commands', () => {
       const location = {longitude: '50.5',
                         latitude: '50.1'};
 
-      it('should call shell with correct args for real device', async () => {
+      it('should call shell with correct args for real device', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'startservice', '-e', 'longitude', location.longitude,
                                  '-e', 'latitude', location.latitude, `io.appium.settings/.LocationService`])
@@ -560,7 +560,7 @@ describe('adb commands', () => {
         await adb.setGeoLocation(location);
         mocks.adb.verify();
       });
-      it('should call adb with correct args for emulator', async () => {
+      it('should call adb with correct args for emulator', async function () {
         mocks.adb.expects("resetTelnetAuthToken")
           .once().returns(true);
         mocks.adb.expects("adbExec")
@@ -575,14 +575,14 @@ describe('adb commands', () => {
       });
     }));
     describe('processExists', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args and should find process', async () => {
+      it('should call shell with correct args and should find process', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs("ps")
           .returns(psOutput);
         (await adb.processExists(contactManagerPackage)).should.be.true;
         mocks.adb.verify();
       });
-      it('should call shell with correct args and should not find process', async () => {
+      it('should call shell with correct args and should not find process', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs("ps")
           .returns("foo");
@@ -593,21 +593,21 @@ describe('adb commands', () => {
     describe('forwardPort', withMocks({adb}, (mocks) => {
       const sysPort = 12345,
             devicePort = 54321;
-      it('forwardPort should call shell with correct args', async () => {
+      it('forwardPort should call shell with correct args', async function () {
         mocks.adb.expects("adbExec")
           .once().withExactArgs(['forward', `tcp:${sysPort}`, `tcp:${devicePort}`])
           .returns("");
         await adb.forwardPort(sysPort, devicePort);
         mocks.adb.verify();
       });
-      it('forwardAbstractPort should call shell with correct args', async () => {
+      it('forwardAbstractPort should call shell with correct args', async function () {
         mocks.adb.expects("adbExec")
           .once().withExactArgs(['forward', `tcp:${sysPort}`, `localabstract:${devicePort}`])
           .returns("");
         await adb.forwardAbstractPort(sysPort, devicePort);
         mocks.adb.verify();
       });
-      it('removePortForward should call shell with correct args', async () => {
+      it('removePortForward should call shell with correct args', async function () {
         mocks.adb.expects("adbExec")
             .once().withExactArgs(['forward', `--remove`, `tcp:${sysPort}`])
             .returns("");
@@ -616,7 +616,7 @@ describe('adb commands', () => {
       });
     }));
     describe('ping', withMocks({adb}, (mocks) => {
-      it('should call shell with correct args and should return true', async () => {
+      it('should call shell with correct args and should return true', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(["echo", "ping"])
           .returns("ping");
@@ -625,7 +625,7 @@ describe('adb commands', () => {
       });
     }));
     describe('restart', withMocks({adb}, (mocks) => {
-      it('should call adb in correct order', async () => {
+      it('should call adb in correct order', async function () {
         mocks.adb.expects("stopLogcat").once().returns("");
         mocks.adb.expects("restartAdb").once().returns("");
         mocks.adb.expects("waitForDevice").once().returns("");
@@ -635,7 +635,7 @@ describe('adb commands', () => {
       });
     }));
     describe('stopLogcat', withMocks({logcat}, (mocks) => {
-      it('should call stopCapture', async () => {
+      it('should call stopCapture', async function () {
         adb.logcat = logcat;
         mocks.logcat.expects("stopCapture").once().returns("");
         await adb.stopLogcat();
@@ -643,7 +643,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getLogcatLogs', withMocks({logcat}, (mocks) => {
-      it('should call getLogs', async () => {
+      it('should call getLogs', async function () {
         adb.logcat = logcat;
         mocks.logcat.expects("getLogs").once().returns("");
         await adb.getLogcatLogs();
@@ -651,7 +651,7 @@ describe('adb commands', () => {
       });
     }));
     describe('getPIDsByName', withMocks({adb}, (mocks) => {
-      it('should call shell and parse pids correctly', async () => {
+      it('should call shell and parse pids correctly', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['ps'])
           .returns(psOutput);
@@ -660,7 +660,7 @@ describe('adb commands', () => {
       });
     }));
     describe('killProcessesByName', withMocks({adb}, (mocks) => {
-      it('should call getPIDsByName and kill process correctly', async () => {
+      it('should call getPIDsByName and kill process correctly', async function () {
         mocks.adb.expects("getPIDsByName")
           .once().withExactArgs(contactManagerPackage)
           .returns([5078]);
@@ -674,7 +674,7 @@ describe('adb commands', () => {
     describe('killProcessByPID', withMocks({adb}, (mocks) => {
       const pid = 5078;
 
-      it('should call kill process correctly', async () => {
+      it('should call kill process correctly', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['kill', '-0', pid])
           .returns('');
@@ -690,7 +690,7 @@ describe('adb commands', () => {
         mocks.adb.verify();
       });
 
-      it('should force kill process if normal kill fails', async () => {
+      it('should force kill process if normal kill fails', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['kill', '-0', pid])
           .returns('');
@@ -704,7 +704,7 @@ describe('adb commands', () => {
         mocks.adb.verify();
       });
 
-      it('should throw an error if a process with given ID does not exist', async () => {
+      it('should throw an error if a process with given ID does not exist', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['kill', '-0', pid])
           .throws();
@@ -713,7 +713,7 @@ describe('adb commands', () => {
       });
     }));
     describe('broadcastProcessEnd', withMocks({adb}, (mocks) => {
-      it('should broadcast process end', async () => {
+      it('should broadcast process end', async function () {
         let intent = 'intent',
             processName = 'processName';
         mocks.adb.expects("shell")
@@ -727,7 +727,7 @@ describe('adb commands', () => {
       });
     }));
     describe('broadcast', withMocks({adb}, (mocks) => {
-      it('should broadcast intent', async () => {
+      it('should broadcast intent', async function () {
         let intent = 'intent';
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', intent])
@@ -737,7 +737,7 @@ describe('adb commands', () => {
       });
     }));
     describe('instrument', withMocks({adb}, (mocks) => {
-      it('should call shell with correct arguments', async () => {
+      it('should call shell with correct arguments', async function () {
         let intent = 'intent';
         mocks.adb.expects("shell")
           .once().withExactArgs(['am', 'broadcast', '-a', intent])
@@ -747,7 +747,7 @@ describe('adb commands', () => {
       });
     }));
     describe('androidCoverage', withMocks({adb, teen_process}, (mocks) => {
-      it('should call shell with correct arguments', async () => {
+      it('should call shell with correct arguments', async function () {
         adb.executable.defaultArgs = [];
         adb.executable.path = "dummy_adb_path";
         let conn = new events.EventEmitter();
@@ -771,28 +771,28 @@ describe('adb commands', () => {
     }));
   });
   describe('device info', withMocks({adb}, (mocks) => {
-    it('should get device model', async () => {
+    it('should get device model', async function () {
       mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'ro.product.model'])
           .returns(model);
       await adb.getModel();
       mocks.adb.verify();
     });
-    it('should get device manufacturer', async () => {
+    it('should get device manufacturer', async function () {
       mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'ro.product.manufacturer'])
           .returns(manufacturer);
       await adb.getManufacturer();
       mocks.adb.verify();
     });
-    it('should get device screen size', async () => {
+    it('should get device screen size', async function () {
       mocks.adb.expects("shell")
           .once().withExactArgs(['wm', 'size'])
           .returns(screenSize);
       await adb.getScreenSize();
       mocks.adb.verify();
     });
-    it('should get device screen density', async () => {
+    it('should get device screen density', async function () {
       mocks.adb.expects("shell")
           .once().withExactArgs(['wm', 'density'])
           .returns("Physical density: 420");
@@ -800,7 +800,7 @@ describe('adb commands', () => {
       density.should.equal(420);
       mocks.adb.verify();
     });
-    it('should return null for invalid screen density', async () => {
+    it('should return null for invalid screen density', async function () {
       mocks.adb.expects("shell")
           .once().withExactArgs(['wm', 'density'])
           .returns("Physical density: unknown");
@@ -871,19 +871,19 @@ describe('adb commands', () => {
       ACTIVITY MANAGER PENDING INTENTS (dumpsys activity intents)
         (nothing)`;
 
-    it('should grant requested permission', async () => {
+    it('should grant requested permission', async function () {
       mocks.adb.expects("shell")
           .once().withArgs(['pm', 'grant', 'io.appium.android.apis', 'android.permission.READ_EXTERNAL_STORAGE']);
       await adb.grantPermission('io.appium.android.apis', 'android.permission.READ_EXTERNAL_STORAGE');
       mocks.adb.verify();
     });
-    it('should revoke requested permission', async () => {
+    it('should revoke requested permission', async function () {
       mocks.adb.expects("shell")
           .once().withArgs(['pm', 'revoke', 'io.appium.android.apis', 'android.permission.READ_EXTERNAL_STORAGE']);
       await adb.revokePermission('io.appium.android.apis', 'android.permission.READ_EXTERNAL_STORAGE');
       mocks.adb.verify();
     });
-    it('should properly list requested permissions', async () => {
+    it('should properly list requested permissions', async function () {
       mocks.adb.expects("shell").once().returns(dumpedOutput);
       const result = await adb.getReqPermissions('io.appium.android');
       for (let perm of ['android.permission.ACCESS_NETWORK_STATE',
@@ -904,7 +904,7 @@ describe('adb commands', () => {
         result.should.include(perm);
       }
     });
-    it('should properly list granted permissions', async () => {
+    it('should properly list granted permissions', async function () {
       mocks.adb.expects("shell").once().returns(dumpedOutput);
       const result = await adb.getGrantedPermissions('io.appium.android');
       for (let perm of ['android.permission.MODIFY_AUDIO_SETTINGS',
@@ -927,7 +927,7 @@ describe('adb commands', () => {
         result.should.not.include(perm);
       }
     });
-    it('should properly list denied permissions', async () => {
+    it('should properly list denied permissions', async function () {
       mocks.adb.expects("shell").once().returns(dumpedOutput);
       const result = await adb.getDeniedPermissions('io.appium.android');
       for (let perm of ['android.permission.MODIFY_AUDIO_SETTINGS',
@@ -952,7 +952,7 @@ describe('adb commands', () => {
     });
   }));
   describe('sendTelnetCommand', withMocks({adb, net}, (mocks) => {
-    it('should call shell with correct args', async () => {
+    it('should call shell with correct args', async function () {
       const port = 54321;
       let conn = new events.EventEmitter();
       let commands = [];
@@ -978,7 +978,7 @@ describe('adb commands', () => {
       mocks.adb.verify();
       mocks.net.verify();
     });
-    it('should return the last line of the output only', async () => {
+    it('should return the last line of the output only', async function () {
       const port = 54321;
       let conn = new events.EventEmitter();
       let commands = [];
@@ -1002,7 +1002,7 @@ describe('adb commands', () => {
       let actual = await p;
       (actual).should.equal(expected);
     });
-    it('should throw error if network connection errors', async () => {
+    it('should throw error if network connection errors', async function () {
       const port = 54321;
       let conn = new events.EventEmitter();
       let commands = [];
@@ -1026,21 +1026,21 @@ describe('adb commands', () => {
       await p.should.eventually.be.rejectedWith(/ouch/);
     });
   }));
-  it('isValidClass should correctly validate class names', () => {
+  it('isValidClass should correctly validate class names', function () {
     adb.isValidClass('some.package/some.package.Activity').index.should.equal(0);
     should.not.exist(adb.isValidClass('illegalPackage#/adsasd'));
   });
-  it('getAdbPath should correctly return adbPath', () => {
+  it('getAdbPath should correctly return adbPath', function () {
     adb.getAdbPath().should.equal(adb.executable.path);
   });
   describe('setHttpProxy', withMocks({adb}, (mocks) => {
-    it('should throw an error on undefined proxy_host', async () => {
+    it('should throw an error on undefined proxy_host', async function () {
       await adb.setHttpProxy().should.eventually.be.rejected;
     });
-    it('should throw an error on undefined proxy_port', async () => {
+    it('should throw an error on undefined proxy_port', async function () {
       await adb.setHttpProxy("http://localhost").should.eventually.be.rejected;
     });
-    it('should call setSetting method with correct args', async () => {
+    it('should call setSetting method with correct args', async function () {
       let proxyHost = "http://localhost";
       let proxyPort = 4723;
       mocks.adb.expects('setSetting').once().withExactArgs('global', 'http_proxy', `${proxyHost}:${proxyPort}`);
@@ -1053,7 +1053,7 @@ describe('adb commands', () => {
     });
   }));
   describe('setSetting', withMocks({adb}, (mocks) => {
-    it('should call shell settings put', async () => {
+    it('should call shell settings put', async function () {
       mocks.adb.expects('shell').once()
         .withExactArgs(['settings', 'put', 'namespace', 'setting', 'value']);
       await adb.setSetting('namespace', 'setting', 'value');
@@ -1061,7 +1061,7 @@ describe('adb commands', () => {
     });
   }));
   describe('getSetting', withMocks({adb}, (mocks) => {
-    it('should call shell settings get', async () => {
+    it('should call shell settings get', async function () {
       mocks.adb.expects('shell').once()
         .withExactArgs(['settings', 'get', 'namespace', 'setting'])
         .returns('value');

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -13,11 +13,11 @@ const emulators = [
 ];
 const fingerprintId = 1111;
 
-describe('adb emulator commands', () => {
+describe('adb emulator commands', function () {
   let adb = new ADB();
-  describe("emu", () => {
+  describe("emu", function () {
     describe("isEmulatorConnected", withMocks({adb}, (mocks) => {
-      it("should verify emulators state", async () => {
+      it("should verify emulators state", async function () {
         mocks.adb.expects("getConnectedEmulators")
           .atLeast(3)
           .returns(emulators);
@@ -31,7 +31,7 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("verifyEmulatorConnected", withMocks({adb}, (mocks) => {
-      it("should throw an exception on emulator not connected", async () => {
+      it("should throw an exception on emulator not connected", async function () {
         adb.curDeviceId = "emulator-5558";
         mocks.adb.expects("isEmulatorConnected")
           .once()
@@ -41,18 +41,18 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("fingerprint", withMocks({adb}, (mocks) => {
-      it("should throw exception on undefined fingerprintId", async () => {
+      it("should throw exception on undefined fingerprintId", async function () {
         await adb.fingerprint().should.eventually.be.rejected;
         mocks.adb.verify();
       });
-      it("should throw exception on apiLevel lower than 23", async () => {
+      it("should throw exception on apiLevel lower than 23", async function () {
         mocks.adb.expects("getApiLevel")
           .once().withExactArgs()
           .returns(21);
         await adb.fingerprint(fingerprintId).should.eventually.be.rejected;
         mocks.adb.verify();
       });
-      it("should call adbExec with the correct args", async () => {
+      it("should call adbExec with the correct args", async function () {
         mocks.adb.expects("getApiLevel")
           .once().withExactArgs()
           .returns(23);
@@ -70,7 +70,7 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("rotate", withMocks({adb}, (mocks) => {
-      it("should call adbExec with the correct args", async () => {
+      it("should call adbExec with the correct args", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -85,11 +85,11 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("power methods", withMocks({adb}, (mocks) => {
-      it("should throw exception on invalid power ac state", async () => {
+      it("should throw exception on invalid power ac state", async function () {
         await adb.powerAC('dead').should.eventually.be.rejectedWith("Wrong power AC state");
         mocks.adb.verify();
       });
-      it("should set the power ac off", async () => {
+      it("should set the power ac off", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -102,7 +102,7 @@ describe('adb emulator commands', () => {
         await adb.powerAC('off');
         mocks.adb.verify();
       });
-      it("should set the power ac on", async () => {
+      it("should set the power ac on", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -115,13 +115,13 @@ describe('adb emulator commands', () => {
         await adb.powerAC('on');
         mocks.adb.verify();
       });
-      it("should throw exception on invalid power battery percent", async () => {
+      it("should throw exception on invalid power battery percent", async function () {
         await adb.powerCapacity(-1).should.eventually.be.rejectedWith("should be valid integer between 0 and 100");
         await adb.powerCapacity("a").should.eventually.be.rejectedWith("should be valid integer between 0 and 100");
         await adb.powerCapacity(500).should.eventually.be.rejectedWith("should be valid integer between 0 and 100");
         mocks.adb.verify();
       });
-      it("should set the power capacity", async () => {
+      it("should set the power capacity", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -134,7 +134,7 @@ describe('adb emulator commands', () => {
         await adb.powerCapacity(0);
         mocks.adb.verify();
       });
-      it("should call methods to power off the emulator", async () => {
+      it("should call methods to power off the emulator", async function () {
         mocks.adb.expects("powerAC")
           .once().withExactArgs('off')
           .returns();
@@ -146,15 +146,15 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("sendSMS", withMocks({adb}, (mocks) => {
-      it("should throw exception on invalid message", async () => {
+      it("should throw exception on invalid message", async function () {
         await adb.sendSMS("+549341312345678").should.eventually.be.rejectedWith("Sending an SMS requires a message");
         mocks.adb.verify();
       });
-      it("should throw exception on invalid phoneNumber", async () => {
+      it("should throw exception on invalid phoneNumber", async function () {
         await adb.sendSMS("00549341a312345678", 'Hello Appium').should.eventually.be.rejectedWith("Invalid sendSMS phoneNumber");
         mocks.adb.verify();
       });
-      it("should call adbExec with the correct args", async () => {
+      it("should call adbExec with the correct args", async function () {
         let phoneNumber = 4509;
         let message = " Hello Appium ";
         mocks.adb.expects("isEmulatorConnected")
@@ -171,11 +171,11 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("gsm signal method", withMocks({adb}, (mocks) => {
-      it("should throw exception on invalid strength", async () => {
+      it("should throw exception on invalid strength", async function () {
         await adb.gsmSignal(5).should.eventually.be.rejectedWith("Invalid signal strength");
         mocks.adb.verify();
       });
-      it("should call adbExecEmu with the correct args", async () => {
+      it("should call adbExecEmu with the correct args", async function () {
         let signalStrength = 0;
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
@@ -191,15 +191,15 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("gsm call methods", withMocks({adb}, (mocks) => {
-      it("should throw exception on invalid action", async () => {
+      it("should throw exception on invalid action", async function () {
         await adb.gsmCall("+549341312345678").should.eventually.be.rejectedWith("Invalid gsm action");
         mocks.adb.verify();
       });
-      it("should throw exception on invalid phoneNumber", async () => {
+      it("should throw exception on invalid phoneNumber", async function () {
         await adb.gsmCall("+5493413a12345678", "call").should.eventually.be.rejectedWith("Invalid gsmCall phoneNumber");
         mocks.adb.verify();
       });
-      it("should set the correct method for making gsm call", async () => {
+      it("should set the correct method for making gsm call", async function () {
         let phoneNumber = 4509;
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
@@ -213,7 +213,7 @@ describe('adb emulator commands', () => {
         await adb.gsmCall(phoneNumber, "call");
         mocks.adb.verify();
       });
-      it("should set the correct method for accepting gsm call", async () => {
+      it("should set the correct method for accepting gsm call", async function () {
         let phoneNumber = 4509;
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
@@ -227,7 +227,7 @@ describe('adb emulator commands', () => {
         await adb.gsmCall(phoneNumber, "accept");
         mocks.adb.verify();
       });
-      it("should set the correct method for refusing gsm call", async () => {
+      it("should set the correct method for refusing gsm call", async function () {
         let phoneNumber = 4509;
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
@@ -241,7 +241,7 @@ describe('adb emulator commands', () => {
         await adb.gsmCall(phoneNumber, "cancel");
         mocks.adb.verify();
       });
-      it("should set the correct method for holding gsm call", async () => {
+      it("should set the correct method for holding gsm call", async function () {
         let phoneNumber = 4509;
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
@@ -257,12 +257,12 @@ describe('adb emulator commands', () => {
       });
     }));
     describe("network speed method", withMocks({adb}, (mocks) => {
-      it("should throw exception on invalid speed", async () => {
+      it("should throw exception on invalid speed", async function () {
         await adb.networkSpeed('light').should.eventually.be.rejectedWith("Invalid network speed");
         mocks.adb.verify();
       });
       for (let [key, value] of _.toPairs(adb.NETWORK_SPEED)) {
-        it(`should set network speed(${key}) correctly`, async () => {
+        it(`should set network speed(${key}) correctly`, async function () {
           mocks.adb.expects("isEmulatorConnected")
             .once().withExactArgs()
             .returns(true);
@@ -278,11 +278,11 @@ describe('adb emulator commands', () => {
       }
     }));
     describe("gsm voice method", withMocks({adb}, (mocks) => {
-      it("should throw exception on invalid strength", async () => {
+      it("should throw exception on invalid strength", async function () {
         await adb.gsmVoice('weird').should.eventually.be.rejectedWith("Invalid gsm voice state");
         mocks.adb.verify();
       });
-      it("should set gsm voice to unregistered", async () => {
+      it("should set gsm voice to unregistered", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -295,7 +295,7 @@ describe('adb emulator commands', () => {
         await adb.gsmVoice("unregistered");
         mocks.adb.verify();
       });
-      it("should set gsm voice to home", async () => {
+      it("should set gsm voice to home", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -308,7 +308,7 @@ describe('adb emulator commands', () => {
         await adb.gsmVoice("home");
         mocks.adb.verify();
       });
-      it("should set gsm voice to roaming", async () => {
+      it("should set gsm voice to roaming", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -321,7 +321,7 @@ describe('adb emulator commands', () => {
         await adb.gsmVoice("roaming");
         mocks.adb.verify();
       });
-      it("should set gsm voice to searching", async () => {
+      it("should set gsm voice to searching", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -334,7 +334,7 @@ describe('adb emulator commands', () => {
         await adb.gsmVoice("searching");
         mocks.adb.verify();
       });
-      it("should set gsm voice to denied", async () => {
+      it("should set gsm voice to denied", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -347,7 +347,7 @@ describe('adb emulator commands', () => {
         await adb.gsmVoice("denied");
         mocks.adb.verify();
       });
-      it("should set gsm voice to off", async () => {
+      it("should set gsm voice to off", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);
@@ -360,7 +360,7 @@ describe('adb emulator commands', () => {
         await adb.gsmVoice("off");
         mocks.adb.verify();
       });
-      it("should set gsm voice to on", async () => {
+      it("should set gsm voice to on", async function () {
         mocks.adb.expects("isEmulatorConnected")
           .once().withExactArgs()
           .returns(true);

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -7,10 +7,10 @@ import { withMocks } from 'appium-test-support';
 
 chai.use(chaiAsPromised);
 
-describe('android-manifest', () => {
+describe('android-manifest', function () {
   let adb = new ADB();
   describe('processFromManifest', withMocks({adb, teen_process}, (mocks) => {
-    it('should correctly parse process from manifest', async () => {
+    it('should correctly parse process from manifest', async function () {
       adb.binaries.aapt = 'dummy_aapt';
       const localApk = 'dummyAPK',
             dummyProcess = 'dummyProcess';
@@ -27,7 +27,7 @@ describe('android-manifest', () => {
     });
   }));
   describe('packageAndLaunchActivityFromManifest', withMocks({adb, teen_process}, (mocks) => {
-    it('should correctly parse package and activity from manifest', async () => {
+    it('should correctly parse package and activity from manifest', async function () {
       adb.binaries.aapt = 'dummy_aapt';
       const localApk = 'dummyAPK',
             dummyPackageName = 'package',
@@ -46,7 +46,7 @@ describe('android-manifest', () => {
     });
   }));
   describe('hasInternetPermissionFromManifest', withMocks({adb, teen_process}, (mocks) => {
-    it('should correctly parse internet permission from manifest', async () => {
+    it('should correctly parse internet permission from manifest', async function () {
       adb.binaries.aapt = 'dummy_aapt';
       const localApk = 'dummyAPK';
       mocks.adb.expects("initAapt")

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -24,7 +24,7 @@ const selendroidTestApp = path.resolve(helpers.rootDir, 'test', 'fixtures', 'sel
       tempDir = appiumSupport.tempDir,
       fs = appiumSupport.fs;
 
-describe('signing', () => {
+describe('signing', function () {
   let adb = new ADB();
   adb.keystorePath = keystorePath;
   adb.keyAlias = keyAlias;

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -21,10 +21,10 @@ const should = chai.should(),
       country = 'US',
       locale = 'en-US';
 
-describe('Apk-utils', () => {
+describe('Apk-utils', function () {
   let adb = new ADB();
   describe('isAppInstalled', withMocks({adb}, (mocks) => {
-    it('should parse correctly and return true', async () => {
+    it('should parse correctly and return true', async function () {
       const pkg = 'dummy.package';
       mocks.adb.expects('shell')
         .once().withExactArgs(['pm', 'list', 'packages', pkg])
@@ -32,7 +32,7 @@ describe('Apk-utils', () => {
       (await adb.isAppInstalled(pkg)).should.be.true;
       mocks.adb.verify();
     });
-    it('should parse correctly and return false', async () => {
+    it('should parse correctly and return false', async function () {
       const pkg = 'dummy.package';
       mocks.adb.expects('shell')
         .once().withExactArgs(['pm', 'list', 'packages', pkg])
@@ -42,7 +42,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('getFocusedPackageAndActivity', withMocks({adb}, (mocks) => {
-    it('should parse correctly and return package and activity', async () => {
+    it('should parse correctly and return package and activity', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -53,7 +53,7 @@ describe('Apk-utils', () => {
       appActivity.should.equal(act);
       mocks.adb.verify();
     });
-    it('should parse correctly and return package and activity when a comma is present', async () => {
+    it('should parse correctly and return package and activity when a comma is present', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{20fe217e token=Token{21878739 ` +
@@ -64,7 +64,7 @@ describe('Apk-utils', () => {
       appActivity.should.equal(act);
       mocks.adb.verify();
     });
-    it('should parse correctly and return null', async () => {
+    it('should parse correctly and return null', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns('mFocusedApp=null');
@@ -75,7 +75,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('waitForActivityOrNot', withMocks({adb}, (mocks) => {
-    it('should call shell once and should return', async () => {
+    it('should call shell once and should return', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -84,7 +84,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, act, false);
       mocks.adb.verify();
     });
-    it('should call shell multiple times and return', async () => {
+    it('should call shell multiple times and return', async function () {
       mocks.adb.expects('shell').onCall(0)
         .returns('mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ' +
                  'ActivityRecord{2c7c4318 u0 foo/bar t181}}}');
@@ -95,7 +95,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, act, false);
       mocks.adb.verify();
     });
-    it('should call shell once return for not', async () => {
+    it('should call shell once return for not', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns('mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ' +
@@ -104,7 +104,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, act, true);
       mocks.adb.verify();
     });
-    it('should call shell multiple times and return for not', async () => {
+    it('should call shell multiple times and return for not', async function () {
       mocks.adb.expects('shell').onCall(0)
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/${act} t181}}}`);
@@ -114,7 +114,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, act, true);
       mocks.adb.verify();
     });
-    it('should be able to get first of a comma-separated list of activities', async () => {
+    it('should be able to get first of a comma-separated list of activities', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -123,7 +123,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, '.ContactManager, .OtherManager', false);
       mocks.adb.verify();
     });
-    it('should be able to get second of a comma-separated list of activities', async () => {
+    it('should be able to get second of a comma-separated list of activities', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -132,7 +132,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, '.ContactManager, .OtherManager', false);
       mocks.adb.verify();
     });
-    it('should fail if no activity in a comma-separated list is available', async () => {
+    it('should fail if no activity in a comma-separated list is available', async function () {
       mocks.adb.expects('shell')
         .atLeast(1)
         .withExactArgs(['dumpsys', 'window', 'windows'])
@@ -143,7 +143,7 @@ describe('Apk-utils', () => {
         .should.eventually.be.rejected;
       mocks.adb.verify();
     });
-    it('should be able to match activities if waitActivity is a wildcard', async () => {
+    it('should be able to match activities if waitActivity is a wildcard', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -152,7 +152,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, `*`, false);
       mocks.adb.verify();
     });
-    it('should be able to match activities if waitActivity is shortened and contains a whildcard', async () => {
+    it('should be able to match activities if waitActivity is shortened and contains a whildcard', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -161,7 +161,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, `.*Manager`, false);
       mocks.adb.verify();
     });
-    it('should be able to match activities if waitActivity contains a wildcard alternative to activity', async () => {
+    it('should be able to match activities if waitActivity contains a wildcard alternative to activity', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -170,7 +170,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, `${pkg}.*`, false);
       mocks.adb.verify();
     });
-    it('should be able to match activities if waitActivity contains a wildcard on head', async () => {
+    it('should be able to match activities if waitActivity contains a wildcard on head', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -179,7 +179,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, `*.contactmanager.ContactManager`, false);
       mocks.adb.verify();
     });
-    it('should be able to match activities if waitActivity contains a wildcard across a pkg name and an activity name', async () => {
+    it('should be able to match activities if waitActivity contains a wildcard across a pkg name and an activity name', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -188,7 +188,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, `com.*Manager`, false);
       mocks.adb.verify();
     });
-    it('should be able to match activities if waitActivity contains wildcards in both a pkg name and an activity name', async () => {
+    it('should be able to match activities if waitActivity contains wildcards in both a pkg name and an activity name', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -197,7 +197,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, `com.*.contactmanager.*Manager`, false);
       mocks.adb.verify();
     });
-    it('should fail if activity not to match from regexp activities', async () => {
+    it('should fail if activity not to match from regexp activities', async function () {
       mocks.adb.expects('shell')
         .atLeast(1).withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -207,7 +207,7 @@ describe('Apk-utils', () => {
         .should.eventually.be.rejected;
       mocks.adb.verify();
     });
-    it('should be able to get an activity that is an inner class', async () => {
+    it('should be able to get an activity that is an inner class', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -216,7 +216,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot(pkg, '.Settings$AppDrawOverlaySettingsActivity', false);
       mocks.adb.verify();
     });
-    it('should be able to get first activity from first package in a comma-separated list of packages + activities', async () => {
+    it('should be able to get first activity from first package in a comma-separated list of packages + activities', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -225,7 +225,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
       mocks.adb.verify();
     });
-    it('should be able to get first activity from second package in a comma-separated list of packages + activities', async () => {
+    it('should be able to get first activity from second package in a comma-separated list of packages + activities', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -234,7 +234,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
       mocks.adb.verify();
     });
-    it('should be able to get second activity from first package in a comma-separated list of packages + activities', async () => {
+    it('should be able to get second activity from first package in a comma-separated list of packages + activities', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -243,7 +243,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
       mocks.adb.verify();
     });
-    it('should be able to get second activity from second package in a comma-separated list of packages', async () => {
+    it('should be able to get second activity from second package in a comma-separated list of packages', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -252,7 +252,7 @@ describe('Apk-utils', () => {
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
       mocks.adb.verify();
     });
-    it('should fail to get activity when focused activity matches none of the provided list of packages', async () => {
+    it('should fail to get activity when focused activity matches none of the provided list of packages', async function () {
       mocks.adb.expects('shell')
         .atLeast(1).withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
@@ -264,7 +264,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('waitForActivity', withMocks({adb}, (mocks) => {
-    it('should call waitForActivityOrNot with correct arguments', async () => {
+    it('should call waitForActivityOrNot with correct arguments', async function () {
       mocks.adb.expects('waitForActivityOrNot')
         .once().withExactArgs(pkg, act, false, 20000)
         .returns('');
@@ -273,7 +273,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('waitForNotActivity', withMocks({adb}, (mocks) => {
-    it('should call waitForActivityOrNot with correct arguments', async () => {
+    it('should call waitForActivityOrNot with correct arguments', async function () {
       mocks.adb.expects('waitForActivityOrNot')
         .once().withExactArgs(pkg, act, true, 20000)
         .returns('');
@@ -282,7 +282,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('uninstallApk', withMocks({adb}, (mocks) => {
-    it('should call forceStop and adbExec with correct arguments', async () => {
+    it('should call forceStop and adbExec with correct arguments', async function () {
       mocks.adb.expects('isAppInstalled')
         .once().withExactArgs(pkg)
         .returns(true);
@@ -295,7 +295,7 @@ describe('Apk-utils', () => {
       (await adb.uninstallApk(pkg)).should.be.true;
       mocks.adb.verify();
     });
-    it('should not call forceStop and adbExec if app not installed', async () => {
+    it('should not call forceStop and adbExec if app not installed', async function () {
       mocks.adb.expects('isAppInstalled')
         .once().withExactArgs(pkg)
         .returns(false);
@@ -308,7 +308,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('installFromDevicePath', withMocks({adb}, (mocks) => {
-    it('should call forceStop and adbExec with correct arguments', async () => {
+    it('should call forceStop and adbExec with correct arguments', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['pm', 'install', '-r', 'foo'], {})
         .returns('');
@@ -317,14 +317,14 @@ describe('Apk-utils', () => {
     });
   }));
   describe('install', withMocks({adb}, (mocks) => {
-    it('should call forceStop and adbExec with correct arguments', async () => {
+    it('should call forceStop and adbExec with correct arguments', async function () {
       mocks.adb.expects('adbExec')
         .once().withExactArgs(['install', '-r', 'foo'], {timeout: 60000})
         .returns('');
       (await adb.install('foo'));
       mocks.adb.verify();
     });
-    it('should call forceStop and adbExec with correct arguments when not replacing', async () => {
+    it('should call forceStop and adbExec with correct arguments when not replacing', async function () {
       mocks.adb.expects('adbExec')
         .once().withExactArgs(['install', 'foo'], {timeout: 60000})
         .returns('');
@@ -333,11 +333,11 @@ describe('Apk-utils', () => {
     });
   }));
   describe('startUri', withMocks({adb}, (mocks) => {
-    it('should fail if uri or pkg are not provided', async () => {
+    it('should fail if uri or pkg are not provided', async function () {
       await adb.startUri().should.eventually.be.rejectedWith(/arguments are required/);
       await adb.startUri('foo').should.eventually.be.rejectedWith(/arguments are required/);
     });
-    it('should build a call to a VIEW intent with the uri', async () => {
+    it('should build a call to a VIEW intent with the uri', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['am', 'start', '-W', '-a',
                                'android.intent.action.VIEW', '-d', uri, pkg]);
@@ -346,7 +346,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('startApp', withMocks({adb}, (mocks) => {
-    it('should call getApiLevel and shell with correct arguments', async () => {
+    it('should call getApiLevel and shell with correct arguments', async function () {
       mocks.adb.expects('getApiLevel')
         .once().withExactArgs()
         .returns(17);
@@ -356,7 +356,7 @@ describe('Apk-utils', () => {
       (await adb.startApp(startAppOptions));
       mocks.adb.verify();
     });
-    it('should call getApiLevel and shell with correct arguments', async () => {
+    it('should call getApiLevel and shell with correct arguments', async function () {
       mocks.adb.expects('getApiLevel')
         .twice()
         .returns(17);
@@ -368,7 +368,7 @@ describe('Apk-utils', () => {
       (await adb.startApp(startAppOptions));
       mocks.adb.verify();
     });
-    it('should call getApiLevel and shell with correct arguments when activity is inner class', async () => {
+    it('should call getApiLevel and shell with correct arguments when activity is inner class', async function () {
       const startAppOptionsWithInnerClass = { pkg: 'pkg', activity: 'act$InnerAct'},
             cmdWithInnerClass = ['am', 'start', '-W', '-n', 'pkg/act\\$InnerAct', '-S'];
 
@@ -383,7 +383,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('getDeviceLanguage', withMocks({adb}, (mocks) => {
-    it('should call shell one time with correct args and return language when API < 23', async () => {
+    it('should call shell one time with correct args and return language when API < 23', async function () {
       mocks.adb.expects("getApiLevel").returns(18);
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.language'])
@@ -391,7 +391,7 @@ describe('Apk-utils', () => {
       (await adb.getDeviceLanguage()).should.equal(language);
       mocks.adb.verify();
     });
-    it('should call shell two times with correct args and return language when API < 23', async () => {
+    it('should call shell two times with correct args and return language when API < 23', async function () {
       mocks.adb.expects("getApiLevel").returns(18);
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.language'])
@@ -402,7 +402,7 @@ describe('Apk-utils', () => {
       (await adb.getDeviceLanguage()).should.equal(language);
       mocks.adb.verify();
     });
-    it('should call shell one time with correct args and return language when API = 23', async () => {
+    it('should call shell one time with correct args and return language when API = 23', async function () {
       mocks.adb.expects("getApiLevel").returns(23);
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.locale'])
@@ -410,7 +410,7 @@ describe('Apk-utils', () => {
       (await adb.getDeviceLanguage()).should.equal(language);
       mocks.adb.verify();
     });
-    it('should call shell two times with correct args and return language when API = 23', async () => {
+    it('should call shell two times with correct args and return language when API = 23', async function () {
       mocks.adb.expects("getApiLevel").returns(23);
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.locale'])
@@ -423,7 +423,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('setDeviceLanguage', withMocks({adb}, (mocks) => {
-    it('should call shell one time with correct args when API < 23', async () => {
+    it('should call shell one time with correct args when API < 23', async function () {
       mocks.adb.expects("getApiLevel")
         .once().returns(21);
       mocks.adb.expects("shell")
@@ -434,14 +434,14 @@ describe('Apk-utils', () => {
     });
   }));
   describe('getDeviceCountry', withMocks({adb}, (mocks) => {
-    it('should call shell one time with correct args and return country', async () => {
+    it('should call shell one time with correct args and return country', async function () {
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.country'])
         .returns(country);
       (await adb.getDeviceCountry()).should.equal(country);
       mocks.adb.verify();
     });
-    it('should call shell two times with correct args and return country', async () => {
+    it('should call shell two times with correct args and return country', async function () {
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.country'])
         .returns('');
@@ -453,7 +453,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('setDeviceCountry', withMocks({adb}, (mocks) => {
-    it('should call shell one time with correct args', async () => {
+    it('should call shell one time with correct args', async function () {
       mocks.adb.expects("getApiLevel")
         .once().returns(21);
       mocks.adb.expects("shell")
@@ -464,14 +464,14 @@ describe('Apk-utils', () => {
     });
   }));
   describe('getDeviceLocale', withMocks({adb}, (mocks) => {
-    it('should call shell one time with correct args and return locale', async () => {
+    it('should call shell one time with correct args and return locale', async function () {
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.locale'])
         .returns(locale);
       (await adb.getDeviceLocale()).should.equal(locale);
       mocks.adb.verify();
     });
-    it('should call shell two times with correct args and return locale', async () => {
+    it('should call shell two times with correct args and return locale', async function () {
       mocks.adb.expects("shell")
         .once().withExactArgs(['getprop', 'persist.sys.locale'])
         .returns('');
@@ -483,44 +483,44 @@ describe('Apk-utils', () => {
     });
   }));
   describe('ensureCurrentLocale', withMocks({adb}, (mocks) => {
-    it('should return false if no arguments', async() => {
+    it('should return false if no arguments', async function () {
       (await adb.ensureCurrentLocale()).should.be.false;
     });
-    it('should return true when API 22 and only language', async() => {
+    it('should return true when API 22 and only language', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
       mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");
       mocks.adb.expects("getDeviceCountry").withExactArgs().never();
       (await adb.ensureCurrentLocale("fr", null)).should.be.true;
       mocks.adb.verify();
     });
-    it('should return true when API 22 and only country', async() => {
+    it('should return true when API 22 and only country', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
       mocks.adb.expects("getDeviceCountry").withExactArgs().once().returns("FR");
       mocks.adb.expects("getDeviceLanguage").withExactArgs().never();
       (await adb.ensureCurrentLocale(null, "FR")).should.be.true;
       mocks.adb.verify();
     });
-    it('should return true when API 22', async() => {
+    it('should return true when API 22', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
       mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("fr");
       mocks.adb.expects("getDeviceCountry").withExactArgs().once().returns("FR");
       (await adb.ensureCurrentLocale('FR', 'fr')).should.be.true;
       mocks.adb.verify();
     });
-    it('should return false when API 22', async() => {
+    it('should return false when API 22', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(22);
       mocks.adb.expects("getDeviceLanguage").withExactArgs().once().returns("");
       mocks.adb.expects("getDeviceCountry").withExactArgs().once().returns("FR");
       (await adb.ensureCurrentLocale('en', 'US')).should.be.false;
       mocks.adb.verify();
     });
-    it('should return true when API 23', async() => {
+    it('should return true when API 23', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(23);
       mocks.adb.expects("getDeviceLocale").withExactArgs().once().returns("fr-FR");
       (await adb.ensureCurrentLocale('fr', 'fr')).should.be.true;
       mocks.adb.verify();
     });
-    it('should return false when API 23', async() => {
+    it('should return false when API 23', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs().once().returns(23);
       mocks.adb.expects("getDeviceLocale").withExactArgs().once().returns("");
       (await adb.ensureCurrentLocale('en', 'us')).should.be.false;
@@ -528,28 +528,28 @@ describe('Apk-utils', () => {
     });
   }));
   describe('setDeviceLocale', withMocks({adb}, (mocks) => {
-    it('should not call setDeviceLanguageCountry because of empty', async() => {
+    it('should not call setDeviceLanguageCountry because of empty', async function () {
       mocks.adb.expects('setDeviceLanguageCountry').never();
       await adb.setDeviceLocale();
       mocks.adb.verify();
     });
-    it('should not call setDeviceLanguageCountry because of invalid format no -', async() => {
+    it('should not call setDeviceLanguageCountry because of invalid format no -', async function () {
       mocks.adb.expects('setDeviceLanguageCountry').never();
       await adb.setDeviceLocale('jp');
       mocks.adb.verify();
     });
-    it('should not call setDeviceLanguageCountry because of invalid format /', async() => {
+    it('should not call setDeviceLanguageCountry because of invalid format /', async function () {
       mocks.adb.expects('setDeviceLanguageCountry').never();
       await adb.setDeviceLocale('en/US');
       mocks.adb.verify();
     });
-    it('should call setDeviceLanguageCountry', async() => {
+    it('should call setDeviceLanguageCountry', async function () {
       mocks.adb.expects('setDeviceLanguageCountry').withExactArgs(language, country)
           .once().returns("");
       await adb.setDeviceLocale('en-US');
       mocks.adb.verify();
     });
-    it('should call setDeviceLanguageCountry with degits for country', async() => {
+    it('should call setDeviceLanguageCountry with degits for country', async function () {
       mocks.adb.expects('setDeviceLanguageCountry').withExactArgs(language, country + "0")
           .once().returns("");
       await adb.setDeviceLocale('en-US0');
@@ -557,7 +557,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('setDeviceLanguageCountry', withMocks({adb}, (mocks) => {
-    it('should return if language and country are not passed', async () => {
+    it('should return if language and country are not passed', async function () {
       mocks.adb.expects('getDeviceLanguage').never();
       mocks.adb.expects('getDeviceCountry').never();
       mocks.adb.expects('getDeviceLocale').never();
@@ -568,7 +568,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry();
       mocks.adb.verify();
     });
-    it('should set language, country and reboot the device when API < 23', async () => {
+    it('should set language, country and reboot the device when API < 23', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(22);
       mocks.adb.expects("getDeviceLanguage").withExactArgs()
@@ -584,7 +584,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry(language, country);
       mocks.adb.verify();
     });
-    it('should not set language and country if it does not change when API < 23', async () => {
+    it('should not set language and country if it does not change when API < 23', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(22);
       mocks.adb.expects('getDeviceLanguage').once().returns('en');
@@ -597,7 +597,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry(language.toLowerCase(), country.toLowerCase());
       mocks.adb.verify();
     });
-    it('should set locale when API is 23', async () => {
+    it('should set locale when API is 23', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(23);
       mocks.adb.expects("getDeviceLocale").withExactArgs()
@@ -609,7 +609,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry(language, country);
       mocks.adb.verify();
     });
-    it('should not set language and country if it does not change when API is 23', async () => {
+    it('should not set language and country if it does not change when API is 23', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(23);
       mocks.adb.expects("getDeviceLocale").withExactArgs()
@@ -619,7 +619,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry(language, country);
       mocks.adb.verify();
     });
-    it('should call set locale via setting app when API 24+', async () => {
+    it('should call set locale via setting app when API 24+', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(24);
       mocks.adb.expects("getDeviceLocale").withExactArgs()
@@ -630,7 +630,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry(language, country);
       mocks.adb.verify();
     });
-    it('should not set language and country if it does not change when API 24+', async () => {
+    it('should not set language and country if it does not change when API 24+', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(24);
       mocks.adb.expects("getDeviceLocale").withExactArgs()
@@ -640,7 +640,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry(language, country);
       mocks.adb.verify();
     });
-    it('should not set language and country if no language when API 24+', async () => {
+    it('should not set language and country if no language when API 24+', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(24);
       mocks.adb.expects("getDeviceLocale").withExactArgs()
@@ -650,7 +650,7 @@ describe('Apk-utils', () => {
       await adb.setDeviceLanguageCountry(country);
       mocks.adb.verify();
     });
-    it('should not set language and country if no country when API 24+', async () => {
+    it('should not set language and country if no country when API 24+', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(24);
       mocks.adb.expects("getDeviceLocale").withExactArgs()
@@ -662,7 +662,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('getApkInfo', withMocks({adb, teen_process, fs}, (mocks) => {
-    it('should properly parse apk info', async () => {
+    it('should properly parse apk info', async function () {
       mocks.fs.expects('exists').once().returns(true);
       mocks.adb.expects('initAapt').once().returns(true);
       mocks.teen_process.expects('exec').once().returns({stdout: `package: name='io.appium.settings' versionCode='2' versionName='1.1' platformBuildVersionName='6.0-2166767'
@@ -712,7 +712,7 @@ describe('Apk-utils', () => {
     });
   }));
   describe('getPackageInfo', withMocks({adb}, (mocks) => {
-    it('should properly parse installed package info', async () => {
+    it('should properly parse installed package info', async function () {
       mocks.adb.expects('shell').once().returns(`Packages:
       Package [com.example.testapp.first] (2036fd1):
         userId=10225
@@ -751,7 +751,7 @@ describe('Apk-utils', () => {
     const pkgId = 'io.appium.settings';
     const apkPath = '/path/to/my.apk';
 
-    it('should execute install if the package is not present', async () => {
+    it('should execute install if the package is not present', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId
       });
@@ -760,7 +760,7 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
-    it('should return if the same package version is already installed', async () => {
+    it('should return if the same package version is already installed', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         versionCode: 1
       });
@@ -771,7 +771,7 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath, pkgId);
       mocks.adb.verify();
     });
-    it('should return if newer package version is already installed', async () => {
+    it('should return if newer package version is already installed', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 1
@@ -783,7 +783,7 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
-    it('should not throw an error if apk version code cannot be read', async () => {
+    it('should not throw an error if apk version code cannot be read', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId
       });
@@ -794,7 +794,7 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
-    it('should not throw an error if pkg version code cannot be read', async () => {
+    it('should not throw an error if pkg version code cannot be read', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 1
@@ -804,12 +804,12 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
-    it('should not throw an error if pkg id cannot be read', async () => {
+    it('should not throw an error if pkg id cannot be read', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({});
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
-    it('should perform upgrade if older package version is installed', async () => {
+    it('should perform upgrade if older package version is installed', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 2
@@ -822,7 +822,7 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
-    it('should uninstall and re-install if older package version is installed and upgrade fails', async () => {
+    it('should uninstall and re-install if older package version is installed and upgrade fails', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 2
@@ -837,7 +837,7 @@ describe('Apk-utils', () => {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
-    it('should throw an exception if upgrade and reinstall fail', async () => {
+    it('should throw an exception if upgrade and reinstall fail', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 2
@@ -857,7 +857,7 @@ describe('Apk-utils', () => {
       isExceptionThrown.should.be.true;
       mocks.adb.verify();
     });
-    it('should throw an exception if upgrade and uninstall fail', async () => {
+    it('should throw an exception if upgrade and uninstall fail', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,
         versionCode: 2

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -6,7 +6,7 @@ import path from 'path';
 import _ from 'lodash';
 
 
-describe('helpers', () => {
+describe('helpers', function () {
   describe('getAndroidPlatformAndPath', withMocks({fs}, (mocks) => {
     let oldAndroidHome;
     let oldResolve;
@@ -62,56 +62,56 @@ describe('helpers', () => {
     });
   }));
 
-  describe('isShowingLockscreen', () => {
-    it('should return true if mShowingLockscreen is true', async () => {
+  describe('isShowingLockscreen', function () {
+    it('should return true if mShowingLockscreen is true', async function () {
       let dumpsys = 'mShowingLockscreen=true mShowingDream=false mDreamingLockscreen=false mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.true;
     });
-    it('should return true if mDreamingLockscreen is true', async () => {
+    it('should return true if mDreamingLockscreen is true', async function () {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=true mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.true;
     });
-    it('should return false if mShowingLockscreen and mDreamingLockscreen are false', async () => {
+    it('should return false if mShowingLockscreen and mDreamingLockscreen are false', async function () {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=false mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
-    it('should assume that screen is unlocked if can not determine lock state', async () => {
+    it('should assume that screen is unlocked if can not determine lock state', async function () {
       let dumpsys = 'mShowingDream=false mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
   });
 
-  describe('buildStartCmd', () => {
+  describe('buildStartCmd', function () {
     let startOptions = {
       pkg: 'com.something',
       activity: '.SomeActivity'
     };
 
-    it('should parse optionalIntentArguments with single key', () => {
+    it('should parse optionalIntentArguments with single key', function () {
       let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key'}, startOptions), 20);
       cmd[cmd.length-2].should.eql('-d');
       cmd[cmd.length-1].should.eql('key');
     });
-    it('should parse optionalIntentArguments with single key/value pair', () => {
+    it('should parse optionalIntentArguments with single key/value pair', function () {
       let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key value'}, startOptions), 20);
       cmd[cmd.length-3].should.eql('-d');
       cmd[cmd.length-2].should.eql('key');
       cmd[cmd.length-1].should.eql('value');
     });
-    it('should parse optionalIntentArguments with single key/value pair with spaces', () => {
+    it('should parse optionalIntentArguments with single key/value pair with spaces', function () {
       let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key value value2'}, startOptions), 20);
       cmd[cmd.length-3].should.eql('-d');
       cmd[cmd.length-2].should.eql('key');
       cmd[cmd.length-1].should.eql('value value2');
     });
-    it('should parse optionalIntentArguments with multiple keys', () => {
+    it('should parse optionalIntentArguments with multiple keys', function () {
       let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key1 -e key2'}, startOptions), 20);
       cmd[cmd.length-4].should.eql('-d');
       cmd[cmd.length-3].should.eql('key1');
       cmd[cmd.length-2].should.eql('-e');
       cmd[cmd.length-1].should.eql('key2');
     });
-    it('should parse optionalIntentArguments with multiple key/value pairs', () => {
+    it('should parse optionalIntentArguments with multiple key/value pairs', function () {
       let cmd = buildStartCmd(_.defaults({optionalIntentArguments: '-d key1 value1 -e key2 value2'}, startOptions), 20);
       cmd[cmd.length-6].should.eql('-d');
       cmd[cmd.length-5].should.eql('key1');
@@ -120,13 +120,13 @@ describe('helpers', () => {
       cmd[cmd.length-2].should.eql('key2');
       cmd[cmd.length-1].should.eql('value2');
     });
-    it('should parse optionalIntentArguments with hyphens', () => {
+    it('should parse optionalIntentArguments with hyphens', function () {
       let arg = 'http://some-url-with-hyphens.com/';
       let cmd = buildStartCmd(_.defaults({optionalIntentArguments: `-d ${arg}`}, startOptions), 20);
       cmd[cmd.length-2].should.eql('-d');
       cmd[cmd.length-1].should.eql(arg);
     });
-    it('should parse optionalIntentArguments with multiple arguments with hyphens', () => {
+    it('should parse optionalIntentArguments with multiple arguments with hyphens', function () {
       let arg1 = 'http://some-url-with-hyphens.com/';
       let arg2 = 'http://some-other-url-with-hyphens.com/';
       let cmd = buildStartCmd(_.defaults({
@@ -138,11 +138,11 @@ describe('helpers', () => {
       cmd[cmd.length-2].should.eql('key');
       cmd[cmd.length-1].should.eql(arg2);
     });
-    it('should have -S option when stopApp is set', async () => {
+    it('should have -S option when stopApp is set', async function () {
       let cmd = buildStartCmd(_.defaults({stopApp: true}, startOptions), 20);
       cmd[cmd.length-1].should.eql('-S');
     });
-    it('should not have -S option when stopApp is not set', async () => {
+    it('should not have -S option when stopApp is not set', async function () {
       let cmd = buildStartCmd(_.defaults({stopApp: false}, startOptions), 20);
       cmd[cmd.length-1].should.not.eql('-S');
     });

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -13,7 +13,7 @@ adb.executable.path = 'adb_path';
 const avdName = 'AVD_NAME';
 
 describe('System calls', withMocks({teen_process}, (mocks) => {
-  it('getConnectedDevices should get all connected devices', async () => {
+  it('getConnectedDevices should get all connected devices', async function () {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"List of devices attached \n emulator-5554	device"});
@@ -21,7 +21,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  it('getConnectedDevices should get all connected devices which have valid udid', async () => {
+  it('getConnectedDevices should get all connected devices which have valid udid', async function () {
     let stdoutValue = "List of devices attached \n" +
                       "adb server version (32) doesn't match this client (36); killing...\n" +
                       "* daemon started successfully *\n" +
@@ -34,7 +34,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  it('getConnectedDevices should fail when adb devices returns unexpected output', async () => {
+  it('getConnectedDevices should fail when adb devices returns unexpected output', async function () {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"foobar"});
@@ -51,7 +51,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
                                        .rejectedWith("Could not find a connected Android device.");
     mocks.teen_process.verify();
   });
-  it('getDevicesWithRetry should fail when adb devices returns unexpected output', async () => {
+  it('getDevicesWithRetry should fail when adb devices returns unexpected output', async function () {
     mocks.teen_process.expects("exec")
       .atLeast(2).withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"foobar"});
@@ -59,7 +59,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
                                        .rejectedWith("Could not find a connected Android device.");
     mocks.teen_process.verify();
   });
-  it('getDevicesWithRetry should get all connected devices', async () => {
+  it('getDevicesWithRetry should get all connected devices', async function () {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices'])
       .returns({stdout:"List of devices attached \n emulator-5554	device"});
@@ -67,7 +67,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  it('getDevicesWithRetry should get all connected devices second time', async () => {
+  it('getDevicesWithRetry should get all connected devices second time', async function () {
     mocks.teen_process.expects("exec")
       .onCall(0)
       .returns({stdout:"Foobar"});
@@ -78,7 +78,7 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
     devices.should.have.length.above(0);
     mocks.teen_process.verify();
   });
-  it('getDevicesWithRetry should fail when exec throws an error', async () => {
+  it('getDevicesWithRetry should fail when exec throws an error', async function () {
     mocks.teen_process.expects("exec")
       .atLeast(2)
       .throws("Error foobar");
@@ -86,30 +86,30 @@ describe('System calls', withMocks({teen_process}, (mocks) => {
                                        .rejectedWith("Could not find a connected Android device.");
     mocks.teen_process.verify();
   });
-  it('setDeviceId should set the device id', () => {
+  it('setDeviceId should set the device id', function () {
     adb.setDeviceId('foobar');
     adb.curDeviceId.should.equal('foobar');
     adb.executable.defaultArgs.should.include('foobar');
   });
-  it('setDevice should set the device id and emu port from obj', () => {
+  it('setDevice should set the device id and emu port from obj', function () {
     adb.setDevice({udid: 'emulator-1234'});
     adb.curDeviceId.should.equal('emulator-1234');
     adb.executable.defaultArgs.should.include('emulator-1234');
     adb.emulatorPort.should.equal(1234);
   });
-  it('setEmulatorPort should change emulator port', () => {
+  it('setEmulatorPort should change emulator port', function () {
     adb.setEmulatorPort(5554);
     adb.emulatorPort.should.equal(5554);
   });
-  describe('createSubProcess', () => {
-    it('should return an instance of SubProcess', () => {
+  describe('createSubProcess', function () {
+    it('should return an instance of SubProcess', function () {
       adb.createSubProcess([]).should.be.an.instanceof(teen_process.SubProcess);
     });
   });
 }));
 
 describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
-  it('should return adb version', async () => {
+  it('should return adb version', async function () {
     mocks.adb.expects("adbExec")
       .once()
       .withExactArgs('version')
@@ -122,7 +122,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     adbVersion.patch.should.equal(39);
     mocks.adb.verify();
   });
-  it('should cache adb results', async () => {
+  it('should cache adb results', async function () {
     adb.getAdbVersion.cache = new _.memoize.Cache();
     mocks.adb.expects("adbExec")
       .once()
@@ -132,14 +132,14 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     await adb.getAdbVersion();
     mocks.adb.verify();
   });
-  it('fileExists should return true for if ls returns', async () => {
+  it('fileExists should return true for if ls returns', async function () {
     mocks.adb.expects("ls")
       .once().withExactArgs('foo')
       .returns(['bar']);
     await adb.fileExists("foo").should.eventually.equal(true);
     mocks.adb.verify();
   });
-  it('ls should return list', async () => {
+  it('ls should return list', async function () {
     mocks.adb.expects("shell")
       .once().withExactArgs(['ls', 'foo'])
       .returns('bar');
@@ -163,7 +163,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     let size = await adb.fileSize(remotePath);
     size.should.eql(39571);
   });
-  it('reboot should call stop and start using shell', async () => {
+  it('reboot should call stop and start using shell', async function () {
     mocks.adb.expects("shell")
       .once().withExactArgs(['stop']);
     mocks.adb.expects("setDeviceProperty")
@@ -179,7 +179,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     mocks.adb.verify();
     mocks.B.verify();
   });
-  it('reboot should restart adbd as root if necessary', async () => {
+  it('reboot should restart adbd as root if necessary', async function () {
     mocks.teen_process.expects("exec")
       .once().withExactArgs(adb.executable.path, ['root'])
       .returns(false);
@@ -201,7 +201,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     mocks.adb.verify();
     mocks.B.verify();
   });
-  it('getRunningAVD should get connected avd', async () => {
+  it('getRunningAVD should get connected avd', async function () {
     let udid = 'emulator-5554';
     let port = 5554;
     let emulator = {udid, port};
@@ -218,7 +218,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     (await adb.getRunningAVD(avdName)).should.equal(emulator);
     mocks.adb.verify();
   });
-  it('getRunningAVD should return null when expected avd is not connected', async () => {
+  it('getRunningAVD should return null when expected avd is not connected', async function () {
     let udid = 'emulator-5554';
     let port = 5554;
     let emulator = {udid, port};
@@ -233,7 +233,7 @@ describe('System calls',  withMocks({adb, B, teen_process}, (mocks) => {
     chai.expect(await adb.getRunningAVD(avdName)).to.be.null;
     mocks.adb.verify();
   });
-  it('getRunningAVD should return null when no avd is connected', async () => {
+  it('getRunningAVD should return null when no avd is connected', async function () {
     mocks.adb.expects("getConnectedEmulators")
       .once().withExactArgs()
       .returns([]);


### PR DESCRIPTION
Add a gulp task for fixing eslint. And fix the arrow functions in mocha.