### PR TITLE
Replace `logAndThrow` with `throw new Error`

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -249,7 +249,7 @@ function buildStartCmd (startAppOptions, apiLevel) {
 const getSdkToolsVersion = _.memoize(async function getSdkToolsVersion () {
   const androidHome = process.env.ANDROID_HOME;
   if (!androidHome) {
-    throw new Error('ANDROID_HOME environment varibale is expected to be set');
+    throw new Error('ANDROID_HOME environment variable is expected to be set');
   }
   const propertiesPath = path.resolve(androidHome, 'tools', 'source.properties');
   if (!await fs.exists(propertiesPath)) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,7 @@ const rootDir = path.resolve(__dirname, process.env.NO_PRECOMPILE ? '..' : '../.
 async function getAndroidPlatformAndPath () {
   const androidHome = process.env.ANDROID_HOME;
   if (!_.isString(androidHome)) {
-    log.errorAndThrow("ANDROID_HOME environment variable was not exported");
+    throw new Error("ANDROID_HOME environment variable was not exported");
   }
 
   let propsPaths = await fs.glob(path.resolve(androidHome, 'platforms', '*', 'build.prop'), {
@@ -249,7 +249,7 @@ function buildStartCmd (startAppOptions, apiLevel) {
 const getSdkToolsVersion = _.memoize(async function getSdkToolsVersion () {
   const androidHome = process.env.ANDROID_HOME;
   if (!androidHome) {
-    log.errorAndThrow('ANDROID_HOME environment varibale is expected to be set');
+    throw new Error('ANDROID_HOME environment varibale is expected to be set');
   }
   const propertiesPath = path.resolve(androidHome, 'tools', 'source.properties');
   if (!await fs.exists(propertiesPath)) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { fs } from 'appium-support';
 import net from 'net';
 import Logcat from '../logcat';
-import { sleep, retryInterval, waitForCondition } from 'asyncbox';
+import { sleep, waitForCondition } from 'asyncbox';
 import { SubProcess } from 'teen_process';
 import B from 'bluebird';
 
@@ -68,7 +68,7 @@ methods.getApiLevel = async function () {
         throw new Error(`The actual output "${strOutput}" cannot be converted to an integer`);
       }
     } catch (e) {
-      log.errorAndThrow(`Error getting device API level. Original error: ${e.message}`);
+      throw new Error(`Error getting device API level. Original error: ${e.message}`);
     }
   }
   log.debug(`Device API level: ${this._apiLevel}`);
@@ -86,7 +86,7 @@ methods.getPlatformVersion = async function () {
   try {
     return await this.getDeviceProperty('ro.build.version.release');
   } catch (e) {
-    log.errorAndThrow(`Error getting device platform version. Original error: ${e.message}`);
+    throw new Error(`Error getting device platform version. Original error: ${e.message}`);
   }
 };
 
@@ -344,7 +344,7 @@ methods.stopAndClear = async function (pkg) {
     await this.forceStop(pkg);
     await this.clear(pkg);
   } catch (e) {
-    log.errorAndThrow(`Cannot stop and clear ${pkg}. Original error: ${e.message}`);
+    throw new Error(`Cannot stop and clear ${pkg}. Original error: ${e.message}`);
   }
 };
 
@@ -369,7 +369,7 @@ methods.availableIMEs = async function () {
   try {
     return getIMEListFromOutput(await this.shell(['ime', 'list', '-a']));
   } catch (e) {
-    log.errorAndThrow(`Error getting available IME's. Original error: ${e.message}`);
+    throw new Error(`Error getting available IME's. Original error: ${e.message}`);
   }
 };
 
@@ -382,7 +382,7 @@ methods.enabledIMEs = async function () {
   try {
     return getIMEListFromOutput(await this.shell(['ime', 'list']));
   } catch (e) {
-    log.errorAndThrow(`Error getting enabled IME's. Original error: ${e.message}`);
+    throw new Error(`Error getting enabled IME's. Original error: ${e.message}`);
   }
 };
 
@@ -423,7 +423,7 @@ methods.defaultIME = async function () {
     let engine = await this.getSetting('secure', 'default_input_method');
     return engine.trim();
   } catch (e) {
-    log.errorAndThrow(`Error getting default IME. Original error: ${e.message}`);
+    throw new Error(`Error getting default IME. Original error: ${e.message}`);
   }
 };
 
@@ -491,20 +491,21 @@ methods.clearTextField = async function (length = 100) {
  * Send the special keycode to the device under test in order to lock it.
  */
 methods.lock = async function () {
-  let locked = await this.isScreenLocked();
-  if (!locked) {
-    log.debug("Pressing the KEYCODE_POWER button to lock screen");
-    await this.keyevent(26);
-
-    // wait for the screen to lock
-    await retryInterval(10, 500, async () => {
-      locked = await this.isScreenLocked();
-      if (!locked) {
-        log.errorAndThrow("Waiting for screen to lock.");
-      }
-    });
-  } else {
+  if (await this.isScreenLocked()) {
     log.debug("Screen is already locked. Doing nothing.");
+    return;
+  }
+  log.debug("Pressing the KEYCODE_POWER button to lock screen");
+  await this.keyevent(26);
+
+  const timeoutMs = 5000;
+  try {
+    await waitForCondition(async () => await this.isScreenLocked(), {
+      waitMs: timeoutMs,
+      intervalMs: 500,
+    });
+  } catch (e) {
+    throw new Error(`The device screen is still locked after ${timeoutMs}ms timeout`);
   }
 };
 
@@ -581,7 +582,7 @@ methods.isSoftKeyboardPresent = async function () {
     }
     return {isKeyboardShown, canCloseKeyboard};
   } catch (e) {
-    log.errorAndThrow(`Error finding softkeyboard. Original error: ${e.message}`);
+    throw new Error(`Error finding softkeyboard. Original error: ${e.message}`);
   }
 };
 
@@ -804,12 +805,12 @@ methods.setDeviceSysLocaleViaSettingApp = async function (language, country) {
 methods.setGeoLocation = async function (location, isEmulator = false) {
   let longitude = parseFloat(location.longitude);
   if (isNaN(longitude)) {
-    log.errorAndThrow(`location.longitude is expected to be a valid float number. '${location.longitude}' is given instead`);
+    throw new Error(`location.longitude is expected to be a valid float number. '${location.longitude}' is given instead`);
   }
   longitude = `${_.ceil(longitude, 5)}`;
   let latitude = parseFloat(location.latitude);
   if (isNaN(latitude)) {
-    log.errorAndThrow(`location.latitude is expected to be a valid float number. '${location.latitude}' is given instead`);
+    throw new Error(`location.latitude is expected to be a valid float number. '${location.latitude}' is given instead`);
   }
   latitude = `${_.ceil(latitude, 5)}`;
   if (isEmulator) {
@@ -881,7 +882,7 @@ methods.processExists = async function (processName) {
     }
     return false;
   } catch (e) {
-    log.errorAndThrow(`Error finding if process exists. Original error: ${e.message}`);
+    throw new Error(`Error finding if process exists. Original error: ${e.message}`);
   }
 };
 
@@ -958,7 +959,7 @@ methods.restart = async function () {
     await this.waitForDevice(60);
     await this.startLogcat();
   } catch (e) {
-    log.errorAndThrow(`Restart failed. Orginial error: ${e.message}`);
+    throw new Error(`Restart failed. Orginial error: ${e.message}`);
   }
 };
 
@@ -969,7 +970,7 @@ methods.restart = async function () {
  */
 methods.startLogcat = async function () {
   if (!_.isEmpty(this.logcat)) {
-    log.errorAndThrow("Trying to start logcat capture but it's already started!");
+    throw new Error("Trying to start logcat capture but it's already started!");
   }
   this.logcat = new Logcat({
     adb: this.executable,
@@ -1004,7 +1005,7 @@ methods.stopLogcat = async function () {
  */
 methods.getLogcatLogs = function () {
   if (_.isEmpty(this.logcat)) {
-    log.errorAndThrow("Can't get logcat logs since logcat hasn't started");
+    throw new Error("Can't get logcat logs since logcat hasn't started");
   }
   return this.logcat.getLogs();
 };
@@ -1018,7 +1019,7 @@ methods.getLogcatLogs = function () {
  */
 methods.setLogcatListener = function (listener) {
   if (_.isEmpty(this.logcat)) {
-    log.errorAndThrow("Can't get logcat logs since logcat hasn't started");
+    throw new Error("Can't get logcat logs since logcat hasn't started");
   }
   this.logcat.on('output', listener);
 };
@@ -1050,7 +1051,7 @@ methods.getPIDsByName = async function (name) {
     }
     return pids;
   } catch (e) {
-    log.errorAndThrow(`Unable to get pids for ${name}. Orginial error: ${e.message}`);
+    throw new Error(`Unable to get pids for ${name}. Orginial error: ${e.message}`);
   }
 };
 
@@ -1072,7 +1073,7 @@ methods.killProcessesByName = async function (name) {
       await this.killProcessByPID(pid);
     }
   } catch (e) {
-    log.errorAndThrow(`Unable to kill ${name} processes. Original error: ${e.message}`);
+    throw new Error(`Unable to kill ${name} processes. Original error: ${e.message}`);
   }
 };
 
@@ -1130,7 +1131,7 @@ methods.broadcastProcessEnd = async function (intent, processName) {
     }
     throw new Error(`Process never died within ${timeoutMs} ms`);
   } catch (e) {
-    log.errorAndThrow(`Unable to broadcast process end. Original error: ${e.message}`);
+    throw new Error(`Unable to broadcast process end. Original error: ${e.message}`);
   }
 };
 
@@ -1142,7 +1143,7 @@ methods.broadcastProcessEnd = async function (intent, processName) {
  */
 methods.broadcast = async function (intent) {
   if (!this.isValidClass(intent)) {
-    log.errorAndThrow(`Invalid intent ${intent}`);
+    throw new Error(`Invalid intent ${intent}`);
   }
   log.debug(`Broadcasting: ${intent}`);
   await this.shell(['am', 'broadcast', '-a', intent]);
@@ -1174,7 +1175,7 @@ methods.instrument = async function (pkg, activity, instrumentWith) {
   let stdout = await this.shell(['am', 'instrument', '-e', 'main_activity',
                                  pkgActivity, instrumentWith]);
   if (stdout.indexOf("Exception") !== -1) {
-    log.errorAndThrow(`Unknown exception during instrumentation. ` +
+    throw new Error(`Unknown exception during instrumentation. ` +
                       `Original error ${stdout.split("\n")[0]}`);
   }
 };
@@ -1191,7 +1192,7 @@ methods.instrument = async function (pkg, activity, instrumentWith) {
  */
 methods.androidCoverage = async function (instrumentClass, waitPkg, waitActivity) {
   if (!this.isValidClass(instrumentClass)) {
-    log.errorAndThrow(`Invalid class ${instrumentClass}`);
+    throw new Error(`Invalid class ${instrumentClass}`);
   }
   return await new B(async (resolve, reject) => {
     let args = this.executable.defaultArgs
@@ -1382,10 +1383,10 @@ methods.getScreenDensity = async function () {
 methods.setHttpProxy = async function (proxyHost, proxyPort) {
   let proxy = `${proxyHost}:${proxyPort}`;
   if (_.isUndefined(proxyHost)) {
-    log.errorAndThrow(`Call to setHttpProxy method with undefined proxy_host: ${proxy}`);
+    throw new Error(`Call to setHttpProxy method with undefined proxy_host: ${proxy}`);
   }
   if (_.isUndefined(proxyPort)) {
-    log.errorAndThrow(`Call to setHttpProxy method with undefined proxy_port ${proxy}`);
+    throw new Error(`Call to setHttpProxy method with undefined proxy_port ${proxy}`);
   }
   await this.setSetting('global', 'http_proxy', proxy);
   await this.setSetting('secure', 'http_proxy', proxy);

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -54,7 +54,7 @@ emuMethods.isEmulatorConnected = async function () {
  */
 emuMethods.verifyEmulatorConnected = async function () {
   if (!(await this.isEmulatorConnected())) {
-    log.errorAndThrow(`The emulator "${this.curDeviceId}" was unexpectedly disconnected`);
+    throw new Error(`The emulator "${this.curDeviceId}" was unexpectedly disconnected`);
   }
 };
 
@@ -65,12 +65,12 @@ emuMethods.verifyEmulatorConnected = async function () {
  */
 emuMethods.fingerprint = async function (fingerprintId) {
   if (!fingerprintId) {
-    log.errorAndThrow('Fingerprint id parameter must be defined');
+    throw new Error('Fingerprint id parameter must be defined');
   }
   // the method used only works for API level 23 and above
   let level = await this.getApiLevel();
   if (level < 23) {
-    log.errorAndThrow(`Device API Level must be >= 23. Current Api level '${level}'`);
+    throw new Error(`Device API Level must be >= 23. Current Api level '${level}'`);
   }
   await this.adbExecEmu(['finger', 'touch', fingerprintId]);
 };
@@ -91,7 +91,7 @@ emuMethods.rotate = async function () {
  */
 emuMethods.powerAC = async function (state = 'on') {
   if (_.values(emuMethods.POWER_AC_STATES).indexOf(state) === -1) {
-    log.errorAndThrow(`Wrong power AC state sent '${state}'. Supported values: ${_.values(emuMethods.POWER_AC_STATES)}]`);
+    throw new Error(`Wrong power AC state sent '${state}'. Supported values: ${_.values(emuMethods.POWER_AC_STATES)}]`);
   }
   await this.adbExecEmu(['power', 'ac', state]);
 };
@@ -104,7 +104,7 @@ emuMethods.powerAC = async function (state = 'on') {
 emuMethods.powerCapacity = async function (percent = 100) {
   percent = parseInt(percent, 10);
   if (isNaN(percent) || percent < 0 || percent > 100) {
-    log.errorAndThrow(`The percentage value should be valid integer between 0 and 100`);
+    throw new Error(`The percentage value should be valid integer between 0 and 100`);
   }
   await this.adbExecEmu(['power', 'capacity', percent]);
 };
@@ -127,11 +127,11 @@ emuMethods.powerOFF = async function () {
 emuMethods.sendSMS = async function (phoneNumber, message = '') {
   message = message.trim();
   if (message === "") {
-    log.errorAndThrow('Sending an SMS requires a message');
+    throw new Error('Sending an SMS requires a message');
   }
   phoneNumber = `${phoneNumber}`.replace(/\s*/, "");
   if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
-    log.errorAndThrow(`Invalid sendSMS phoneNumber param ${phoneNumber}`);
+    throw new Error(`Invalid sendSMS phoneNumber param ${phoneNumber}`);
   }
   await this.adbExecEmu(['sms', 'send', phoneNumber, message]);
 };
@@ -146,11 +146,11 @@ emuMethods.sendSMS = async function (phoneNumber, message = '') {
  */
 emuMethods.gsmCall = async function (phoneNumber, action = '') {
   if (_.values(emuMethods.GSM_CALL_ACTIONS).indexOf(action) === -1) {
-    log.errorAndThrow(`Invalid gsm action param ${action}. Supported values: ${_.values(emuMethods.GSM_CALL_ACTIONS)}`);
+    throw new Error(`Invalid gsm action param ${action}. Supported values: ${_.values(emuMethods.GSM_CALL_ACTIONS)}`);
   }
   phoneNumber = `${phoneNumber}`.replace(/\s*/, "");
   if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
-    log.errorAndThrow(`Invalid gsmCall phoneNumber param ${phoneNumber}`);
+    throw new Error(`Invalid gsmCall phoneNumber param ${phoneNumber}`);
   }
   await this.adbExecEmu(['gsm', action, phoneNumber]);
 };
@@ -164,7 +164,7 @@ emuMethods.gsmCall = async function (phoneNumber, action = '') {
 emuMethods.gsmSignal = async function (strength = 4) {
   strength = parseInt(strength, 10);
   if (emuMethods.GSM_SIGNAL_STRENGTHS.indexOf(strength) === -1) {
-    log.errorAndThrow(`Invalid signal strength param ${strength}. Supported values: ${_.values(emuMethods.GSM_SIGNAL_STRENGTHS)}`);
+    throw new Error(`Invalid signal strength param ${strength}. Supported values: ${_.values(emuMethods.GSM_SIGNAL_STRENGTHS)}`);
   }
   log.info('gsm signal-profile <strength> changes the reported strength on next (15s) update.');
   await this.adbExecEmu(['gsm', 'signal-profile', strength]);
@@ -179,7 +179,7 @@ emuMethods.gsmSignal = async function (strength = 4) {
 emuMethods.gsmVoice = async function (state = 'on') {
   // gsm voice <state> allows you to change the state of your GPRS connection
   if (_.values(emuMethods.GSM_VOICE_STATES).indexOf(state) === -1) {
-    log.errorAndThrow(`Invalid gsm voice state param ${state}. Supported values: ${_.values(emuMethods.GSM_VOICE_STATES)}`);
+    throw new Error(`Invalid gsm voice state param ${state}. Supported values: ${_.values(emuMethods.GSM_VOICE_STATES)}`);
   }
   await this.adbExecEmu(['gsm', 'voice', state]);
 };
@@ -193,7 +193,7 @@ emuMethods.gsmVoice = async function (state = 'on') {
 emuMethods.networkSpeed = async function (speed = 'full') {
   // network speed <speed> allows you to set the network speed emulation.
   if (_.values(emuMethods.NETWORK_SPEED).indexOf(speed) === -1) {
-    log.errorAndThrow(`Invalid network speed param ${speed}. Supported values: ${_.values(emuMethods.NETWORK_SPEED)}`);
+    throw new Error(`Invalid network speed param ${speed}. Supported values: ${_.values(emuMethods.NETWORK_SPEED)}`);
   }
   await this.adbExecEmu(['network', 'speed', speed]);
 };

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -197,8 +197,14 @@ manifestMethods.targetSdkVersionFromManifest = async function (localApk) {
   await this.initAapt();
   log.info("Extracting package and launch activity from manifest");
   let args = ['dump', 'badging', localApk];
-  let {stdout} = await exec(this.binaries.aapt, args);
-  let targetSdkVersion = new RegExp(/targetSdkVersion:'([^']+)'/g).exec(stdout);
+  let output;
+  try {
+    let {stdout} = await exec(this.binaries.aapt, args);
+    output = stdout;
+  } catch (e) {
+    throw new Error(`fetching targetSdkVersion from local APK failed. Original error: ${e.message}`);
+  }
+  let targetSdkVersion = new RegExp(/targetSdkVersion:'([^']+)'/g).exec(output);
   if (!targetSdkVersion) {
     throw new Error(`targetSdkVersion is not specified in the application.`);
   }
@@ -297,8 +303,12 @@ manifestMethods.insertManifest = async function (manifest, srcApk, dstApk) {
 manifestMethods.hasInternetPermissionFromManifest = async function (localApk) {
   await this.initAapt();
   log.debug("Checking if has internet permission from manifest");
-  let {stdout} = await exec(this.binaries.aapt, ['dump', 'badging', localApk]);
-  return new RegExp(/uses-permission:.*'android.permission.INTERNET'/).test(stdout);
+  try {
+    let {stdout} = await exec(this.binaries.aapt, ['dump', 'badging', localApk]);
+    return new RegExp(/uses-permission:.*'android.permission.INTERNET'/).test(stdout);
+  } catch (e) {
+    throw new Error(`Error checking internet permission for manifest. Original error: ${e.message}`);
+  }
 };
 
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -15,44 +15,40 @@ let manifestMethods = {};
 // note that the process name when used with ps must be truncated to the last 15 chars
 // ps -c com.example.android.apis becomes ps -c le.android.apis
 manifestMethods.processFromManifest = async function (localApk) {
-  try {
-    await this.initAapt();
-    log.info("Retrieving process from manifest");
-    let args = ['dump', 'xmltree', localApk, 'AndroidManifest.xml'];
-    let {stdout} = await exec(this.binaries.aapt, args);
-    let result = null;
-    let lines = stdout.split("\n");
-    let applicationRegex = new RegExp(/\s+E: application \(line=\d+\).*/);
-    let applicationFound = false;
-    let attributeRegex = new RegExp(/\s+A: .+/);
-    let processRegex = new RegExp(/\s+A: android:process\(0x01010011\)="([^"]+).*"/);
-    for (let line of lines) {
-      if (!applicationFound) {
-        if (applicationRegex.test(line)) {
-          applicationFound = true;
+  await this.initAapt();
+  log.info("Retrieving process from manifest");
+  let args = ['dump', 'xmltree', localApk, 'AndroidManifest.xml'];
+  let {stdout} = await exec(this.binaries.aapt, args);
+  let result = null;
+  let lines = stdout.split("\n");
+  let applicationRegex = new RegExp(/\s+E: application \(line=\d+\).*/);
+  let applicationFound = false;
+  let attributeRegex = new RegExp(/\s+A: .+/);
+  let processRegex = new RegExp(/\s+A: android:process\(0x01010011\)="([^"]+).*"/);
+  for (let line of lines) {
+    if (!applicationFound) {
+      if (applicationRegex.test(line)) {
+        applicationFound = true;
+      }
+    } else {
+      let notAttribute = !attributeRegex.test(line);
+      // process must be an attribute after application.
+      if (notAttribute) {
+        break;
+      }
+      let process = processRegex.exec(line);
+      // this is an application attribute process.
+      if (process && process.length > 1) {
+        result = process[1];
+        // must trim to last 15 for android's ps binary
+        if (result.length > 15) {
+          result = result.substr(result.length - 15);
         }
-      } else {
-        let notAttribute = !attributeRegex.test(line);
-        // process must be an attribute after application.
-        if (notAttribute) {
-          break;
-        }
-        let process = processRegex.exec(line);
-        // this is an application attribute process.
-        if (process && process.length > 1) {
-          result = process[1];
-          // must trim to last 15 for android's ps binary
-          if (result.length > 15) {
-            result = result.substr(result.length - 15);
-          }
-          break;
-        }
+        break;
       }
     }
-    return result;
-  } catch (e) {
-    log.errorAndThrow(`processFromManifest failed. Original error: ${e.message}`);
   }
+  return result;
 };
 
 /**
@@ -184,9 +180,9 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function (localApk)
       savedError = e;
     }
   }
-  log.errorAndThrow(`packageAndLaunchActivityFromManifest failed. ` +
-                    `Original error: ${savedError.message}` +
-                    (savedError.stderr ? `; StdErr: ${savedError.stderr}` : ''));
+  throw new Error(`packageAndLaunchActivityFromManifest failed. ` +
+                  `Original error: ${savedError.message}` +
+                  (savedError.stderr ? `; StdErr: ${savedError.stderr}` : ''));
 };
 
 /**
@@ -198,19 +194,15 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function (localApk)
  *                 application package.
  */
 manifestMethods.targetSdkVersionFromManifest = async function (localApk) {
-  try {
-    await this.initAapt();
-    log.info("Extracting package and launch activity from manifest");
-    let args = ['dump', 'badging', localApk];
-    let {stdout} = await exec(this.binaries.aapt, args);
-    let targetSdkVersion = new RegExp(/targetSdkVersion:'([^']+)'/g).exec(stdout);
-    if (!targetSdkVersion) {
-      throw new Error(`targetSdkVersion is not specified in the application.`);
-    }
-    return parseInt(targetSdkVersion[1], 10);
-  } catch (e) {
-    log.errorAndThrow(`fetching targetSdkVersion from local APK failed. Original error: ${e.message}`);
+  await this.initAapt();
+  log.info("Extracting package and launch activity from manifest");
+  let args = ['dump', 'badging', localApk];
+  let {stdout} = await exec(this.binaries.aapt, args);
+  let targetSdkVersion = new RegExp(/targetSdkVersion:'([^']+)'/g).exec(stdout);
+  if (!targetSdkVersion) {
+    throw new Error(`targetSdkVersion is not specified in the application.`);
   }
+  return parseInt(targetSdkVersion[1], 10);
 };
 
 /**
@@ -260,7 +252,7 @@ manifestMethods.compileManifest = async function (manifest, manifestPackage, tar
     ]);
     log.debug("Compiled manifest");
   } catch (err) {
-    log.errorAndThrow(`Error compiling manifest. Original error: ${err.message}`);
+    throw new Error(`Error compiling manifest. Original error: ${err.message}`);
   }
 };
 
@@ -280,24 +272,20 @@ manifestMethods.compileManifest = async function (manifest, manifestPackage, tar
 manifestMethods.insertManifest = async function (manifest, srcApk, dstApk) {
   log.debug(`Inserting manifest, src: ${srcApk} dst: ${dstApk}`);
   await this.initAapt();
+  await unzipFile(`${manifest}.apk`);
+  await fs.copyFile(srcApk, dstApk);
+  log.debug("Testing new tmp apk");
+  await assertZipArchive(dstApk);
+  log.debug("Moving manifest");
   try {
-    await unzipFile(`${manifest}.apk`);
-    await fs.copyFile(srcApk, dstApk);
-    log.debug("Testing new tmp apk");
-    await assertZipArchive(dstApk);
-    log.debug("Moving manifest");
-    try {
-      await exec(this.binaries.aapt, [
-        'remove', dstApk, path.basename(manifest)
-      ]);
-    } catch (ign) {}
     await exec(this.binaries.aapt, [
-      'add', dstApk, path.basename(manifest)
-    ], {cwd: path.dirname(manifest)});
-    log.debug("Inserted manifest.");
-  } catch (e) {
-    log.errorAndThrow(`Error inserting manifest. Original error: ${e.message}`);
-  }
+      'remove', dstApk, path.basename(manifest)
+    ]);
+  } catch (ign) {}
+  await exec(this.binaries.aapt, [
+    'add', dstApk, path.basename(manifest)
+  ], {cwd: path.dirname(manifest)});
+  log.debug("Inserted manifest.");
 };
 
 /**
@@ -307,14 +295,10 @@ manifestMethods.insertManifest = async function (manifest, srcApk, dstApk) {
  * @return {boolean} True if the manifest requires Internet access permission.
  */
 manifestMethods.hasInternetPermissionFromManifest = async function (localApk) {
-  try {
-    await this.initAapt();
-    log.debug("Checking if has internet permission from manifest");
-    let {stdout} = await exec(this.binaries.aapt, ['dump', 'badging', localApk]);
-    return new RegExp(/uses-permission:.*'android.permission.INTERNET'/).test(stdout);
-  } catch (e) {
-    log.errorAndThrow(`Error checking internet permission for manifest. Original error: ${e.message}`);
-  }
+  await this.initAapt();
+  log.debug("Checking if has internet permission from manifest");
+  let {stdout} = await exec(this.binaries.aapt, ['dump', 'badging', localApk]);
+  return new RegExp(/uses-permission:.*'android.permission.INTERNET'/).test(stdout);
 };
 
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -302,12 +302,13 @@ manifestMethods.insertManifest = async function (manifest, srcApk, dstApk) {
  */
 manifestMethods.hasInternetPermissionFromManifest = async function (localApk) {
   await this.initAapt();
-  log.debug("Checking if has internet permission from manifest");
+  log.debug(`Checking if '${localApk}' requires internet access permission in the manifest`);
   try {
     let {stdout} = await exec(this.binaries.aapt, ['dump', 'badging', localApk]);
     return new RegExp(/uses-permission:.*'android.permission.INTERNET'/).test(stdout);
   } catch (e) {
-    throw new Error(`Error checking internet permission for manifest. Original error: ${e.message}`);
+    throw new Error(`Cannot check if '${localApk}' requires internet access permission. ` +
+                    `Original error: ${e.message}`);
   }
 };
 

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -77,7 +77,7 @@ apkSigningMethods.signWithDefaultCert = async function (apk) {
     try {
       await exec(java, ['-jar', signPath, apk, '--override']);
     } catch (e) {
-      log.errorAndThrow(`Could not sign with default certificate. Original error ${e.message}`);
+      throw new Error(`Could not sign with default certificate. Original error ${e.message}`);
     }
   }
 };
@@ -117,7 +117,7 @@ apkSigningMethods.signWithCustomCert = async function (apk) {
         '-keystore', this.keystorePath, '-storepass', this.keystorePassword,
         '-keypass', this.keyPassword, apk, this.keyAlias]);
     } catch (e) {
-      log.errorAndThrow(`Could not sign with custom certificate. Original error ${e.message}`);
+      throw new Error(`Could not sign with custom certificate. Original error ${e.message}`);
     }
   }
 };
@@ -176,7 +176,7 @@ apkSigningMethods.zipAlignApk = async function (apk) {
     if (await fs.exists(alignedApk)) {
       await fs.unlink(alignedApk);
     }
-    log.errorAndThrow(`zipAlignApk failed. Original error: ${e.message}. Stdout: '${e.stdout}'; Stderr: '${e.stderr}'`);
+    throw new Error(`zipAlignApk failed. Original error: ${e.message}. Stdout: '${e.stdout}'; Stderr: '${e.stderr}'`);
   }
 };
 
@@ -260,7 +260,7 @@ apkSigningMethods.getKeystoreMd5 = async function (keytool, md5re) {
     log.debug(`Keystore MD5: ${keystoreHash}`);
     return keystoreHash;
   } catch (e) {
-    log.errorAndThrow(`getKeystoreMd5 failed. Original error: ${e.message}`);
+    throw new Error(`getKeystoreMd5 failed. Original error: ${e.message}`);
   }
 };
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -17,16 +17,16 @@ let apkUtilsMethods = {};
  * @return {boolean} True if the package is installed.
  */
 apkUtilsMethods.isAppInstalled = async function (pkg) {
+  let installed = false;
+  log.debug(`Getting install status for ${pkg}`);
   try {
-    let installed = false;
-    log.debug(`Getting install status for ${pkg}`);
     let stdout = await this.shell(['pm', 'list', 'packages', pkg]);
     let apkInstalledRgx = new RegExp(`^package:${pkg.replace(/(\.)/g, "\\$1")}$`, 'm');
     installed = apkInstalledRgx.test(stdout);
     log.debug(`App is${!installed ? ' not' : ''} installed`);
     return installed;
   } catch (e) {
-    log.errorAndThrow(`Error finding if app is installed. Original error: ${e.message}`);
+    throw new Error(`Error finding if app is installed. Original error: ${e.message}`);
   }
 };
 
@@ -38,7 +38,7 @@ apkUtilsMethods.isAppInstalled = async function (pkg) {
  */
 apkUtilsMethods.startUri = async function (uri, pkg) {
   if (!uri || !pkg) {
-    log.errorAndThrow("URI and package arguments are required");
+    throw new Error("URI and package arguments are required");
   }
   try {
     let args = ["am", "start", "-W", "-a", "android.intent.action.VIEW", "-d",
@@ -48,7 +48,7 @@ apkUtilsMethods.startUri = async function (uri, pkg) {
       throw new Error(res);
     }
   } catch (e) {
-    log.errorAndThrow(`Error attempting to start URI. Original error: ${e}`);
+    throw new Error(`Error attempting to start URI. Original error: ${e}`);
   }
 };
 
@@ -64,7 +64,7 @@ apkUtilsMethods.startUri = async function (uri, pkg) {
 apkUtilsMethods.startApp = async function (startAppOptions = {}) {
   try {
     if (!startAppOptions.activity || !startAppOptions.pkg) {
-      log.errorAndThrow("activity and pkg is required for launching application");
+      throw new Error("activity and pkg is required for launching application");
     }
     startAppOptions = _.clone(startAppOptions);
     startAppOptions.activity = startAppOptions.activity.replace('$', '\\$');
@@ -90,19 +90,19 @@ apkUtilsMethods.startApp = async function (startAppOptions = {}) {
         startAppOptions.retry = false;
         return this.startApp(startAppOptions);
       } else {
-        log.errorAndThrow("Activity used to start app doesn't exist or cannot be " +
+        throw new Error("Activity used to start app doesn't exist or cannot be " +
                           "launched! Make sure it exists and is a launchable activity");
       }
     } else if (stdout.indexOf("java.lang.SecurityException") !== -1) {
       // if the app is disabled on a real device it will throw a security exception
-      log.errorAndThrow("Permission to start activity denied.");
+      throw new Error("Permission to start activity denied.");
     }
     if (startAppOptions.waitActivity) {
       await this.waitForActivity(startAppOptions.waitPkg, startAppOptions.waitActivity,
                                  startAppOptions.waitDuration);
     }
   } catch (e) {
-    log.errorAndThrow(`Error occured while starting App. Original error: ${e.message}`);
+    throw new Error(`Error occured while starting App. Original error: ${e.message}`);
   }
 };
 
@@ -139,10 +139,10 @@ apkUtilsMethods.getFocusedPackageAndActivity = async function () {
     if (foundNullMatch) {
       return {appPackage: null, appActivity: null};
     } else {
-      log.errorAndThrow("Could not parse activity from dumpsys");
+      throw new Error("Could not parse activity from dumpsys");
     }
   } catch (e) {
-    log.errorAndThrow(`Could not get focusPackageAndActivity. Original error: ${e.message}`);
+    throw new Error(`Could not get focusPackageAndActivity. Original error: ${e.message}`);
   }
 };
 
@@ -277,7 +277,7 @@ apkUtilsMethods.uninstallApk = async function (pkg, options = {}) {
     await this.forceStop(pkg);
     stdout = (await this.adbExec(cmd, {timeout})).trim();
   } catch (e) {
-    log.errorAndThrow(`Unable to uninstall APK. Original error: ${e.message}`);
+    throw new Error(`Unable to uninstall APK. Original error: ${e.message}`);
   }
   log.debug(`'adb ${cmd.join(' ')}' command output: ${stdout}`);
   if (stdout.includes("Success")) {
@@ -299,7 +299,7 @@ apkUtilsMethods.uninstallApk = async function (pkg, options = {}) {
 apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = {}) {
   let stdout = await this.shell(['pm', 'install', '-r', apkPathOnDevice], opts);
   if (stdout.indexOf("Failure") !== -1) {
-    log.errorAndThrow(`Remote install failed: ${stdout}`);
+    throw new Error(`Remote install failed: ${stdout}`);
   }
 };
 
@@ -467,7 +467,7 @@ apkUtilsMethods.installOrUpgrade = async function (apk, pkg = null, options = {}
   } catch (err) {
     log.warn(`Cannot upgrade '${pkg}' because of '${err.message}'. Trying full reinstall`);
     if (!await this.uninstallApk(pkg)) {
-      log.errorAndThrow(`'${pkg}' package cannot be uninstalled`);
+      throw new Error(`'${pkg}' package cannot be uninstalled`);
     }
     await this.install(apk, Object.assign({}, options, {replace: false}));
   }
@@ -498,7 +498,7 @@ apkUtilsMethods.extractStringsFromApk = async function (apk, language, out) {
     ]);
     rawAaptOutput = stdout;
   } catch (e) {
-    log.errorAndThrow(`Cannot extract resources from '${apk}'. Original error: ${e.message}`);
+    throw new Error(`Cannot extract resources from '${apk}'. Original error: ${e.message}`);
   }
 
   const defaultConfigMarker = '(default)';
@@ -847,7 +847,7 @@ apkUtilsMethods.getPackageName = async function (apk) {
  */
 apkUtilsMethods.getApkInfo = async function (apkPath) {
   if (!await fs.exists(apkPath)) {
-    log.errorAndThrow(`The file at path ${apkPath} does not exist or is not accessible`);
+    throw new Error(`The file at path ${apkPath} does not exist or is not accessible`);
   }
   await this.initAapt();
   try {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -121,7 +121,7 @@ systemCallMethods.getBinaryFromPath = async function (binaryName) {
     binaryLoc = stdout.trim();
     return binaryLoc;
   } catch (e) {
-    log.errorAndThrow(`Could not find ${binaryName} Please set the ANDROID_HOME ` +
+    throw new Error(`Could not find ${binaryName} Please set the ANDROID_HOME ` +
               `environment variable with the Android SDK root directory path.`);
   }
 };
@@ -168,7 +168,7 @@ systemCallMethods.getConnectedDevices = async function () {
     log.debug(`${devices.length} device(s) connected`);
     return devices;
   } catch (e) {
-    log.errorAndThrow(`Error while getting connected devices. Original error: ${e.message}`);
+    throw new Error(`Error while getting connected devices. Original error: ${e.message}`);
   }
 };
 
@@ -381,7 +381,7 @@ systemCallMethods.getEmulatorPort = async function () {
       throw new Error(`Emulator port not found`);
     }
   } catch (e) {
-    log.errorAndThrow(`No devices connected. Original error: ${e.message}`);
+    throw new Error(`No devices connected. Original error: ${e.message}`);
   }
 };
 
@@ -420,7 +420,7 @@ systemCallMethods.getConnectedEmulators = async function () {
     log.debug(`${emulators.length} emulator(s) connected`);
     return emulators;
   } catch (e) {
-    log.errorAndThrow(`Error getting emulators. Original error: ${e.message}`);
+    throw new Error(`Error getting emulators. Original error: ${e.message}`);
   }
 };
 
@@ -483,7 +483,7 @@ systemCallMethods.getRunningAVD = async function (avdName) {
     log.debug(`Emulator ${avdName} not running`);
     return null;
   } catch (e) {
-    log.errorAndThrow(`Error getting AVD. Original error: ${e.message}`);
+    throw new Error(`Error getting AVD. Original error: ${e.message}`);
   }
 };
 
@@ -513,9 +513,9 @@ systemCallMethods.getRunningAVDWithRetry = async function (avdName, timeoutMs = 
       // cool down
       await sleep(200);
     }
-    log.errorAndThrow(`Could not find ${avdName} emulator.`);
+    throw new Error(`Could not find ${avdName} emulator.`);
   } catch (e) {
-    log.errorAndThrow(`Error getting AVD with retry. Original error: ${e.message}`);
+    throw new Error(`Error getting AVD with retry. Original error: ${e.message}`);
   }
 };
 
@@ -536,7 +536,7 @@ systemCallMethods.killAllEmulators = async function () {
   try {
     await exec(cmd, args);
   } catch (e) {
-    log.errorAndThrow(`Error killing emulators. Original error: ${e.message}`);
+    throw new Error(`Error killing emulators. Original error: ${e.message}`);
   }
 };
 
@@ -611,7 +611,7 @@ systemCallMethods.launchAVD = async function (avdName, avdArgs, language, countr
   });
   proc.on('exit', (code, signal) => {
     if (code !== 0) {
-      log.errorAndThrow(`Emulator avd ${avdName} exit with code ${code}, signal ${signal}`);
+      throw new Error(`Emulator avd ${avdName} exit with code ${code}, signal ${signal}`);
     }
   });
   await retry(retryTimes, this.getRunningAVDWithRetry.bind(this), avdName, avdLaunchTimeout);
@@ -647,7 +647,7 @@ systemCallMethods.getAdbVersion = _.memoize(async function () {
       patch: parts[2] ? parseInt(parts[2], 10) : undefined,
     };
   } catch (e) {
-    log.errorAndThrow(`Error getting adb version. Original error: '${e.message}'; ` +
+    throw new Error(`Error getting adb version. Original error: '${e.message}'; ` +
                         `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
   }
 });
@@ -666,7 +666,7 @@ systemCallMethods.checkAvdExist = async function (avdName) {
   } catch (e) {
     let unknownOptionError = new RegExp("unknown option: -list-avds", "i").test(e.stderr);
     if (!unknownOptionError) {
-      log.errorAndThrow(`Error executing checkAvdExist. Original error: '${e.message}'; ` +
+      throw new Error(`Error executing checkAvdExist. Original error: '${e.message}'; ` +
                         `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
 
     }
@@ -685,7 +685,7 @@ systemCallMethods.checkAvdExist = async function (avdName) {
   }
   if (result.stdout.indexOf(avdName) === -1) {
     let existings = `(${result.stdout.trim().replace(/[\n]/g, '), (')})`;
-    log.errorAndThrow(`Avd '${avdName}' is not available. please select your avd name from one of these: '${existings}'`);
+    throw new Error(`Avd '${avdName}' is not available. please select your avd name from one of these: '${existings}'`);
   }
 };
 
@@ -709,7 +709,7 @@ systemCallMethods.waitForEmulatorReady = async function (timeoutMs = 20000) {
     }
     await sleep(3000);
   }
-  log.errorAndThrow('Emulator not ready');
+  throw new Error('Emulator not ready');
 };
 
 /**
@@ -729,7 +729,7 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
     } catch (e) {
       await this.restartAdb();
       await this.getConnectedDevices();
-      log.errorAndThrow(`Error in waiting for device. Original error: '${e.message}'. ` +
+      throw new Error(`Error in waiting for device. Original error: '${e.message}'. ` +
                          `Retrying by restarting ADB`);
     }
   });
@@ -868,7 +868,7 @@ systemCallMethods.fileSize = async function (remotePath) {
     }
     return parseInt(match[1], 10);
   } catch (err) {
-    log.errorAndThrow(`Unable to get file size for '${remotePath}': ${err.message}`);
+    throw new Error(`Unable to get file size for '${remotePath}': ${err.message}`);
   }
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -667,7 +667,7 @@ systemCallMethods.checkAvdExist = async function (avdName) {
     let unknownOptionError = new RegExp("unknown option: -list-avds", "i").test(e.stderr);
     if (!unknownOptionError) {
       throw new Error(`Error executing checkAvdExist. Original error: '${e.message}'; ` +
-                        `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
+                      `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
 
     }
     const sdkVersion = await getSdkToolsVersion();

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -288,14 +288,15 @@ describe('adb commands', function () {
       });
     }));
     describe('lock', withMocks({adb, log}, (mocks) => {
-      it('should call isScreenLocked, keyevent and errorAndThrow', async function () {
+      it('should call isScreenLocked, keyevent', async function () {
         mocks.adb.expects("isScreenLocked")
-          .atLeast(2).returns(false);
+          .exactly(3)
+          .onCall(0).returns(false)
+          .onCall(1).returns(false)
+          .onCall(2).returns(true);
         mocks.adb.expects("keyevent")
           .once().withExactArgs(26)
           .returns("");
-        mocks.log.expects("errorAndThrow")
-          .once().returns("");
         await adb.lock();
         mocks.adb.verify();
       });


### PR DESCRIPTION
logAndThrow leaves unnecessary traces in logs, which confuse users when these are ignored in the caller code.