### PR TITLE
Delete the unused method

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -390,18 +390,6 @@ methods.stopAndClear = async function (pkg) {
 };
 
 /**
- * Retrieve the target SDK version for the particular package.
- *
- * @param {string} pkg - The package name to be processed.
- * @return {string} The parsed SDK version.
- */
-methods.getTargetSdkUsingPKG = async function (pkg) {
-  let stdout = await this.shell(['pm', 'dump', pkg]);
-  let targetSdk = new RegExp(/targetSdk=([^\s\s]+)/g).exec(stdout)[1];
-  return targetSdk;
-};
-
-/**
  * Retrieve the list of available input methods (IMEs) for the device under test.
  *
  * @return {Array.<String>} The list of IME names or an empty list.


### PR DESCRIPTION
This method is:
- slow
- not used anywhere
- duplicate of `targetSdkVersionUsingPKG`