### PR TITLE
Speed up isInstalled verification

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -18,18 +18,17 @@ const ACTIVITIES_TROUBLESHOOTING_LINK =
  *
  * @param {string} pkg - The name of the package to check.
  * @return {boolean} True if the package is installed.
+ * @throws {Error} If there was an error while detecting application state
  */
 apkUtilsMethods.isAppInstalled = async function (pkg) {
-  let installed = false;
   log.debug(`Getting install status for ${pkg}`);
   try {
-    let stdout = await this.shell(['pm', 'list', 'packages', pkg]);
-    let apkInstalledRgx = new RegExp(`^package:${pkg.replace(/(\.)/g, "\\$1")}$`, 'm');
-    installed = apkInstalledRgx.test(stdout);
-    log.debug(`App is${!installed ? ' not' : ''} installed`);
-    return installed;
+    const stdout = await this.shell(['dumpsys', 'package', pkg]);
+    const isInstalled = !_.includes(stdout, 'Unable to find package:');
+    log.debug(`'${pkg}' is${!isInstalled ? ' not' : ''} installed`);
+    return isInstalled;
   } catch (e) {
-    throw new Error(`Error finding if app is installed. Original error: ${e.message}`);
+    throw new Error(`Error finding if '${pkg}' is installed. Original error: ${e.message}`);
   }
 };
 

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -33,15 +33,20 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     it('should parse correctly and return true', async function () {
       const pkg = 'dummy.package';
       mocks.adb.expects('shell')
-        .once().withExactArgs(['pm', 'list', 'packages', pkg])
-        .returns(`package:${pkg}`);
+        .once().withExactArgs(['dumpsys', 'package', pkg])
+        .returns(`Dexopt state:
+        [${pkg}]
+          Instruction Set: x86
+            path: /system/priv-app/Shell/Shell.apk
+            status: /system/priv-app/Shell/oat/x86/Shell.odex [compilation_filter=speed, status=kOatUpToDate]`);
       (await adb.isAppInstalled(pkg)).should.be.true;
     });
     it('should parse correctly and return false', async function () {
       const pkg = 'dummy.package';
       mocks.adb.expects('shell')
-        .once().withExactArgs(['pm', 'list', 'packages', pkg])
-        .returns("");
+        .once().withExactArgs(['dumpsys', 'package', pkg])
+        .returns(`Dexopt state:
+          Unable to find package: ${pkg}`);
       (await adb.isAppInstalled(pkg)).should.be.false;
     });
   });


### PR DESCRIPTION
It looks like package manager invocation from adb takes much more time than dumpsys invocation:

```
2018-09-21 17:37:43:211 - info: [debug] [ADB] Getting install status for com.wire.internal
2018-09-21 17:37:43:212 - info: [debug] [ADB] Running '/Users/elf/Library/Android/sdk/platform-tools/adb -P 5037 -s 52003a49f46b84a1 shell pm list packages com.wire.internal'
2018-09-21 17:37:44:421 - info: [debug] [ADB] App is installed
2018-09-21 17:37:44:422 - info: [debug] [ADB] Running '/Users/elf/Library/Android/sdk/platform-tools/adb -P 5037 -s 52003a49f46b84a1 shell am force-stop com.wire.internal'
2018-09-21 17:37:45:568 - info: [debug] [ADB] Running '/Users/elf/Library/Android/sdk/platform-tools/adb -P 5037 -s 52003a49f46b84a1 shell pm clear com.wire.internal'
2018-09-21 17:37:46:723 - info: [debug] [ADB] Device API level: 24
2018-09-21 17:37:46:724 - info: [debug] [ADB] Running '/Users/elf/Library/Android/sdk/platform-tools/adb -P 5037 -s 52003a49f46b84a1 shell dumpsys package com.wire.internal'
2018-09-21 17:37:46:804 - info: [debug] [ADB] Running '/Users/elf/Library/Android/sdk/platform-tools/adb -P 5037 -s 52003a49f46b84a1 shell pm dump com.wire.internal'
```