### PR TITLE
Log the output of `adb install` command

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -354,10 +354,12 @@ apkUtilsMethods.install = async function (apk, options = {}) {
   }
 
   if (options.replace) {
-    await this.adbExec(['install', '-r', ...additionalArgs, apk], {timeout});
+    const output = await this.adbExec(['install', '-r', ...additionalArgs, apk], {timeout});
+    log.debug(`Install command stdout: ${output}`);
   } else {
     try {
-      await this.adbExec(['install', ...additionalArgs, apk], {timeout});
+      const output = await this.adbExec(['install', ...additionalArgs, apk], {timeout});
+      log.debug(`Install command stdout: ${output}`);
     } catch (err) {
       // on some systems this will throw an error if the app already
       // exists


### PR DESCRIPTION
Sometimes this bloody tool fails to do what it is supposed to do, and the return code is still zero and the error description is printed into stdout instead of stderr.