### PR TITLE
Return standard error from adb commands

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -294,11 +294,11 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
       }
       let args = this.executable.defaultArgs.concat(cmd);
       log.debug(`Running '${this.executable.path} ${quote(args)}'`);
-      let {stdout} = await exec(this.executable.path, args, opts);
+      let {stdout, stderr} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out
       stdout = stdout.replace(linkerWarningRe, '').trim();
-      return stdout;
+      return stderr ? stdout + '\n' + stderr : stdout;
     } catch (e) {
       let protocolFaultError = new RegExp("protocol fault \\(no status\\)", "i").test(e);
       let deviceNotFoundError = new RegExp("error: device ('.+' )?not found", "i").test(e);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -277,7 +277,7 @@ systemCallMethods.adbExecEmu = async function (cmd) {
  * @param {Object} opts - Additional options mapping. See
  *                        {@link https://github.com/appium/node-teen_process}
  *                        for more details.
- * @return {string} - Command's stdout.
+ * @return {string} - Command's stdout and stderr.
  * @throws {Error} If the command returned non-zero exit code.
  */
 systemCallMethods.adbExec = async function (cmd, opts = {}) {
@@ -298,7 +298,7 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out
       stdout = stdout.replace(linkerWarningRe, '').trim();
-      return stderr ? stdout + '\n' + stderr : stdout;
+      return _.isEmpty(stderr) ? stdout : `${stdout}\n${stderr}`;
     } catch (e) {
       let protocolFaultError = new RegExp("protocol fault \\(no status\\)", "i").test(e);
       let deviceNotFoundError = new RegExp("error: device ('.+' )?not found", "i").test(e);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -277,7 +277,7 @@ systemCallMethods.adbExecEmu = async function (cmd) {
  * @param {Object} opts - Additional options mapping. See
  *                        {@link https://github.com/appium/node-teen_process}
  *                        for more details.
- * @return {string} - Command's stdout and stderr.
+ * @return {string} - Command's stdout or both stdout and stderr split by single line break if stderr is not empty
  * @throws {Error} If the command returned non-zero exit code.
  */
 systemCallMethods.adbExec = async function (cmd, opts = {}) {


### PR DESCRIPTION
Currently ADB commands are only returning standard output. On some cases standard error is also filled and should be returned.

For instance running the following adb command (an activity not present in device) in Android 8:
    
    adb shell am start -n 'com.android.settings/.Settings\$AccountsGroupSettingsActivity'

using:

    driver.executeScript("mobile: shell",commandAndArguments);

returns output:

    Starting: Intent { cmp=com.android.settings/.Settings\$AccountsGroupSettingsActivity }

and complete output with stdout and stderr is:

    Starting: Intent { cmp=com.android.settings/.Settings\$AccountsGroupSettingsActivity }
    Error type 3
    Error: Activity class {com.android.settings/com.android.settings.Settings\$AccountsGroupSettingsActivity} does not exist.