### PR TITLE
Verify APK state before zipaligning it

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -171,9 +171,7 @@ apkSigningMethods.sign = async function (apk) {
     // it is necessary to apply zipalign only before signing
     // if apksigner is used or only after signing if we only have
     // sign.jar utility
-    try {
-      await this.zipAlignApk(apk);
-    } catch (ign) {}
+    await this.zipAlignApk(apk);
   }
 
   if (this.useKeystore) {
@@ -191,16 +189,25 @@ apkSigningMethods.sign = async function (apk) {
  * Perform zip-aligning to the given local apk file.
  *
  * @param {string} apk - The full path to the local apk file.
+ * @returns {boolean} True if the apk has been successfully aligned
+ * or false if the apk has been already aligned.
  * @throws {Error} If zip-align fails.
  */
 apkSigningMethods.zipAlignApk = async function (apk) {
-  log.debug(`Zip-aligning '${apk}'`);
   await this.initZipAlign();
-  let alignedApk = await tempDir.path({prefix: 'appium', suffix: '.tmp'});
+  try {
+    await exec(this.binaries.zipalign, ['-c', '4', apk]);
+    log.debug('The apk is already aligned. Doing nothing');
+    return false;
+  } catch (e) {
+    log.debug(`'${apk}' is not aligned. Zip-aligning`);
+  }
+  const alignedApk = await tempDir.path({prefix: 'appium', suffix: '.tmp'});
   await mkdirp(path.dirname(alignedApk));
   try {
     await exec(this.binaries.zipalign, ['-f', '4', apk, alignedApk]);
     await fs.mv(alignedApk, apk, { mkdirp: true });
+    return true;
   } catch (e) {
     if (await fs.exists(alignedApk)) {
       await fs.unlink(alignedApk);

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -197,10 +197,10 @@ apkSigningMethods.zipAlignApk = async function (apk) {
   await this.initZipAlign();
   try {
     await exec(this.binaries.zipalign, ['-c', '4', apk]);
-    log.debug('The apk is already aligned. Doing nothing');
+    log.debug(`${apk}' is already zip-aligned. Doing nothing`);
     return false;
   } catch (e) {
-    log.debug(`'${apk}' is not aligned. Zip-aligning`);
+    log.debug(`'${apk}' is not zip-aligned. Aligning`);
   }
   const alignedApk = await tempDir.path({prefix: 'appium', suffix: '.tmp'});
   await mkdirp(path.dirname(alignedApk));


### PR DESCRIPTION
There is no point to perform zip align on already aligned package. This also saves resources.