### PR TITLE
Do not include apksigner warnings into the common log

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -49,15 +49,17 @@ apkSigningMethods.executeApksigner = async function (args = []) {
       cwd: originalFolder,
     });
     for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
-      if (stream) {
-        if (name === 'stdout') {
-          // Make the output less talkative
-          stream = stream.split('\n')
-            .filter((line) => !line.includes('WARNING:'))
-            .join('\n');
-        }
-        log.debug(`apksigner ${name}: ${stream}`);
+      if (!stream) {
+        continue;
       }
+
+      if (name === 'stdout') {
+        // Make the output less talkative
+        stream = stream.split('\n')
+          .filter((line) => !line.includes('WARNING:'))
+          .join('\n');
+      }
+      log.debug(`apksigner ${name}: ${stream}`);
     }
     return stdout;
   };

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -48,8 +48,14 @@ apkSigningMethods.executeApksigner = async function (args = []) {
     const {stdout, stderr} = await exec(apksignerPath, args, {
       cwd: originalFolder,
     });
-    for (const [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
+    for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
       if (stream) {
+        if (name === 'stdout') {
+          // Make the output less talkative
+          stream = stream.split('\n')
+            .filter((line) => !line.includes('WARNING:'))
+            .join('\n');
+        }
         log.debug(`apksigner ${name}: ${stream}`);
       }
     }


### PR DESCRIPTION
Sometimes the utility is too talkative and spams the log with unnecessary stuff:

```
2018-09-21 17:37:40:644 - info: [debug] [ADB] WARNING: META-INF/android.arch.core_runtime.version not protected by signature. Unauthorized modifications to this JAR entry will not be detected. Delete or move the entry outside of META-INF/.
2018-09-21 17:37:40:644 - info: [debug] [ADB] WARNING: META-INF/android.arch.lifecycle_extensions.version not protected by signature. Unauthorized modifications to this JAR entry will not be detected. Delete or move the entry outside of META-INF/.
2018-09-21 17:37:40:644 - info: [debug] [ADB] WARNING: META-INF/android.arch.lifecycle_livedata-core.version not protected by signature. Unauthorized modifications to this JAR entry will not be detected. Delete or move the entry outside of META-INF/.
2018-09-21 17:37:40:644 - info: [debug] [ADB] WARNING: META-INF/android.arch.lifecycle_livedata.version not protected by signature. Unauthorized modifications to this JAR entry will not be detected. Delete or move the entry outside of META-INF/.
2
```