### PR TITLE
Fix auto detection main-activity

### DIFF
--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -144,7 +144,12 @@ async function extractApkInfoWithApkanalyzer (localApk, apkanalyzerPath) {
   if (!apkActivityAttribute) {
     throw new Error(`Cannot parse main activity name from ${manifestXml}`);
   }
-  const apkActivity = apkActivityAttribute.value;
+
+  let apkActivity = apkActivityAttribute.value;
+  if (!apkActivity.startsWith(apkPackage)) {
+    apkActivity = apkPackage + '.' + apkActivity;
+  }
+
   return {apkPackage, apkActivity};
 }
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -146,12 +146,13 @@ async function extractApkInfoWithApkanalyzer (localApk, apkanalyzerPath) {
   }
 
   let apkActivity = apkActivityAttribute.value;
-  // `android:name` has various cases from analyser.
+  // `android:name` has various cases from apkanalyzer.
   // 1. ApiDemos
   // 2. io.appium.mainactivity.MainTabActivity
   // 3. .app.HelloWorld
+  // It should add package name only 1 case since 2 and 3 can be activity name properly.
   if (!apkActivity.includes(".")) {
-    apkActivity = apkPackage + '.' + apkActivity;
+    apkActivity = `${apkPackage}.${apkActivity}`;
   }
 
   return {apkPackage, apkActivity};

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -146,7 +146,11 @@ async function extractApkInfoWithApkanalyzer (localApk, apkanalyzerPath) {
   }
 
   let apkActivity = apkActivityAttribute.value;
-  if (!apkActivity.startsWith(apkPackage)) {
+  // `android:name` has various cases from analyser.
+  // 1. ApiDemos
+  // 2. io.appium.mainactivity.MainTabActivity
+  // 3. .app.HelloWorld
+  if (!apkActivity.includes(".")) {
     apkActivity = apkPackage + '.' + apkActivity;
   }
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -151,7 +151,7 @@ async function extractApkInfoWithApkanalyzer (localApk, apkanalyzerPath) {
   // 2. io.appium.mainactivity.MainTabActivity
   // 3. .app.HelloWorld
   // It should add package name only 1 case since 2 and 3 can be activity name properly.
-  if (!apkActivity.includes(".")) {
+  if (!apkActivity.includes('.')) {
     apkActivity = `${apkPackage}.${apkActivity}`;
   }
 

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -208,7 +208,7 @@ describe('android-manifest', function () {
                   android:process=":browser" />
           </application>
       </manifest>`});
-      let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
+      let {apkPackage, apkActivity} = await adb.packageAndLaunchActivityFromManifest(localApk);
       apkPackage.should.equal(dummyPackageName);
       apkActivity.should.equal(dummyActivityName);
       mocks.teen_process.verify();
@@ -266,7 +266,7 @@ describe('android-manifest', function () {
                 android:process=":browser" />
         </application>
       </manifest>`});
-      let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
+      let {apkPackage, apkActivity} = await adb.packageAndLaunchActivityFromManifest(localApk);
       apkPackage.should.equal(dummyPackageName);
       apkActivity.should.equal(`${apkPackage}.${dummyActivityName}`);
       mocks.teen_process.verify();
@@ -325,7 +325,7 @@ describe('android-manifest', function () {
                 android:process=":browser" />
         </application>
       </manifest>`});
-      let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
+      let {apkPackage, apkActivity} = await adb.packageAndLaunchActivityFromManifest(localApk);
       apkPackage.should.equal(dummyPackageName);
       apkActivity.should.equal(dummyActivityName);
       mocks.teen_process.verify();
@@ -345,7 +345,7 @@ describe('android-manifest', function () {
         .once().withExactArgs('dummy_aapt', ['dump', 'badging', localApk])
         .returns({stdout: ` package: name='${dummyPackageName}'
                           launchable-activity: name='${dummyActivityName}'`});
-      let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
+      let {apkPackage, apkActivity} = await adb.packageAndLaunchActivityFromManifest(localApk);
       apkPackage.should.equal(dummyPackageName);
       apkActivity.should.equal(dummyActivityName);
       mocks.adb.verify();

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -268,7 +268,66 @@ describe('android-manifest', function () {
       </manifest>`});
       let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
       apkPackage.should.equal(dummyPackageName);
-      apkActivity.should.equal(apkPackage + '.' + dummyActivityName);
+      apkActivity.should.equal(`${apkPackage}.${dummyActivityName}`);
+      mocks.teen_process.verify();
+      mocks.helpers.verify();
+    });
+
+
+    it('should correctly parse package and activity from manifest with apkanalyzer tool and activity name without package name', async function () {
+      const apkanalyzerDummyPath = 'apkanalyzer';
+      mocks.helpers.expects("getApkanalyzerForOs").returns(apkanalyzerDummyPath);
+      const localApk = 'dummyAPK';
+      const dummyPackageName = 'io.appium.android';
+      const dummyActivityName = '.app.HelloWorld';
+      mocks.teen_process.expects("exec")
+          .once().withArgs(apkanalyzerDummyPath)
+          .returns({stdout: `
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest
+        xmlns:amazon="http://schemas.amazon.com/apk/res/android"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:versionCode="1234"
+        android:versionName="3.0.0"
+        android:installLocation="0"
+        package="${dummyPackageName}">
+  
+        <application
+            android:theme="@ref/0x7f0f00ef"
+            android:label="@ref/0x7f0e00b4"
+            android:icon="@ref/0x7f0b0001"
+            android:name="io.appium.app.testappAppShell"
+            android:debuggable="false"
+            android:allowTaskReparenting="true"
+            android:allowBackup="false"
+            android:hardwareAccelerated="true"
+            android:supportsRtl="true">
+  
+            <activity
+                android:name="${dummyActivityName}">
+    
+                <intent-filter>
+    
+                    <action
+                        android:name="android.intent.action.MAIN" />
+    
+                    <category
+                        android:name="android.intent.category.DEFAULT" />
+    
+                    <category
+                        android:name="android.intent.category.LAUNCHER" />
+                </intent-filter>
+            </activity>
+  
+            <service
+                android:name="io.appium.browser.lite.BrowserLiteIntentService"
+                android:exported="false"
+                android:process=":browser" />
+        </application>
+      </manifest>`});
+      let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
+      apkPackage.should.equal(dummyPackageName);
+      apkActivity.should.equal(dummyActivityName);
       mocks.teen_process.verify();
       mocks.helpers.verify();
     });

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -84,6 +84,40 @@ describe('android-manifest', function () {
                           android:name="android.intent.action.MAIN" />
 
                       <category
+                          android:name="android.intent.category.DEFAULT" />
+
+                      <category
+                          android:name="android.intent.category.LAUNCHER" />
+                  </intent-filter>
+              </activity>
+
+              <activity
+                  android:name="io.appium.mainactivity.MainTabActivity"
+                  android:exported="true"
+                  android:clearTaskOnLaunch="false"
+                  android:launchMode="1"
+                  android:screenOrientation="1"
+                  android:configChanges="0x4a0"
+                  android:alwaysRetainTaskState="true"
+                  android:windowSoftInputMode="0x30" />
+
+              <activity-alias
+                  android:name="${dummyActivityName}"
+                  android:exported="true"
+                  android:clearTaskOnLaunch="false"
+                  android:launchMode="1"
+                  android:screenOrientation="1"
+                  android:configChanges="0x4a0"
+                  android:targetActivity="io.appium.mainactivity.MainTabActivity"
+                  android:alwaysRetainTaskState="true"
+                  android:windowSoftInputMode="0x30">
+
+                  <intent-filter>
+
+                      <action
+                          android:name="android.intent.action.MAIN" />
+
+                      <category
                           android:name="android.intent.category.LAUNCHER" />
                   </intent-filter>
 
@@ -207,6 +241,64 @@ describe('android-manifest', function () {
                   android:exported="false"
                   android:process=":browser" />
           </application>
+      </manifest>`});
+      let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
+      apkPackage.should.equal(dummyPackageName);
+      apkActivity.should.equal(dummyActivityName);
+      mocks.teen_process.verify();
+      mocks.helpers.verify();
+    });
+
+    it('should correctly parse package and activity from manifest with apkanalyzer tool with package name', async function () {
+      const apkanalyzerDummyPath = 'apkanalyzer';
+      mocks.helpers.expects("getApkanalyzerForOs").returns(apkanalyzerDummyPath);
+      const localApk = 'dummyAPK';
+      const dummyPackageName = 'io.appium.android';
+      const dummyActivityName = 'ApiDemos';
+      mocks.teen_process.expects("exec")
+          .once().withArgs(apkanalyzerDummyPath)
+          .returns({stdout: `
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest
+        xmlns:amazon="http://schemas.amazon.com/apk/res/android"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:versionCode="1234"
+        android:versionName="3.0.0"
+        android:installLocation="0"
+        package="${dummyPackageName}">
+
+        <application
+            android:theme="@ref/0x7f0f00ef"
+            android:label="@ref/0x7f0e00b4"
+            android:icon="@ref/0x7f0b0001"
+            android:name="io.appium.app.testappAppShell"
+            android:debuggable="false"
+            android:allowTaskReparenting="true"
+            android:allowBackup="false"
+            android:hardwareAccelerated="true"
+            android:supportsRtl="true">
+
+            <activity
+                android:name="${dummyActivityName}">
+    
+                <intent-filter>
+    
+                    <action
+                        android:name="android.intent.action.MAIN" />
+    
+                    <category
+                        android:name="android.intent.category.DEFAULT" />
+    
+                    <category
+                        android:name="android.intent.category.LAUNCHER" />
+                </intent-filter>
+            </activity>
+
+            <service
+                android:name="io.appium.browser.lite.BrowserLiteIntentService"
+                android:exported="false"
+                android:process=":browser" />
+        </application>
       </manifest>`});
       let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
       apkPackage.should.equal(dummyPackageName);

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -84,40 +84,6 @@ describe('android-manifest', function () {
                           android:name="android.intent.action.MAIN" />
 
                       <category
-                          android:name="android.intent.category.DEFAULT" />
-
-                      <category
-                          android:name="android.intent.category.LAUNCHER" />
-                  </intent-filter>
-              </activity>
-
-              <activity
-                  android:name="io.appium.mainactivity.MainTabActivity"
-                  android:exported="true"
-                  android:clearTaskOnLaunch="false"
-                  android:launchMode="1"
-                  android:screenOrientation="1"
-                  android:configChanges="0x4a0"
-                  android:alwaysRetainTaskState="true"
-                  android:windowSoftInputMode="0x30" />
-
-              <activity-alias
-                  android:name="${dummyActivityName}"
-                  android:exported="true"
-                  android:clearTaskOnLaunch="false"
-                  android:launchMode="1"
-                  android:screenOrientation="1"
-                  android:configChanges="0x4a0"
-                  android:targetActivity="io.appium.mainactivity.MainTabActivity"
-                  android:alwaysRetainTaskState="true"
-                  android:windowSoftInputMode="0x30">
-
-                  <intent-filter>
-
-                      <action
-                          android:name="android.intent.action.MAIN" />
-
-                      <category
                           android:name="android.intent.category.LAUNCHER" />
                   </intent-filter>
 

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -210,7 +210,7 @@ describe('android-manifest', function () {
       </manifest>`});
       let {apkPackage, apkActivity} = (await adb.packageAndLaunchActivityFromManifest(localApk));
       apkPackage.should.equal(dummyPackageName);
-      apkActivity.should.equal(dummyActivityName);
+      apkActivity.should.equal(apkPackage + '.' + dummyActivityName);
       mocks.teen_process.verify();
       mocks.helpers.verify();
     });


### PR DESCRIPTION
When I ran with the following capability case, appium server failed to launch app. => [full log](https://gist.github.com/KazuCocoa/d9de39af98dbe62301b6bd8af3b55a01)

```
info: [Appium] Capabilities:
info: [Appium]   platformName: Android
info: [Appium]   deviceName: Android
info: [Appium]   automationName: uiautomator2
info: [Appium]   app: /Users/kazuaki/GitHub/AppiumRegressionCheck/test/../test_app/ApiDemos-debug.apk
```
(The ApiDemos is Appium's demo app.)

The reason was failed to detect activity the server should launch. The detection worked with Appium 1.7.2, but it started failing after https://github.com/appium/appium-adb/pull/296

- With `Appium 1.7.2`, we can see the below log.
    ```
    [debug] [ADB] badging package: io.appium.android.apis
    [debug] [ADB] badging act: io.appium.android.apis.ApiDemos
    ```
- After  https://github.com/appium/appium-adb/pull/296 , we can see the following logs and failed to detect the main activity the appium server should launch.
    ```
    [info] [ADB] Package name: 'io.appium.android.apis'
    [info] [ADB] Main activity name: 'ApiDemos'
    ```
    - The demoapp's result of analyser is [this](https://gist.github.com/KazuCocoa/1aa046ebf2a5ed74cf36d8afde708c0f). You can see `android:name="ApiDemos"`

After this PR, we can see the following log instead of the above and succeeds to launch the test app as well as Appium 1.7.2.

```
info: [ADB] Package name: 'io.appium.android.apis'
info: [ADB] Main activity name: 'io.appium.android.apis.ApiDemos'
```

If we consider variations, the logic will be complex, I guess. So, I just try to care simple case. The name has no separation `.` like the demo app.

What do you think?

----

link: https://github.com/Magic-Pod/AppiumRegressionCheck/issues/2