### PR TITLE
Make sure adb is running in root mode before sending svc commands

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -688,7 +688,14 @@ methods.isWifiOn = async function () {
  */
 methods.setWifiState = async function (on, isEmulator = false) {
   if (isEmulator) {
-    await this.shell(['svc', 'wifi', on ? 'enable' : 'disable']);
+    const isRoot = await this.root();
+    try {
+      await this.shell(['svc', 'wifi', on ? 'enable' : 'disable']);
+    } finally {
+      if (isRoot) {
+        await this.unroot();
+      }
+    }
   } else {
     await this.shell(['am', 'broadcast', '-a', WIFI_CONNECTION_SETTING_ACTION,
                       '-n', WIFI_CONNECTION_SETTING_RECEIVER,
@@ -715,7 +722,14 @@ methods.isDataOn = async function () {
  */
 methods.setDataState = async function (on, isEmulator = false) {
   if (isEmulator) {
-    await this.shell(['svc', 'data', on ? 'enable' : 'disable']);
+    const isRoot = await this.root();
+    try {
+      await this.shell(['svc', 'data', on ? 'enable' : 'disable']);
+    } finally {
+      if (isRoot) {
+        await this.unroot();
+      }
+    }
   } else {
     await this.shell(['am', 'broadcast', '-a', DATA_CONNECTION_SETTING_ACTION,
                       '-n', DATA_CONNECTION_SETTING_RECEIVER,

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -770,7 +770,7 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
       }
     });
   } finally {
-    this.unroot();
+    await this.unroot();
   }
 };
 

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -409,9 +409,14 @@ describe('adb commands', function () {
         mocks.adb.verify();
       });
       it('should call shell with correct args for emulator', async function () {
+        mocks.adb.expects("root")
+          .once()
+          .returns(true);
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'wifi', 'disable'])
           .returns("");
+        mocks.adb.expects("unroot")
+          .once();
         await adb.setWifiState(false, true);
         mocks.adb.verify();
       });
@@ -443,9 +448,14 @@ describe('adb commands', function () {
         mocks.adb.verify();
       });
       it('should call shell with correct args for emulator', async function () {
+        mocks.adb.expects("root")
+          .once()
+          .returns(true);
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'data', 'enable'])
           .returns("");
+        mocks.adb.expects("unroot")
+          .once();
         await adb.setDataState(true, true);
         mocks.adb.verify();
       });
@@ -461,16 +471,26 @@ describe('adb commands', function () {
         mocks.adb.verify();
       });
       it('should call shell with correct args when turning only wifi off for emulator', async function () {
+        mocks.adb.expects("root")
+          .once()
+          .returns(true);
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'wifi', 'disable'])
           .returns("");
+        mocks.adb.expects("unroot")
+          .once();
         await adb.setWifiAndData({wifi: false}, true);
         mocks.adb.verify();
       });
       it('should call shell with correct args when turning only data on for emulator', async function () {
+        mocks.adb.expects("root")
+          .once()
+          .returns(true);
         mocks.adb.expects("shell")
           .once().withExactArgs(['svc', 'data', 'enable'])
           .returns("");
+        mocks.adb.expects("unroot")
+          .once();
         await adb.setWifiAndData({data: true}, true);
         mocks.adb.verify();
       });
@@ -489,7 +509,12 @@ describe('adb commands', function () {
         mocks.adb.verify();
       });
       it('should call shell with correct args when turning both wifi and data off for emulator', async function () {
+        mocks.adb.expects("root")
+          .atLeast(1)
+          .returns(true);
         mocks.adb.expects("shell").twice().returns("");
+        mocks.adb.expects("unroot")
+          .atLeast(1);
         await adb.setWifiAndData({wifi: false, data: false}, true);
         mocks.adb.verify();
       });


### PR DESCRIPTION
Running any `svc` command, that changes device state, in non-root mode on Android emulator since API 23 has no effect.

@SrinivasanTarget FYI