### PR TITLE
Throw errors if result of `startUri` has errors

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -43,7 +43,10 @@ apkUtilsMethods.startUri = async function (uri, pkg) {
   try {
     let args = ["am", "start", "-W", "-a", "android.intent.action.VIEW", "-d",
                 uri.replace(/&/g, '\\&'), pkg];
-    return await this.shell(args);
+    const res = await this.shell(args);
+    if (res.toLowerCase().includes('unable to resolve intent')) {
+      throw new Error(res);
+    }
   } catch (e) {
     log.errorAndThrow(`Error attempting to start URI. Original error: ${e}`);
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -43,7 +43,12 @@ apkUtilsMethods.startUri = async function (uri, pkg) {
   try {
     let args = ["am", "start", "-W", "-a", "android.intent.action.VIEW", "-d",
                 uri.replace(/&/g, '\\&'), pkg];
-    await this.shell(args);
+    const res = await this.shell(args);
+
+    // Doesn't always return non-zero exit code when it fails
+    if (res.toLowerCase().includes('activity not started')) {
+      throw new Error(res);
+    }
   } catch (e) {
     log.errorAndThrow(`Error attempting to start URI. Original error: ${e}`);
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -43,12 +43,7 @@ apkUtilsMethods.startUri = async function (uri, pkg) {
   try {
     let args = ["am", "start", "-W", "-a", "android.intent.action.VIEW", "-d",
                 uri.replace(/&/g, '\\&'), pkg];
-    const res = await this.shell(args);
-
-    // Doesn't always return non-zero exit code when it fails
-    if (res.toLowerCase().includes('activity not started')) {
-      throw new Error(res);
-    }
+    return await this.shell(args);
   } catch (e) {
     log.errorAndThrow(`Error attempting to start URI. Original error: ${e}`);
   }

--- a/test/functional/adb-e2e-specs.js
+++ b/test/functional/adb-e2e-specs.js
@@ -15,7 +15,7 @@ describe('ADB', function () {
     let adb = await ADB.createADB(opts);
     should.exist(adb.executable.path);
   });
-  it.skip('should error out if binary not persent', async () => {
+  it.skip('should error out if binary not persent', async function () {
     // TODO write a negative test
   });
   it('should initialize aapt', async function () {

--- a/test/functional/android-manifest-e2e-specs.js
+++ b/test/functional/android-manifest-e2e-specs.js
@@ -39,7 +39,7 @@ describe('Android-manifest', async function () {
     flag.should.be.false;
   });
   // TODO fix this test
-  it.skip('should compile and insert manifest', async () => {
+  it.skip('should compile and insert manifest', async function () {
     let appPackage = 'com.example.android.contactmanager',
         newServerPath = path.resolve(tmpDir, `selendroid.${appPackage}.apk`),
         newPackage = 'com.example.android.contactmanager.selendroid',

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -465,9 +465,6 @@ describe('Apk-utils', function () {
     });
   }));
   describe('startUri', withMocks({adb}, (mocks) => {
-    before(async function () {
-
-    });
     it('should fail if uri or pkg are not provided', async function () {
       await adb.startUri().should.eventually.be.rejectedWith(/arguments are required/);
       await adb.startUri('foo').should.eventually.be.rejectedWith(/arguments are required/);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -465,14 +465,32 @@ describe('Apk-utils', function () {
     });
   }));
   describe('startUri', withMocks({adb}, (mocks) => {
+    before(async function () {
+
+    });
     it('should fail if uri or pkg are not provided', async function () {
       await adb.startUri().should.eventually.be.rejectedWith(/arguments are required/);
       await adb.startUri('foo').should.eventually.be.rejectedWith(/arguments are required/);
     });
+    it('should fail if "unable to resolve intent" appears in shell command result', async function () {
+      mocks.adb.expects('shell')
+        .once().withExactArgs([
+          'am', 'start', '-W', '-a',
+          'android.intent.action.VIEW', '-d', uri, pkg
+        ])
+        .returns('Something something something Unable to resolve intent something something');
+
+      await adb.startUri(uri, pkg).should.eventually.be.rejectedWith(/Unable to resolve intent/);
+      mocks.adb.verify();
+    });
     it('should build a call to a VIEW intent with the uri', async function () {
       mocks.adb.expects('shell')
-        .once().withExactArgs(['am', 'start', '-W', '-a',
-                               'android.intent.action.VIEW', '-d', uri, pkg]);
+        .once().withExactArgs([
+          'am', 'start', '-W', '-a',
+          'android.intent.action.VIEW', '-d', uri, pkg
+        ])
+        .returns('Passable result');
+
       await adb.startUri(uri, pkg);
       mocks.adb.verify();
     });


### PR DESCRIPTION
* I need this for another PR because starters was unsuccessfully starting activities but was still returning zero as the error code so I need a way to check that 

(related PR: https://github.com/appium/appium-uiautomator2-driver/pull/151)