### PR TITLE
Add a method to remove the previously assigned logcat listener

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1033,7 +1033,7 @@ methods.getLogcatLogs = function () {
  */
 methods.setLogcatListener = function (listener) {
   if (_.isEmpty(this.logcat)) {
-    throw new Error("Can't get logcat logs since logcat hasn't started");
+    throw new Error("Logcat process hasn't been started");
   }
   this.logcat.on('output', listener);
 };
@@ -1047,7 +1047,7 @@ methods.setLogcatListener = function (listener) {
  */
 methods.removeLogcatListener = function (listener) {
   if (_.isEmpty(this.logcat)) {
-    throw new Error("Can't get logcat logs since logcat hasn't started");
+    throw new Error("Logcat process hasn't been started");
   }
   this.logcat.removeListener('output', listener);
 };

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1025,7 +1025,7 @@ methods.getLogcatLogs = function () {
 };
 
 /**
- * Set the callback for for logcat output event.
+ * Set the callback for the logcat output event.
  *
  * @param {Function} listener - The listener function, which accepts one argument. The argument is
  *                              a log record object with `timestamp`, `level` and `message` properties.
@@ -1036,6 +1036,20 @@ methods.setLogcatListener = function (listener) {
     throw new Error("Can't get logcat logs since logcat hasn't started");
   }
   this.logcat.on('output', listener);
+};
+
+/**
+ * Removes the previously set callback for the logcat output event.
+ *
+ * @param {Function} listener - The listener function, which has been previously
+ *                              passed to `setLogcatListener`
+ * @throws {Error} If logcat process is not running.
+ */
+methods.removeLogcatListener = function (listener) {
+  if (_.isEmpty(this.logcat)) {
+    throw new Error("Can't get logcat logs since logcat hasn't started");
+  }
+  this.logcat.removeListener('output', listener);
 };
 
 /**


### PR DESCRIPTION
This will allow to avoid unexpected memory leaks