### PR TITLE
Extend apk installation options

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -278,21 +278,53 @@ apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = 
 };
 
 /**
+ * @typedef {Object} InstallOptions
+ * @property {number} timeout [60000] - The count of milliseconds to wait until the
+ *                                      app is installed.
+ * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
+ *                                                 packages installation.
+ * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
+ *                                         instead of the device memory.
+ * @property {boolean} grantPermissions [false] - Set to true in order to grant all
+ *                                                all application permissions automatically
+ *                                                after it is installed.
+ * @property {boolean} replace [true] - Set it to false if you don't want
+ *                                      the application to be upgraded.rewritten
+ *                                      if it is already installed.
+ */
+
+/**
  * Install the package from the local file system.
  *
  * @param {string} apk - The full path to the local package.
  * @param {boolean} repalce [true] - Whether to replace the package if it
  *                                   already installed. True by default.
- * @param {number} timeout [60000] - The number of milliseconds to wait until
- *                                   installation is completed.
+ * @param {?InstallOptions} options - The set of installation options.
  * @throws {error} If an unexpected error happens during install.
  */
-apkUtilsMethods.install = async function (apk, replace = true, timeout = 60000) {
-  if (replace) {
-    await this.adbExec(['install', '-r', apk], {timeout});
+apkUtilsMethods.install = async function (apk, options = {replace: true, timeout: 60000}) {
+  const additionalArgs = [];
+  if (options.allowTestPackages) {
+    additionalArgs.push('t');
+  }
+  if (options.useSdcard) {
+    additionalArgs.push('s');
+  }
+  if (options.grantPermissions) {
+    additionalArgs.push('g');
+  }
+
+  if (options.replace) {
+    await this.adbExec(['install', `-r${additionalArgs.join('')}`, apk],
+                       {timeout: options.timeout});
   } else {
     try {
-      await this.adbExec(['install', apk], {timeout});
+      const installCmd = ['install'];
+      if (!_.isEmpty(additionalArgs)) {
+        installCmd.push(`-${additionalArgs.join('')}`);
+      }
+      installCmd.push(apk);
+      await this.adbExec(installCmd, {timeout: options.timeout});
     } catch (err) {
       // on some systems this will throw an error if the app already
       // exists
@@ -305,17 +337,29 @@ apkUtilsMethods.install = async function (apk, replace = true, timeout = 60000) 
 };
 
 /**
+ * @typedef {Object} InstallOrUpgradeOptions
+ * @property {number} timeout [60000] - The count of milliseconds to wait until the
+ *                                      app is installed.
+ * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
+ *                                                 packages installation.
+ * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
+ *                                         instead of the device memory.
+ * @property {boolean} grantPermissions [false] - Set to true in order to grant all
+ *                                                all application permissions automatically
+ *                                                after it is installed.
+ */
+
+/**
  * Install the package from the local file system of upgrade it if an older
  * version of the same package is already installed.
  *
  * @param {string} apk - The full path to the local package.
  * @param {?string} pkg - The name of the installed package. The method will
  *                        perform faster if it is set.
- * @param {?number} timeout [60000] - The number of milliseconds to wait until
- *                                   installation is completed.
+ * @param {?InstallOrUpgradeOptions} options - Set of install options.
  * @throws {error} If an unexpected error happens during install.
  */
-apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60000) {
+apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {timeout: 60000}) {
   let apkInfo = null;
   if (!pkg) {
     apkInfo = await this.getApkInfo(apk);
@@ -328,7 +372,7 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60
 
   if (!await this.isAppInstalled(pkg)) {
     log.debug(`App '${apk}' not installed. Installing`);
-    await this.install(apk, false, timeout);
+    await this.install(apk, Object.assign({replace: false}, options));
     return;
   }
 
@@ -350,13 +394,13 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, timeout = 60
   log.debug(`The installed '${pkg}' package is older than '${apk}' (${pkgVersionCode} < ${apkVersionCode}). ` +
             `Executing upgrade`);
   try {
-    await this.install(apk, true, timeout);
+    await this.install(apk, Object.assign({replace: true}, options));
   } catch (err) {
     log.warn(`Cannot upgrade '${pkg}' because of '${err.message}'. Trying full reinstall`);
     if (!await this.uninstallApk(pkg)) {
       log.errorAndThrow(`'${pkg}' package cannot be uninstalled`);
     }
-    await this.install(apk, false, timeout);
+    await this.install(apk, Object.assign({replace: false}, options));
   }
 };
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -370,11 +370,10 @@ apkUtilsMethods.install = async function (apk, options = {}) {
  *                                                 packages installation.
  * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
  *                                         instead of the device memory.
- * @property {boolean} grantPermissions [false] - Set to true in order to grant all
- *                                                all application permissions automatically
- *                                                after it is installed. Unfortunately,
- *                                                this option does not always work as expected
- *                                                (see https://github.com/appium/appium-adb/pull/173).
+ * @property {boolean} grantPermissions [false] - Set to true in order to grant all the
+ *                                                permissions requested in the application's manifest
+ *                                                automatically after the installation is completed
+ *                                                under Android 6+.
  */
 
 /**

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -233,28 +233,47 @@ apkUtilsMethods.waitForNotActivity = async function (pkg, act, waitMs = 20000) {
 };
 
 /**
+ * @typedef {Object} UninstallOptions
+ * @property {number} timeout [20000] - The count of milliseconds to wait until the
+ *                                      app is uninstalled.
+ * @property {boolean} keepData [false] - Set to true in order to keep the
+ *                                        application data and cache folders after uninstall.
+ */
+
+/**
  * Uninstall the given package from the device under test.
  *
  * @param {string} pkg - The name of the package to be uninstalled.
+ * @param {?UninstallOptions} options - The set of uninstallation options.
  * @return {boolean} True if the package was found on the device and
  *                   successfully uninstalled.
  */
-apkUtilsMethods.uninstallApk = async function (pkg) {
+apkUtilsMethods.uninstallApk = async function (pkg, options = {}) {
   log.debug(`Uninstalling ${pkg}`);
   if (!await this.isAppInstalled(pkg)) {
     log.info(`${pkg} was not uninstalled, because it was not present on the device`);
     return false;
   }
+
+  let timeout = 20000;
+  if (util.hasValue(options.timeout) && !isNaN(options.timeout)) {
+    timeout = parseInt(options.timeout, 10);
+  }
+  const cmd = ['uninstall'];
+  if (options.keepData) {
+    cmd.push('-k');
+  }
+  cmd.push(pkg);
+
   let stdout;
   try {
     await this.forceStop(pkg);
-    stdout = await this.adbExec(['uninstall', pkg], {timeout: 20000});
+    stdout = (await this.adbExec(cmd, {timeout})).trim();
   } catch (e) {
     log.errorAndThrow(`Unable to uninstall APK. Original error: ${e.message}`);
   }
-  stdout = stdout.trim();
-  log.debug(`ADB command output: ${stdout}`);
-  if (stdout.indexOf("Success") !== -1) {
+  log.debug(`'adb ${cmd.join(' ')}' command output: ${stdout}`);
+  if (stdout.includes("Success")) {
     log.info(`${pkg} was successfully uninstalled`);
     return true;
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -4,7 +4,7 @@ import log from '../logger.js';
 import path from 'path';
 import _ from 'lodash';
 import { retryInterval } from 'asyncbox';
-import { fs } from 'appium-support';
+import { fs, util } from 'appium-support';
 
 
 let apkUtilsMethods = {};
@@ -277,6 +277,8 @@ apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = 
   }
 };
 
+const APK_INSTALL_TIMEOUT = 60000;
+
 /**
  * @typedef {Object} InstallOptions
  * @property {number} timeout [60000] - The count of milliseconds to wait until the
@@ -302,7 +304,14 @@ apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = 
  * @param {?InstallOptions} options - The set of installation options.
  * @throws {error} If an unexpected error happens during install.
  */
-apkUtilsMethods.install = async function (apk, options = {replace: true, timeout: 60000}) {
+apkUtilsMethods.install = async function (apk, options = {}) {
+  if (!util.hasValue(options.replace)) {
+    options.replace = true;
+  }
+  if (!util.hasValue(options.timeout)) {
+    options.timeout = APK_INSTALL_TIMEOUT;
+  }
+
   const additionalArgs = [];
   if (options.allowTestPackages) {
     additionalArgs.push('t');
@@ -359,7 +368,11 @@ apkUtilsMethods.install = async function (apk, options = {replace: true, timeout
  * @param {?InstallOrUpgradeOptions} options - Set of install options.
  * @throws {error} If an unexpected error happens during install.
  */
-apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {timeout: 60000}) {
+apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {}) {
+  if (!util.hasValue(options.timeout)) {
+    options.timeout = APK_INSTALL_TIMEOUT;
+  }
+
   let apkInfo = null;
   if (!pkg) {
     apkInfo = await this.getApkInfo(apk);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -289,7 +289,9 @@ const APK_INSTALL_TIMEOUT = 60000;
  *                                         instead of the device memory.
  * @property {boolean} grantPermissions [false] - Set to true in order to grant all
  *                                                all application permissions automatically
- *                                                after it is installed.
+ *                                                after it is installed.  Unfortunately,
+ *                                                this option does not always work as expected
+ *                                                (see https://github.com/appium/appium-adb/pull/173).
  * @property {boolean} replace [true] - Set it to false if you don't want
  *                                      the application to be upgraded/reinstalled
  *                                      if it is already installed.
@@ -355,7 +357,9 @@ apkUtilsMethods.install = async function (apk, options = {}) {
  *                                         instead of the device memory.
  * @property {boolean} grantPermissions [false] - Set to true in order to grant all
  *                                                all application permissions automatically
- *                                                after it is installed.
+ *                                                after it is installed. Unfortunately,
+ *                                                this option does not always work as expected
+ *                                                (see https://github.com/appium/appium-adb/pull/173).
  */
 
 /**

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -240,6 +240,8 @@ apkUtilsMethods.waitForNotActivity = async function (pkg, act, waitMs = 20000) {
  *                                        application data and cache folders after uninstall.
  */
 
+const APK_UNINSTALL_TIMEOUT = 20000;
+
 /**
  * Uninstall the given package from the device under test.
  *
@@ -255,7 +257,7 @@ apkUtilsMethods.uninstallApk = async function (pkg, options = {}) {
     return false;
   }
 
-  let timeout = 20000;
+  let timeout = APK_UNINSTALL_TIMEOUT;
   if (util.hasValue(options.timeout) && !isNaN(options.timeout)) {
     timeout = parseInt(options.timeout, 10);
   }
@@ -329,36 +331,31 @@ apkUtilsMethods.install = async function (apk, options = {}) {
   if (!util.hasValue(options.replace)) {
     options.replace = true;
   }
-  if (!util.hasValue(options.timeout)) {
-    options.timeout = APK_INSTALL_TIMEOUT;
+  let timeout = APK_INSTALL_TIMEOUT;
+  if (util.hasValue(options.timeout) && !isNaN(options.timeout)) {
+    timeout = parseInt(options.timeout, 10);
   }
 
   const additionalArgs = [];
   if (options.allowTestPackages) {
-    additionalArgs.push('t');
+    additionalArgs.push('-t');
   }
   if (options.useSdcard) {
-    additionalArgs.push('s');
+    additionalArgs.push('-s');
   }
   if (options.grantPermissions) {
-    additionalArgs.push('g');
+    additionalArgs.push('-g');
   }
 
   if (options.replace) {
-    await this.adbExec(['install', `-r${additionalArgs.join('')}`, apk],
-                       {timeout: options.timeout});
+    await this.adbExec(['install', '-r', ...additionalArgs, apk], {timeout});
   } else {
     try {
-      const installCmd = ['install'];
-      if (!_.isEmpty(additionalArgs)) {
-        installCmd.push(`-${additionalArgs.join('')}`);
-      }
-      installCmd.push(apk);
-      await this.adbExec(installCmd, {timeout: options.timeout});
+      await this.adbExec(['install', ...additionalArgs, apk], {timeout});
     } catch (err) {
       // on some systems this will throw an error if the app already
       // exists
-      if (err.message.indexOf('INSTALL_FAILED_ALREADY_EXISTS') === -1) {
+      if (!err.message.includes('INSTALL_FAILED_ALREADY_EXISTS')) {
         throw err;
       }
       log.debug(`Application '${apk}' already installed. Continuing.`);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -291,7 +291,7 @@ const APK_INSTALL_TIMEOUT = 60000;
  *                                                all application permissions automatically
  *                                                after it is installed.
  * @property {boolean} replace [true] - Set it to false if you don't want
- *                                      the application to be upgraded.rewritten
+ *                                      the application to be upgraded/reinstalled
  *                                      if it is already installed.
  */
 
@@ -385,7 +385,7 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {}
 
   if (!await this.isAppInstalled(pkg)) {
     log.debug(`App '${apk}' not installed. Installing`);
-    await this.install(apk, Object.assign({replace: false}, options));
+    await this.install(apk, Object.assign({}, options, {replace: false}));
     return;
   }
 
@@ -407,13 +407,13 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {}
   log.debug(`The installed '${pkg}' package is older than '${apk}' (${pkgVersionCode} < ${apkVersionCode}). ` +
             `Executing upgrade`);
   try {
-    await this.install(apk, Object.assign({replace: true}, options));
+    await this.install(apk, Object.assign({}, options, {replace: true}));
   } catch (err) {
     log.warn(`Cannot upgrade '${pkg}' because of '${err.message}'. Trying full reinstall`);
     if (!await this.uninstallApk(pkg)) {
       log.errorAndThrow(`'${pkg}' package cannot be uninstalled`);
     }
-    await this.install(apk, Object.assign({replace: false}, options));
+    await this.install(apk, Object.assign({}, options, {replace: false}));
   }
 };
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -308,14 +308,13 @@ const APK_INSTALL_TIMEOUT = 60000;
  *                                                 packages installation.
  * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
  *                                         instead of the device memory.
- * @property {boolean} grantPermissions [false] - Set to true in order to grant all
- *                                                all application permissions automatically
- *                                                after it is installed.  Unfortunately,
- *                                                this option does not always work as expected
- *                                                (see https://github.com/appium/appium-adb/pull/173).
+ * @property {boolean} grantPermissions [false] - Set to true in order to grant all the
+ *                                                permissions requested in the application's manifest
+ *                                                automatically after the installation is completed
+ *                                                under Android 6+.
  * @property {boolean} replace [true] - Set it to false if you don't want
  *                                      the application to be upgraded/reinstalled
- *                                      if it is already installed.
+ *                                      if it is already present on the device.
  */
 
 /**

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -328,7 +328,7 @@ describe('Apk-utils', function () {
       mocks.adb.expects('adbExec')
         .once().withExactArgs(['install', 'foo'], {timeout: 60000})
         .returns('');
-      (await adb.install('foo', false));
+      (await adb.install('foo', {replace: false}));
       mocks.adb.verify();
     });
   }));
@@ -756,7 +756,7 @@ describe('Apk-utils', function () {
         name: pkgId
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(false);
-      mocks.adb.expects('install').withArgs(apkPath, false).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath).once().returns(true);
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
@@ -818,7 +818,7 @@ describe('Apk-utils', function () {
         versionCode: 1
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, true).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, {replace: true, timeout: 60000}).once().returns(true);
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
@@ -831,9 +831,9 @@ describe('Apk-utils', function () {
         versionCode: 1
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, true).once().throws();
+      mocks.adb.expects('install').withArgs(apkPath, {replace: true, timeout: 60000}).once().throws();
       mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, false).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, {replace: false, timeout: 60000}).once().returns(true);
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
@@ -867,7 +867,7 @@ describe('Apk-utils', function () {
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns(false);
-      mocks.adb.expects('install').withArgs(apkPath, true).once().throws();
+      mocks.adb.expects('install').withArgs(apkPath).once().throws();
       let isExceptionThrown = false;
       try {
         await adb.installOrUpgrade(apkPath);


### PR DESCRIPTION
Granting permissions with `pm grant` takes quite a lot of time, however `adb install` utility has -g command line  argument, which allows to do it much faster and also does not require us to parse the  package info. This PR changes public method interface, so the module should become a higher major version number after it is merged.