### PR TITLE
Make sure we try verify.jar if apksigner fails to verify

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -70,7 +70,14 @@ apkSigningMethods.executeApksigner = async function (args = []) {
     log.warn(`Got an error during apksigner execution: ${err.message}`);
     for (const [name, stream] of [['stdout', err.stdout], ['stderr', err.stderr]]) {
       if (stream) {
-        log.warn(`apksigner ${name}: ${stream}`);
+        log.warn(`apksigner ${name}:`);
+        for (const line of stream.split('\n')) {
+          // we do not want to print out stack traces into Java code
+          if (_.isEmpty(line) || /\s+at\s/.test(line)) {
+            continue;
+          }
+          log.warn(`  ${line}`);
+        }
       }
     }
     if (system.isWindows()) {
@@ -241,27 +248,28 @@ apkSigningMethods.checkApkCert = async function (apk, pkg) {
     return await this.checkCustomApkCert(apk, pkg);
   }
 
-  let verificationFunc;
   try {
     await getApksignerForOs(this);
-    verificationFunc = async () => {
-      const output = await this.executeApksigner(['verify', '--print-certs', apk]);
-      if (!_.includes(output, DEFAULT_CERT_DIGEST)) {
-        throw new Error(`'${apk}' is signed with non-default certificate`);
-      }
-    };
-  } catch (e) {
-    log.warn(`Cannot use apksigner tool for signature verification. Defaulting to verify.jar. ` +
-      `Original error: ${e.message}`);
-    const java = getJavaForOs();
-    verificationFunc = async () => await exec(java, ['-jar', path.resolve(this.helperJarPath, 'verify.jar'), apk]);
-  }
-  try {
-    await verificationFunc();
+    const output = await this.executeApksigner(['verify', '--print-certs', apk]);
+    if (!_.includes(output, DEFAULT_CERT_DIGEST)) {
+      throw new Error(`'${apk}' is signed with non-default certificate`);
+    }
     log.debug(`'${apk}' is already signed.`);
     return true;
   } catch (e) {
-    log.debug(`'${apk}' is not signed with debug cert.`);
+    log.warn(`Cannot use apksigner tool for signature verification. ` +
+      `Original error: ${e.message}`);
+  }
+
+  // default to verify.jar
+  try {
+    log.debug(`Defaulting to verify.jar`);
+    const java = getJavaForOs();
+    await exec(java, ['-jar', path.resolve(this.helperJarPath, 'verify.jar'), apk]);
+    log.debug(`'${apk}' is already signed.`);
+    return true;
+  } catch (e) {
+    log.debug(`'${apk}' is not signed with debug cert: ${e.stderr}`);
     return false;
   }
 };

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -71,14 +71,7 @@ apkSigningMethods.executeApksigner = async function (args = []) {
     log.warn(`Got an error during apksigner execution: ${err.message}`);
     for (const [name, stream] of [['stdout', err.stdout], ['stderr', err.stderr]]) {
       if (stream) {
-        log.warn(`apksigner ${name}:`);
-        for (const line of stream.split('\n')) {
-          // we do not want to print out stack traces into Java code
-          if (_.isEmpty(line.trim()) || /\s+at\s/.test(line)) {
-            continue;
-          }
-          log.warn(`  ${line}`);
-        }
+        log.warn(`apksigner ${name}: ${stream}`);
       }
     }
     if (system.isWindows()) {

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -8,6 +8,7 @@ import { getJavaForOs, getApksignerForOs, getJavaHome, rootDir } from '../helper
 const DEFAULT_PRIVATE_KEY = path.resolve(rootDir, 'keys', 'testkey.pk8');
 const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
 const DEFAULT_CERT_DIGEST = 'a40da80a59d170caa950cf15c18c454d47a39b26989d8b640ecd745ba71bf5dc';
+const APKSIGNER_VERIFY_FAIL = 'DOES NOT VERIFY';
 
 let apkSigningMethods = {};
 
@@ -73,7 +74,7 @@ apkSigningMethods.executeApksigner = async function (args = []) {
         log.warn(`apksigner ${name}:`);
         for (const line of stream.split('\n')) {
           // we do not want to print out stack traces into Java code
-          if (_.isEmpty(line) || /\s+at\s/.test(line)) {
+          if (_.isEmpty(line.trim()) || /\s+at\s/.test(line)) {
             continue;
           }
           log.warn(`  ${line}`);
@@ -241,7 +242,7 @@ apkSigningMethods.zipAlignApk = async function (apk) {
 apkSigningMethods.checkApkCert = async function (apk, pkg) {
   log.debug(`Checking app cert for ${apk}`);
   if (!await fs.exists(apk)) {
-    log.debug(`'${apk}' doesn't exist`);
+    log.debug(`'${apk}' does not exist`);
     return false;
   }
   if (this.useKeystore) {
@@ -252,13 +253,19 @@ apkSigningMethods.checkApkCert = async function (apk, pkg) {
     await getApksignerForOs(this);
     const output = await this.executeApksigner(['verify', '--print-certs', apk]);
     if (!_.includes(output, DEFAULT_CERT_DIGEST)) {
-      throw new Error(`'${apk}' is signed with non-default certificate`);
+      log.debug(`'${apk}' is signed with non-default certificate`);
+      return false;
     }
     log.debug(`'${apk}' is already signed.`);
     return true;
-  } catch (e) {
+  } catch (err) {
+    // check if there is no signature
+    if (err.stderr && err.stderr.includes(APKSIGNER_VERIFY_FAIL)) {
+      log.debug(`'${apk}' is not signed with debug cert`);
+      return false;
+    }
     log.warn(`Cannot use apksigner tool for signature verification. ` +
-      `Original error: ${e.message}`);
+      `Original error: ${err.message}`);
   }
 
   // default to verify.jar
@@ -268,8 +275,8 @@ apkSigningMethods.checkApkCert = async function (apk, pkg) {
     await exec(java, ['-jar', path.resolve(this.helperJarPath, 'verify.jar'), apk]);
     log.debug(`'${apk}' is already signed.`);
     return true;
-  } catch (e) {
-    log.debug(`'${apk}' is not signed with debug cert: ${e.stderr}`);
+  } catch (err) {
+    log.debug(`'${apk}' is not signed with debug cert${err.stderr ? `: ${err.stderr}` : ''}`);
     return false;
   }
 };


### PR DESCRIPTION
If `apksigner` is not there, we successfully make use of `verify.jar` to do certificate verification. But if it _is_ there, but fails, we also want to drop back to the older technology. This happens consistently, for instance, when Appium is running with Java 7 and the app was compiled with Java 8. In that case currently we _always_ assume it is unsigned and go through the whole signing process.

Also, there is no need to log stack traces into third party tools. So skip the stack trace for `apksigner` error logs.

Cc: @vrunoa 