### PR TITLE
Sort build-tools folders semantically by default

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,7 @@ import log from './logger.js';
 import { exec } from 'teen_process';
 import _ from 'lodash';
 import B from 'bluebird';
+import semver from 'semver';
 
 
 const rootDir = path.resolve(__dirname, process.env.NO_PRECOMPILE ? '..' : '../..');
@@ -238,10 +239,20 @@ const getSdkToolsVersion = _.memoize(async function getSdkToolsVersion () {
  */
 const getBuildToolsDirs = _.memoize(async function getBuildToolsDirs (sdkRoot) {
   let buildToolsDirs = await fs.glob(path.resolve(sdkRoot, 'build-tools', '*'), {absolute: true});
-  const pairs = await B.map(buildToolsDirs, async (dir) => [(await fs.stat(dir)).mtime.valueOf(), dir]);
-  buildToolsDirs = pairs
-    .sort((a, b) => a[0] < b[0])
-    .map((pair) => pair[1]);
+  try {
+    buildToolsDirs = buildToolsDirs
+      .map((dir) => [path.basename(dir), dir])
+      .sort((a, b) => semver.rcompare(a[0], b[0]))
+      .map((pair) => pair[1]);
+  } catch (err) {
+    log.warn(`Cannot sort build-tools folders ${JSON.stringify(buildToolsDirs.map((dir) => path.basename(dir)))} ` +
+             `by semantic version names.`);
+    log.warn(`Falling back to sorting by modification date. Original error: ${err.message}`);
+    const pairs = await B.map(buildToolsDirs, async (dir) => [(await fs.stat(dir)).mtime.valueOf(), dir]);
+    buildToolsDirs = pairs
+      .sort((a, b) => a[0] < b[0])
+      .map((pair) => pair[1]);
+  }
   log.info(`Found ${buildToolsDirs.length} 'build-tools' folders under '${sdkRoot}' (newest first):`);
   for (let dir of buildToolsDirs) {
     log.info(`    ${dir}`);

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -1,5 +1,5 @@
 import { getAndroidPlatformAndPath,
-         buildStartCmd, isShowingLockscreen } from '../../lib/helpers';
+         buildStartCmd, isShowingLockscreen, getBuildToolsDirs } from '../../lib/helpers';
 import { withMocks } from 'appium-test-support';
 import { fs } from 'appium-support';
 import path from 'path';
@@ -147,4 +147,20 @@ describe('helpers', function () {
       cmd[cmd.length-1].should.not.eql('-S');
     });
   });
+
+  describe('getBuildToolsDirs', withMocks({fs}, (mocks) => {
+    it('should sort build-tools folder names by semantic version', async function () {
+      mocks.fs.expects('glob').once().returns([
+        '/some/path/1.2.3',
+        '/some/path/4.5.6',
+        '/some/path/2.3.1',
+      ]);
+      (await getBuildToolsDirs('/dummy/path')).should.be.eql([
+        '/some/path/4.5.6',
+        '/some/path/2.3.1',
+        '/some/path/1.2.3',
+      ]);
+      mocks.fs.verify();
+    });
+  }));
 });


### PR DESCRIPTION
I see that most of the users have these folder named properly. So lets have the fallback there, which makes the sorting operation safe for everyone.