### PR TITLE
Only patch apksigner if there is execution failure

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -12,40 +12,68 @@ const DEFAULT_CERT_DIGEST = 'a40da80a59d170caa950cf15c18c454d47a39b26989d8b640ec
 let apkSigningMethods = {};
 
 /**
- * Execute apksigner utility with given arguments. This method
- * also applies the patch, which workarounds
- * '-Djava.ext.dirs is not supported. Use -classpath instead.' error on Windows.
+ * Applies the patch, which workarounds'-Djava.ext.dirs is not supported. Use -classpath instead.'
+ * error on Windows by creating a temporary patched copy of the original apksigner script.
+ *
+ * @param {string} originalPath - The original path to apksigner tool
+ * @returns {string} The full path to the patched script or the same path if there is
+ *                   no need to patch the original file.
+ */
+async function patchApksigner (originalPath) {
+  const originalContent = await fs.readFile(originalPath, 'ascii');
+  const patchedContent = originalContent.replace('-Djava.ext.dirs="%frameworkdir%"',
+    '-cp "%frameworkdir%\\*"');
+  if (patchedContent === originalContent) {
+    return originalPath;
+  }
+  log.debug(`Patching '${originalPath}...`);
+  const apkSigner = await tempDir.path({prefix: 'apksigner', suffix: '.bat'});
+  await mkdirp(path.dirname(apkSigner));
+  await fs.writeFile(apkSigner, patchedContent, 'ascii');
+  return apkSigner;
+}
+
+/**
+ * Execute apksigner utility with given arguments.
  *
  * @param {?Array<String>} args - The list of tool arguments.
- * @return {string} Command stdout
+ * @return {string} - Command stdout
  * @throws {Error} If apksigner binary is not present on the local file system
  *                 or the return code is not equal to zero.
  */
 apkSigningMethods.executeApksigner = async function (args = []) {
   let apkSigner = await getApksignerForOs(this);
   const originalFolder = path.dirname(apkSigner);
-  let isPatched = false;
-  if (system.isWindows() && await fs.exists(apkSigner)) {
-    const originalContent = await fs.readFile(apkSigner, 'ascii');
-    const patchedContent = originalContent.replace('-Djava.ext.dirs="%frameworkdir%"',
-      '-cp "%frameworkdir%\\*"');
-    if (patchedContent !== originalContent) {
-      log.debug(`Patching '${apkSigner}' for Windows...`);
-      apkSigner = await tempDir.path({prefix: 'apksigner', suffix: '.bat'});
-      await mkdirp(path.dirname(apkSigner));
-      await fs.writeFile(apkSigner, patchedContent, 'ascii');
-      isPatched = true;
-    }
-  }
-  log.debug(`Starting ${isPatched ? 'patched ' : ''}'${apkSigner}' with args '${args}'`);
-  try {
-    return (await exec(apkSigner, args, {
+  const getApksignerOutput = async (apksignerPath) => {
+    const {stdout, stderr} = await exec(apksignerPath, args, {
       cwd: originalFolder,
-    })).stdout;
-  } finally {
-    if (isPatched && await fs.exists(apkSigner)) {
-      await fs.unlink(apkSigner);
+    });
+    if (stdout) {
+      log.debug(`apksigner output: ${stdout}`);
     }
+    if (stderr) {
+      log.debug(`apksigner stderr: ${stderr}`);
+    }
+    return stdout;
+  };
+  log.debug(`Starting '${apkSigner}' with args '${JSON.stringify(args)}'`);
+  try {
+    return await getApksignerOutput(apkSigner);
+  } catch (err) {
+    if (err.stderr) {
+      log.warn(`Got an error during apksigner execution: ${err.stderr}`);
+    }
+    if (system.isWindows()) {
+      const patchedApksigner = await patchApksigner(apkSigner);
+      if (patchedApksigner !== apkSigner) {
+        try {
+          return await getApksignerOutput(patchedApksigner);
+        } finally {
+          await fs.unlink(patchedApksigner);
+        }
+      }
+    }
+    throw err;
   }
 };
 

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -48,11 +48,10 @@ apkSigningMethods.executeApksigner = async function (args = []) {
     const {stdout, stderr} = await exec(apksignerPath, args, {
       cwd: originalFolder,
     });
-    if (stdout) {
-      log.debug(`apksigner output: ${stdout}`);
-    }
-    if (stderr) {
-      log.debug(`apksigner stderr: ${stderr}`);
+    for (const [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
+      if (stream) {
+        log.debug(`apksigner ${name}: ${stream}`);
+      }
     }
     return stdout;
   };
@@ -60,8 +59,11 @@ apkSigningMethods.executeApksigner = async function (args = []) {
   try {
     return await getApksignerOutput(apkSigner);
   } catch (err) {
-    if (err.stderr) {
-      log.warn(`Got an error during apksigner execution: ${err.stderr}`);
+    log.warn(`Got an error during apksigner execution: ${err.message}`);
+    for (const [name, stream] of [['stdout', err.stdout], ['stderr', err.stderr]]) {
+      if (stream) {
+        log.warn(`apksigner ${name}: ${stream}`);
+      }
     }
     if (system.isWindows()) {
       const patchedApksigner = await patchApksigner(apkSigner);

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -27,10 +27,10 @@ async function patchApksigner (originalPath) {
     return originalPath;
   }
   log.debug(`Patching '${originalPath}...`);
-  const apkSigner = await tempDir.path({prefix: 'apksigner', suffix: '.bat'});
-  await mkdirp(path.dirname(apkSigner));
-  await fs.writeFile(apkSigner, patchedContent, 'ascii');
-  return apkSigner;
+  const patchedPath = await tempDir.path({prefix: 'apksigner', suffix: '.bat'});
+  await mkdirp(path.dirname(patchedPath));
+  await fs.writeFile(patchedPath, patchedContent, 'ascii');
+  return patchedPath;
 }
 
 /**
@@ -42,7 +42,7 @@ async function patchApksigner (originalPath) {
  *                 or the return code is not equal to zero.
  */
 apkSigningMethods.executeApksigner = async function (args = []) {
-  let apkSigner = await getApksignerForOs(this);
+  const apkSigner = await getApksignerForOs(this);
   const originalFolder = path.dirname(apkSigner);
   const getApksignerOutput = async (apksignerPath) => {
     const {stdout, stderr} = await exec(apksignerPath, args, {


### PR DESCRIPTION
It looks like apksigner utility has been fixed in the newer Android SDKs, so it is not necessary to patch it anymore.