### PR TITLE
Improve warning error message

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -70,7 +70,7 @@ apkSigningMethods.signWithDefaultCert = async function (apk) {
     await this.executeApksigner(args);
   } catch (err) {
     log.warn(`Cannot use apksigner tool for signing. Defaulting to sign.jar. ` +
-             `Original error: ${err.message}`);
+             `Original error: ${err.message}` + (err.stderr ? `; StdErr: ${err.stderr}` : ''));
     const java = getJavaForOs();
     const signPath = path.resolve(this.helperJarPath, 'sign.jar');
     log.debug("Resigning apk.");


### PR DESCRIPTION
Now I'm investigating unexpected Java9 signing problem on my PC, but warning error message just says `exited with code 1` and its information is too little to know the error cause.
To know the cause of such problem more easily, I'd like to improve the logging.