### PR TITLE
add hide api policy settings for Android P

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -345,6 +345,28 @@ methods.toggleGPSLocationProvider = async function (enabled) {
 };
 
 /**
+ * Permit access to all non-SDK APIs, but keep warnings in the log.
+ * https://developer.android.com/preview/restrictions-non-sdk-interfaces
+ *
+ * Commands don't lead crash or something, thus simply this method calls putting all setting.
+ */
+methods.hiddenApiPolicyP = async function () {
+  await this.setSetting('global', 'hidden_api_policy_pre_p_apps', '1');
+  await this.setSetting('global', 'hidden_api_policy_p_apps', '1');
+};
+
+/**
+ * Reset accessing to non-SDK APIs to the default setting
+ * https://developer.android.com/preview/restrictions-non-sdk-interfaces
+ *
+ * Commands don't lead crash or something, thus simply this method calls deleting all setting.
+ */
+methods.defaultHiddenApiPolicyP = async function () {
+  await this.shell(['settings', 'delete', 'global', 'hidden_api_policy_pre_p_apps']);
+  await this.shell(['settings', 'delete', 'global', 'hidden_api_policy_p_apps']);
+};
+
+/**
  * Stop the particular package if it is running and clears its application data.
  *
  * @param {string} pkg - The package name to be processed.

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -350,7 +350,7 @@ methods.toggleGPSLocationProvider = async function (enabled) {
  *
  * Commands don't lead crash or something, thus simply this method calls putting all setting.
  */
-methods.hiddenApiPolicyP = async function () {
+methods.relaxHiddenApiPolicy = async function () {
   await this.setSetting('global', 'hidden_api_policy_pre_p_apps', '1');
   await this.setSetting('global', 'hidden_api_policy_p_apps', '1');
 };
@@ -361,7 +361,7 @@ methods.hiddenApiPolicyP = async function () {
  *
  * Commands don't lead crash or something, thus simply this method calls deleting all setting.
  */
-methods.defaultHiddenApiPolicyP = async function () {
+methods.setDefaultHiddenApiPolicy = async function () {
   await this.shell(['settings', 'delete', 'global', 'hidden_api_policy_pre_p_apps']);
   await this.shell(['settings', 'delete', 'global', 'hidden_api_policy_p_apps']);
 };

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -349,10 +349,18 @@ methods.toggleGPSLocationProvider = async function (enabled) {
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  *
  * Commands don't lead crash or something, thus simply this method calls putting all setting.
+ *
+ * @param {number} value - The API enforcement policy.
+ *     0: Disable non-SDK API usage detection. This will also disable logging, and also break the strict mode API,
+ *        detectNonSdkApiUsage(). Not recommended.
+ *     1: "Just warn" - permit access to all non-SDK APIs, but keep warnings in the log.
+ *        The strict mode API will keep working.
+ *     2: Disallow usage of dark grey and black listed APIs.
+ *     3: Disallow usage of blacklisted APIs, but allow usage of dark grey listed APIs.
  */
-methods.relaxHiddenApiPolicy = async function () {
-  await this.setSetting('global', 'hidden_api_policy_pre_p_apps', '1');
-  await this.setSetting('global', 'hidden_api_policy_p_apps', '1');
+methods.setHiddenApiPolicy = async function (value) {
+  await this.setSetting('global', 'hidden_api_policy_pre_p_apps', value.toString());
+  await this.setSetting('global', 'hidden_api_policy_p_apps', value.toString());
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -345,10 +345,8 @@ methods.toggleGPSLocationProvider = async function (enabled) {
 };
 
 /**
- * Permit access to all non-SDK APIs, but keep warnings in the log.
+ * Set hidden api policy to manage access to non-SDK APIs.
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
- *
- * Commands don't lead crash or something, thus simply this method calls putting all setting.
  *
  * @param {number} value - The API enforcement policy.
  *     0: Disable non-SDK API usage detection. This will also disable logging, and also break the strict mode API,
@@ -359,15 +357,13 @@ methods.toggleGPSLocationProvider = async function (enabled) {
  *     3: Disallow usage of blacklisted APIs, but allow usage of dark grey listed APIs.
  */
 methods.setHiddenApiPolicy = async function (value) {
-  await this.setSetting('global', 'hidden_api_policy_pre_p_apps', value.toString());
-  await this.setSetting('global', 'hidden_api_policy_p_apps', value.toString());
+  await this.setSetting('global', 'hidden_api_policy_pre_p_apps', value);
+  await this.setSetting('global', 'hidden_api_policy_p_apps', value);
 };
 
 /**
- * Reset accessing to non-SDK APIs to the default setting
+ * Reset access to non-SDK APIs to its default setting.
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
- *
- * Commands don't lead crash or something, thus simply this method calls deleting all setting.
  */
 methods.setDefaultHiddenApiPolicy = async function () {
   await this.shell(['settings', 'delete', 'global', 'hidden_api_policy_pre_p_apps']);

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -348,7 +348,7 @@ methods.toggleGPSLocationProvider = async function (enabled) {
  * Set hidden api policy to manage access to non-SDK APIs.
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  *
- * @param {number} value - The API enforcement policy.
+ * @param {number|string} value - The API enforcement policy.
  *     0: Disable non-SDK API usage detection. This will also disable logging, and also break the strict mode API,
  *        detectNonSdkApiUsage(). Not recommended.
  *     1: "Just warn" - permit access to all non-SDK APIs, but keep warnings in the log.


### PR DESCRIPTION
Commands mentioned in https://github.com/appium/io.appium.settings/pull/15

Android P emulator returns 27 as the emulator's API level.
Thus, we can't filter if we send this command or not from API Level...