### PR TITLE
Properly handle avdArgs if these are of type array

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -578,29 +578,28 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   }
   await this.checkAvdExist(avdName);
   let launchArgs = ["-avd", avdName];
-  if (typeof language === "string") {
+  if (_.isString(language)) {
     log.debug(`Setting Android Device Language to ${language}`);
     launchArgs.push("-prop", `persist.sys.language=${language.toLowerCase()}`);
   }
-  if (typeof country === "string") {
+  if (_.isString(country)) {
     log.debug(`Setting Android Device Country to ${country}`);
     launchArgs.push("-prop", `persist.sys.country=${country.toUpperCase()}`);
   }
   let locale;
-  if (typeof language === "string" && typeof country === "string") {
+  if (_.isString(language) && _.isString(country)) {
     locale = language.toLowerCase() + "-" + country.toUpperCase();
-  } else if (typeof language === "string") {
+  } else if (_.isString(language)) {
     locale = language.toLowerCase();
-  } else if (typeof country === "string") {
+  } else if (_.isString(country)) {
     locale = country;
   }
-  if (typeof locale === "string") {
+  if (_.isString(locale)) {
     log.debug(`Setting Android Device Locale to ${locale}`);
     launchArgs.push("-prop", `persist.sys.locale=${locale}`);
   }
-  if (typeof avdArgs === "string") {
-    avdArgs = avdArgs.split(" ");
-    launchArgs = launchArgs.concat(avdArgs);
+  if (!_.isEmpty(avdArgs)) {
+    launchArgs.push(...(_.isArray(avdArgs) ? avdArgs : avdArgs.split(' ')));
   }
   log.debug(`Running '${emulatorBinaryPath}' with args: ${JSON.stringify(launchArgs)}`);
   let proc = new SubProcess(emulatorBinaryPath, launchArgs);


### PR DESCRIPTION
The current implementation only works if `avdArgs` is of string type