### PR TITLE
Add parsing of altitude value

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -856,14 +856,16 @@ methods.setDeviceSysLocaleViaSettingApp = async function (language, country) {
 
 /**
  * @typedef {Object} Location
- * @property {float|string} longitude - Valid longitude value.
- * @property {float|string} latitude - Valid latitude value.
+ * @property {number|string} longitude - Valid longitude value.
+ * @property {number|string} latitude - Valid latitude value.
+ * @property {?number|string} altitude - Valid altitude value.
  */
 
 /**
  * Emulate geolocation coordinates on the device under test.
  *
- * @param {Location} location - Location object.
+ * @param {Location} location - Location object. The `altitude` value is ignored
+ * while mocking the position.
  * @param {boolean} isEmulator [false] - Set it to true if the device under test
  *                                       is an emulator rather than a real device.
  */
@@ -913,13 +915,14 @@ methods.getGeoLocation = async function () {
       `services must be enabled on the device. Original error: ${err.message}`);
   }
 
-  const match = /data="(-?[\d\.]+)\s+(-?[\d\.]+)"/.exec(output);
+  const match = /data="(-?[\d\.]+)\s+(-?[\d\.]+)\s+(-?[\d\.]+)"/.exec(output);
   if (!match) {
-    throw new Error(`Cannot parse the actual latitude and longitude values from the command output: ${output}`);
+    throw new Error(`Cannot parse the actual location values from the command output: ${output}`);
   }
   const location = {
     latitude: match[1],
     longitude: match[2],
+    altitude: match[3],
   };
   log.debug(`Got geo coordinates: ${JSON.stringify(location)}`);
   return location;


### PR DESCRIPTION
Selenium API also requires `altitude` value to set. The PR depends on https://github.com/appium/io.appium.settings/pull/17