### PR TITLE
Fix zipalign usage in case if apksigner utility is present on the local FS

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -134,11 +134,17 @@ apkSigningMethods.sign = async function (apk) {
   let apksignerFound = true;
   try {
     await getApksignerForOs(this);
-    // we only want to zipalign here if we are using apksigner
-    // otherwise do it at the end
-    await this.zipAlignApk(apk);
   } catch (err) {
     apksignerFound = false;
+  }
+
+  if (apksignerFound) {
+    // it is necessary to apply zipalign only before signing
+    // if apksigner is used or only after signing if we only have
+    // sign.jar utility
+    try {
+      await this.zipAlignApk(apk);
+    } catch (ign) {}
   }
 
   if (this.useKeystore) {


### PR DESCRIPTION
zipalign might return non-zero code if the apk is already aligned. The previous implementation was erroneously treating such exception as apksigner utility absence.

Addresses https://github.com/appium/appium/issues/8945#issuecomment-374546182