### PR TITLE
Ignore grantPermissions option on install for Android API level older than 23

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -343,7 +343,14 @@ apkUtilsMethods.install = async function (apk, options = {}) {
     additionalArgs.push('-s');
   }
   if (options.grantPermissions) {
-    additionalArgs.push('-g');
+    const apiLevel = await this.getApiLevel();
+    if (apiLevel < 23) {
+      log.debug(`Skipping granting permissions for '${apk}', since ` +
+                `the current API level ${apiLevel} does not support applications ` +
+                `permissions customization`);
+    } else {
+      additionalArgs.push('-g');
+    }
   }
 
   if (options.replace) {


### PR DESCRIPTION
This should fix functional tests for https://github.com/appium/appium-android-driver/pull/319