### PR TITLE
Check whether the default certificate is present instead of just any certificate

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { exec } from 'teen_process';
 import path from 'path';
 import log from '../logger.js';
@@ -6,6 +7,7 @@ import { getJavaForOs, getApksignerForOs, getJavaHome, rootDir } from '../helper
 
 const DEFAULT_PRIVATE_KEY = path.resolve(rootDir, 'keys', 'testkey.pk8');
 const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
+const DEFAULT_CERT_DIGEST = 'a40da80a59d170caa950cf15c18c454d47a39b26989d8b640ecd745ba71bf5dc';
 
 let apkSigningMethods = {};
 
@@ -15,6 +17,7 @@ let apkSigningMethods = {};
  * '-Djava.ext.dirs is not supported. Use -classpath instead.' error on Windows.
  *
  * @param {?Array<String>} args - The list of tool arguments.
+ * @return {string} Command stdout
  * @throws {Error} If apksigner binary is not present on the local file system
  *                 or the return code is not equal to zero.
  */
@@ -36,7 +39,10 @@ apkSigningMethods.executeApksigner = async function (args = []) {
   }
   log.debug(`Starting ${isPatched ? 'patched ' : ''}'${apkSigner}' with args '${args}'`);
   try {
-    await exec(apkSigner, args, {shell: true, cwd: originalFolder});
+    return (await exec(apkSigner, args, {
+      shell: true,
+      cwd: originalFolder,
+    })).stdout;
   } finally {
     if (isPatched && await fs.exists(apkSigner)) {
       await fs.unlink(apkSigner);
@@ -169,7 +175,7 @@ apkSigningMethods.zipAlignApk = async function (apk) {
 };
 
 /**
- * Check if the app is already signed.
+ * Check if the app is already signed with the default Appium ceritficate.
  *
  * @param {string} apk - The full path to the local apk file.
  * @param {string} pgk - The name of application package.
@@ -188,7 +194,12 @@ apkSigningMethods.checkApkCert = async function (apk, pkg) {
   let verificationFunc;
   try {
     await getApksignerForOs(this);
-    verificationFunc = async () => await this.executeApksigner(['verify', apk]);
+    verificationFunc = async () => {
+      const output = await this.executeApksigner(['verify', '--print-certs', apk]);
+      if (!_.includes(output, DEFAULT_CERT_DIGEST)) {
+        throw new Error(`'${apk}' is signed with non-default certificate`);
+      }
+    };
   } catch (e) {
     log.warn(`Cannot use apksigner tool for signature verification. Defaulting to verify.jar. ` +
       `Original error: ${e.message}`);

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -158,7 +158,7 @@ describe('signing', function () {
         .once().withExactArgs(adb.binaries.zipalign, ['-f', '4', selendroidTestApp, alignedApk]);
       mocks.fs.expects("mv")
         .once().withExactArgs(alignedApk, selendroidTestApp, { mkdirp: true })
-        .returns({});
+        .returns("");
       await adb.zipAlignApk(selendroidTestApp);
       mocks.adb.verify();
       mocks.appiumSupport.verify();
@@ -182,7 +182,12 @@ describe('signing', function () {
         .once().withExactArgs(apksignerDummyPath,
           ['verify', '--print-certs', selendroidTestApp],
           {shell: true, cwd: path.dirname(apksignerDummyPath)})
-        .returns({});
+        .returns({
+          stdout: `Signer #1 certificate DN: EMAILADDRESS=android@android.com, CN=Android, OU=Android, O=Android, L=Mountain View, ST=California, C=US
+                   Signer #1 certificate SHA-256 digest: a40da80a59d170caa950cf15c18c454d47a39b26989d8b640ecd745ba71bf5dc
+                   Signer #1 certificate SHA-1 digest: 61ed377e85d386a8dfee6b864bd85b0bfaa5af81
+                   Signer #1 certificate MD5 digest: e89b158e4bcf988ebd09eb83f5378e87`,
+        });
       (await adb.checkApkCert(selendroidTestApp, selendroidTestAppPackage)).should.be.true;
       mocks.adb.verify();
       mocks.teen_process.verify();

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -39,7 +39,7 @@ describe('signing', function () {
         .once().withExactArgs(apksignerDummyPath, ['sign',
           '--key', defaultKeyPath, '--cert', defaultCertPath, selendroidTestApp],
           {shell: true, cwd: path.dirname(apksignerDummyPath)})
-        .returns("");
+        .returns({});
       await adb.signWithDefaultCert(selendroidTestApp);
       mocks.teen_process.verify();
       mocks.helpers.verify();
@@ -58,7 +58,7 @@ describe('signing', function () {
         .returns(javaDummyPath);
       mocks.teen_process.expects("exec")
         .once().withExactArgs(javaDummyPath, ['-jar', signPath, selendroidTestApp, '--override'])
-        .returns("");
+        .returns({});
       await adb.signWithDefaultCert(selendroidTestApp);
       mocks.teen_process.verify();
       mocks.helpers.verify();
@@ -83,7 +83,7 @@ describe('signing', function () {
           '--ks-pass', `pass:${password}`,
           '--key-pass', `pass:${password}`,
           selendroidTestApp], {shell: true, cwd: path.dirname(apksignerDummyPath)})
-        .returns("");
+        .returns({});
       await adb.signWithCustomCert(selendroidTestApp);
       mocks.teen_process.verify();
       mocks.helpers.verify();
@@ -112,12 +112,12 @@ describe('signing', function () {
         .returns(javaDummyPath);
       mocks.teen_process.expects("exec")
         .withExactArgs(javaDummyPath, ['-jar', path.resolve(helperJarPath, 'unsign.jar'), selendroidTestApp])
-        .returns("");
+        .returns({});
       mocks.teen_process.expects("exec")
         .withExactArgs(jarsigner, ['-sigalg', 'MD5withRSA', '-digestalg', 'SHA1',
           '-keystore', keystorePath, '-storepass', password,
           '-keypass', password, selendroidTestApp, keyAlias])
-        .returns("");
+        .returns({});
       await adb.signWithCustomCert(selendroidTestApp);
       mocks.teen_process.verify();
       mocks.helpers.verify();
@@ -134,7 +134,7 @@ describe('signing', function () {
       mocks.teen_process.expects("exec")
         .once().withExactArgs(keytool, ['-v', '-list', '-alias', keyAlias,
           '-keystore', keystorePath, '-storepass', password])
-        .returns("");
+        .returns({});
       (await adb.getKeystoreMd5(keytool, md5));
       mocks.teen_process.verify();
     });
@@ -153,12 +153,12 @@ describe('signing', function () {
         .returns("");
       mocks.appiumSupport.expects('mkdirp')
         .once().withExactArgs(path.dirname(alignedApk))
-        .returns("");
+        .returns({});
       mocks.teen_process.expects("exec")
         .once().withExactArgs(adb.binaries.zipalign, ['-f', '4', selendroidTestApp, alignedApk]);
       mocks.fs.expects("mv")
         .once().withExactArgs(alignedApk, selendroidTestApp, { mkdirp: true })
-        .returns("");
+        .returns({});
       await adb.zipAlignApk(selendroidTestApp);
       mocks.adb.verify();
       mocks.appiumSupport.verify();
@@ -180,9 +180,9 @@ describe('signing', function () {
         .twice().returns(apksignerDummyPath);
       mocks.teen_process.expects("exec")
         .once().withExactArgs(apksignerDummyPath,
-          ['verify', selendroidTestApp],
+          ['verify', '--print-certs', selendroidTestApp],
           {shell: true, cwd: path.dirname(apksignerDummyPath)})
-        .returns("");
+        .returns({});
       (await adb.checkApkCert(selendroidTestApp, selendroidTestAppPackage)).should.be.true;
       mocks.adb.verify();
       mocks.teen_process.verify();
@@ -198,7 +198,7 @@ describe('signing', function () {
         .returns(javaDummyPath);
       mocks.teen_process.expects("exec")
         .withExactArgs(javaDummyPath, ['-jar', path.resolve(helperJarPath, 'verify.jar'), selendroidTestApp])
-        .returns("");
+        .returns({});
       (await adb.checkApkCert(selendroidTestApp, selendroidTestAppPackage)).should.be.true;
       mocks.adb.verify();
       mocks.teen_process.verify();


### PR DESCRIPTION
It turns out that verify.jar checks whether the default Appium certificate is present on the APK and not just any valid certificate.