### PR TITLE
Include pkg + activity as possible activity

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -176,6 +176,7 @@ apkUtilsMethods.waitForActivityOrNot = async function (pkg, activity, waitForSto
     } else {
       // accept fully qualified activity name.
       possibleActivityNames.push(oneActivity);
+      possibleActivityNames.push(`${pkg}.${oneActivity}`);
     }
   }
   /* jshint ignore:start */


### PR DESCRIPTION
* `waitForActivityOrNot` waits for the focused package and activity to be the package and activity specified in caps
* It is not always the case if an activity starts with '.', it is a fully qualified activity name (e.g.: https://github.com/aosp-mirror/platform_development/blob/master/samples/ApiDemos/AndroidManifest.xml#L66 the `android:name` does not start with a '.' and is not fully qualified)
* This case came up when we started using `apkAnalyzer` to parse activity names
* The fix is to add `${pkg}.${oneActivity}` as a _possible_ activity name that we can test
  * For example, if the activity is 'ApiDemos' then we will look for either /^ApiDemos$/ or /^io.appium.android.apis.ApiDemos$/ as possible

(related to https://github.com/appium/appium/issues/10381)