### PR TITLE
Fix `adb install` output handling

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -353,21 +353,27 @@ apkUtilsMethods.install = async function (apk, options = {}) {
     }
   }
 
-  if (options.replace) {
-    const output = await this.adbExec(['install', '-r', ...additionalArgs, apk], {timeout});
+  const executeInstall = async (args) => {
+    const output = await this.adbExec(['install', ...args, apk], {timeout});
     log.debug(`Install command stdout: ${output}`);
-  } else {
-    try {
-      const output = await this.adbExec(['install', ...additionalArgs, apk], {timeout});
-      log.debug(`Install command stdout: ${output}`);
-    } catch (err) {
-      // on some systems this will throw an error if the app already
-      // exists
-      if (!err.message.includes('INSTALL_FAILED_ALREADY_EXISTS')) {
-        throw err;
-      }
-      log.debug(`Application '${apk}' already installed. Continuing.`);
+    if (_.isString(output) && output.includes('INSTALL_FAILED')) {
+      throw new Error(output);
     }
+  };
+
+  if (options.replace) {
+    return await executeInstall(['-r', ...additionalArgs]);
+  }
+
+  try {
+    await executeInstall(additionalArgs);
+  } catch (err) {
+    // on some systems this will throw an error if the app already
+    // exists
+    if (!err.message.includes('INSTALL_FAILED_ALREADY_EXISTS')) {
+      throw err;
+    }
+    log.debug(`Application '${apk}' already installed. Continuing.`);
   }
 };
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -355,7 +355,9 @@ apkUtilsMethods.install = async function (apk, options = {}) {
 
   const executeInstall = async (args) => {
     const output = await this.adbExec(['install', ...args, apk], {timeout});
-    log.debug(`Install command stdout: ${output}`);
+    const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
+      output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;
+    log.debug(`Install command stdout: ${truncatedOutput}`);
     if (_.isString(output) && output.includes('INSTALL_FAILED')) {
       throw new Error(output);
     }


### PR DESCRIPTION
`adb install` still returns zero code even if installations fails, so we 'manually' check the stdout and throw the error if necessary