### PR TITLE
Show raw adb command instead of array of args

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -6,6 +6,7 @@ import { getSdkToolsVersion, getBuildToolsDirs } from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval } from 'asyncbox';
 import _ from 'lodash';
+import { quote } from 'shell-quote';
 
 
 let systemCallMethods = {};
@@ -292,8 +293,7 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         cmd = [cmd];
       }
       let args = this.executable.defaultArgs.concat(cmd);
-      let argString = args.map(x => _.isString(x) && /\s+/.test(x) ? `"${x}"` : x).join(' ');
-      log.debug(`Running '${this.executable.path} ${argString}'`);
+      log.debug(`Running '${this.executable.path} ${quote(args)}'`);
       let {stdout} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -292,8 +292,8 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         cmd = [cmd];
       }
       let args = this.executable.defaultArgs.concat(cmd);
-      log.debug(`Running '${this.executable.path}' with args: ` +
-                `${JSON.stringify(args)}`);
+      let argString = args.map(x => _.isString(x) && /\s+/.test(x) ? `"${x}"` : x).join(' ');
+      log.debug(`Running '${this.executable.path} ${argString}'`);
       let {stdout} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bluebird": "^3.4.7",
     "lodash": "^4.0.0",
     "semver": "^5.5.0",
+    "shell-quote": "^1.6.1",
     "source-map-support": "^0.4.8",
     "teen_process": "^1.11.0",
     "xmldom": "^0.1.27",


### PR DESCRIPTION
Instead of logging ADB exec commands like this: 

```Running '/Users/danielgraham/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","emulator-5554","shell","pm","clear","io.appium.settings"]```

...log them like this: 

```Running '/Users/danielgraham/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell pm clear io.appium.settings'```

...so that we can copy the commands and run them from command line directly for troubleshooting/testing purposes.