### PR TITLE
Tune upgrade verification logic

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -438,7 +438,7 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {}
   // Check version names in case if version codes are not being updated properly
   if (_.isString(apkVersionName) && _.isString(pkgVersionName)) {
     if (semver.satisfies(pkgVersionName, `>=${apkVersionName}`)) {
-      log.debug(`The installed '${pkg}' package does not require upgrade (${pkgVersionName} >= ${apkVersionName})`);
+      log.debug(`The installed '${pkg}' package does not require upgrade ('${pkgVersionName}' >= '${apkVersionName}')`);
       return;
     }
   } else if (_.isNumber(apkVersionCode) && _.isNumber(pkgVersionCode) && pkgVersionCode === apkVersionCode) {
@@ -446,7 +446,8 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {}
     return;
   }
 
-  log.debug(`The installed '${pkg}' package is older than '${apk}' (${pkgVersionCode} < ${apkVersionCode}). ` +
+  log.debug(`The installed '${pkg}' package is older than '${apk}' ` +
+            `(${pkgVersionCode} < ${apkVersionCode} or '${pkgVersionName}' < '${apkVersionName}')'. ` +
             `Executing upgrade`);
   try {
     await this.install(apk, Object.assign({}, options, {replace: true}));

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -5,7 +5,7 @@ import path from 'path';
 import _ from 'lodash';
 import { retryInterval } from 'asyncbox';
 import { fs, util } from 'appium-support';
-
+import semver from 'semver';
 
 let apkUtilsMethods = {};
 
@@ -416,21 +416,36 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {}
     return;
   }
 
-  const pkgInfo = await this.getPackageInfo(pkg);
-  const pkgVersionCode = pkgInfo.versionCode;
+  const {versionCode:pkgVersionCode, versionName:pkgVersionNameStr} = await this.getPackageInfo(pkg);
+  const pkgVersionName = semver.valid(semver.coerce(pkgVersionNameStr));
   if (!apkInfo) {
     apkInfo = await this.getApkInfo(apk);
   }
-  const apkVersionCode = apkInfo.versionCode;
+  const {versionCode:apkVersionCode, versionName:apkVersionNameStr} = apkInfo;
+  const apkVersionName = semver.valid(semver.coerce(apkVersionNameStr));
 
-  if (_.isUndefined(apkVersionCode) || _.isUndefined(pkgVersionCode)) {
-    log.warn(`Cannot read version codes of '${apk}' and/or '${pkg}'. Assuming correct app version is already installed`);
+  if (!_.isNumber(apkVersionCode) || !_.isNumber(pkgVersionCode)) {
+    log.warn(`Cannot read version codes of '${apk}' and/or '${pkg}'`);
+    if (!_.isString(apkVersionName) || !_.isString(pkgVersionName)) {
+      log.warn(`Cannot read version names of '${apk}' and/or '${pkg}'. Assuming correct app version is already installed`);
+      return;
+    }
+  }
+  if (_.isNumber(apkVersionCode) && _.isNumber(pkgVersionCode) && pkgVersionCode > apkVersionCode) {
+    log.debug(`The installed '${pkg}' package does not require upgrade (${pkgVersionCode} > ${apkVersionCode})`);
     return;
   }
-  if (pkgVersionCode >= apkVersionCode) {
-    log.debug(`The installed '${pkg}' package does not require upgrade (${pkgVersionCode} >= ${apkVersionCode})`);
+  // Check version names in case if version codes are not being updated properly
+  if (_.isString(apkVersionName) && _.isString(pkgVersionName)) {
+    if (semver.satisfies(pkgVersionName, `>=${apkVersionName}`)) {
+      log.debug(`The installed '${pkg}' package does not require upgrade (${pkgVersionName} >= ${apkVersionName})`);
+      return;
+    }
+  } else if (_.isNumber(apkVersionCode) && _.isNumber(pkgVersionCode) && pkgVersionCode === apkVersionCode) {
+    log.debug(`The installed '${pkg}' package does not require upgrade (${pkgVersionCode} === ${apkVersionCode})`);
     return;
   }
+
   log.debug(`The installed '${pkg}' package is older than '${apk}' (${pkgVersionCode} < ${apkVersionCode}). ` +
             `Executing upgrade`);
   try {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.4.7",
     "lodash": "^4.0.0",
+    "semver": "^5.5.0",
     "source-map-support": "^0.4.8",
     "teen_process": "^1.11.0"
   },

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -822,6 +822,21 @@ describe('Apk-utils', function () {
       await adb.installOrUpgrade(apkPath);
       mocks.adb.verify();
     });
+    it('should perform upgrade if older package version is installed, but version codes are not maintained', async function () {
+      mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
+        name: pkgId,
+        versionCode: 1,
+        versionName: '2.0.0',
+      });
+      mocks.adb.expects('getPackageInfo').once().returns({
+        versionCode: 1,
+        versionName: '1.0.0',
+      });
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, {replace: true, timeout: 60000}).once().returns(true);
+      await adb.installOrUpgrade(apkPath);
+      mocks.adb.verify();
+    });
     it('should uninstall and re-install if older package version is installed and upgrade fails', async function () {
       mocks.adb.expects('getApkInfo').withExactArgs(apkPath).once().returns({
         name: pkgId,


### PR DESCRIPTION
I see there are packages where versionCode is not maintained properly (for example UIA2) and only versionName is updated. This PR adds version names comparison to address such things