### PR TITLE
Memoize some functions for getting binaries

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -20,7 +20,7 @@ const DEFAULT_ADB_REBOOT_RETRIES = 90;
  * @param {string} binaryName - The name of the binary.
  * @return {string} Full path to the given binary including current SDK root.
  */
-systemCallMethods.getSdkBinaryPath = async function (binaryName) {
+systemCallMethods.getSdkBinaryPath = _.memoize(async function (binaryName) {
   log.info(`Checking whether ${binaryName} is present`);
   if (this.sdkRoot) {
     return await this.getBinaryFromSdkRoot(binaryName);
@@ -29,7 +29,7 @@ systemCallMethods.getSdkBinaryPath = async function (binaryName) {
            `root directory path. ANDROID_HOME is required for compatibility ` +
            `with SDK 23+. Checking along PATH for ${binaryName}.`);
   return await this.getBinaryFromPath(binaryName);
-};
+});
 
 /**
  * Retrieve the name of the tool,
@@ -38,9 +38,9 @@ systemCallMethods.getSdkBinaryPath = async function (binaryName) {
  * @return {string} Depending on the current platform this is
  *                  supposed to be either 'which' or 'where'.
  */
-systemCallMethods.getCommandForOS = function () {
+systemCallMethods.getCommandForOS = _.memoize(function () {
   return system.isWindows() ? 'where' : 'which';
-};
+});
 
 /**
  * Retrieve full binary name for the current operating system.
@@ -49,7 +49,7 @@ systemCallMethods.getCommandForOS = function () {
  * @return {string} Formatted binary name depending on the current platform,
  *                  for example, 'android.bat' on Windows.
  */
-systemCallMethods.getBinaryNameForOS = function (binaryName) {
+systemCallMethods.getBinaryNameForOS = _.memoize(function (binaryName) {
   if (!system.isWindows()) {
     return binaryName;
   }
@@ -62,7 +62,7 @@ systemCallMethods.getBinaryNameForOS = function (binaryName) {
     return `${binaryName}.exe`;
   }
   return binaryName;
-};
+});
 
 /**
  * Retrieve full path to the given binary.
@@ -76,7 +76,7 @@ systemCallMethods.getBinaryNameForOS = function (binaryName) {
  *                 of known locations or Android SDK is not installed on the
  *                 local file system.
  */
-systemCallMethods.getBinaryFromSdkRoot = async function (binaryName) {
+systemCallMethods.getBinaryFromSdkRoot = _.memoize(async function (binaryName) {
   let binaryLoc = null;
   binaryName = this.getBinaryNameForOS(binaryName);
   let binaryLocs = [
@@ -101,7 +101,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function (binaryName) {
   binaryLoc = binaryLoc.trim();
   log.info(`Using ${binaryName} from ${binaryLoc}`);
   return binaryLoc;
-};
+});
 
 /**
  * Retrieve full path to a binary file using the standard system lookup tool.


### PR DESCRIPTION
Speed up startup a little bit. Also de-clutter the logs.

On any given system, during execution, the OS and the installed binaries are unlikely to change.

Logs before:
```
dbug ADB Checking app cert for /Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk
info ADB Using apksigner from /Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner
info ADB Using apksigner from /Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner
dbug ADB Starting '/Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner' with args 'verify,--print-certs,/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk'
dbug ADB '/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk' is not signed with debug cert.
info ADB Using apksigner from /Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner
dbug ADB Zip-aligning '/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk'
info ADB Checking whether zipalign is present
info ADB Using zipalign from /Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/zipalign
dbug ADB Signing '/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk' with default cert
info ADB Using apksigner from /Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner
dbug ADB Starting '/Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner' with args 'sign,--key,/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/appium-adb/keys/testkey.pk8,--cert,/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/appium-adb/keys/testkey.x509.pem,/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk'
dbug ADB Getting install status for io.appium.android.apis
dbug ADB Getting connected devices...
```
Logs with this PR
```
dbug ADB Checking app cert for /Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk
dbug ADB Starting '/Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner' with args 'verify,--print-certs,/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk'
dbug ADB '/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk' is not signed with debug cert.
dbug ADB Zip-aligning '/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk'
dbug ADB Signing '/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk' with default cert
dbug ADB Starting '/Users/isaacmurchie/Library/Android/sdk/build-tools/27.0.3/apksigner' with args 'sign,--key,/Users/isaacmurchie/code/appium-adb/keys/testkey.pk8,--cert,/Users/isaacmurchie/code/appium-adb/keys/testkey.x509.pem,/Users/isaacmurchie/code/appium-uiautomator2-driver/node_modules/android-apidemos/bin/ApiDemos-debug.apk'
dbug ADB Getting install status for io.appium.android.apis
```