### PR TITLE
Add bundletool for .aab module

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -7,6 +7,8 @@ import { retryInterval } from 'asyncbox';
 import { fs, util, mkdirp } from 'appium-support';
 import semver from 'semver';
 import os from 'os';
+import bundletool from "./bundletool";
+import systemCallMethods from "./system-calls";
 
 let apkUtilsMethods = {};
 
@@ -368,13 +370,20 @@ const APK_INSTALL_TIMEOUT = 60000;
 /**
  * Install the package from the local file system.
  *
- * @param {string} apk - The full path to the local package.
+ * @param {string} apk - The full path to the local package. Use bundletool when the path has `.apks`.
  * @param {boolean} repalce [true] - Whether to replace the package if it
  *                                   already installed. True by default.
  * @param {?InstallOptions} options - The set of installation options.
  * @throws {error} If an unexpected error happens during install.
  */
 apkUtilsMethods.install = async function (apk, options = {}) {
+  if (path.extname(apk) === '.apks') {
+    // TODO: Take care of `.apks` in other places
+    if (systemCallMethods.curDeviceId) {
+      return await bundletool.installApks(apk, systemCallMethods.curDeviceId);
+    }
+  }
+
   if (!util.hasValue(options.replace)) {
     options.replace = true;
   }

--- a/lib/tools/bundletool.js
+++ b/lib/tools/bundletool.js
@@ -1,0 +1,114 @@
+import { exec } from 'teen_process';
+import log from '../logger.js';
+import path from 'path';
+import _ from 'lodash';
+import {getJavaForOs} from "../helpers";
+
+let bundletool = {};
+
+/**
+ * Check bundletool version
+ *
+ * @return {string} Version of bundletool. i.e., BundleTool 0.6.0
+ * @throws {Error} If get version fails
+ */
+bundletool.version = async function () {
+  const java = getJavaForOs();
+  const bundletoolPath = path.resolve(this.helperJarPath, 'bundletool.jar');
+  try {
+    return await exec(java, ['-jar', bundletoolPath, 'version']);
+  } catch (e) {
+    throw new Error(`Could not get bundle tool version. Original error ${e.message}`);
+  }
+};
+
+/**
+ * Install apks
+ *
+ * @param {string} apks - The full path to the local apks file.
+ * @param {string} deviceId - The device serial to install the apks to.
+ * @param {[string]} modules - List of modules to be installed (defaults to all of them).
+ *                           Note that the dependent modules will also be installed.
+ *                           Ignored if the device receives a standalone APK.
+ * @return {string} Command stdout
+ * @throws {Error} If installation fails. e.g. INSTALL_PARSE_FAILED_NO_CERTIFICATES
+ */
+bundletool.installApks = async function (apks, deviceId, modules = []) {
+  const java = getJavaForOs();
+  const bundletoolPath = path.resolve(this.helperJarPath, 'bundletool.jar');
+  let installArgs = ['-jar', bundletoolPath, 'install-apks', '--apks', apks, '--device-id', deviceId];
+
+  if (!_.isEmpty(modules)) {
+    installArgs.push('--modules', modules.join(','));
+  }
+
+  log.info(`Install apks with: ${installArgs}`);
+  try {
+    return await exec(java, installArgs);
+  } catch (e) {
+    throw new Error(`Failed to install apks. Original error ${e.message}`);
+  }
+};
+
+/**
+ * Check build version
+ *
+ * @param {string} bundle - The full path to the local `aab` file.
+ * @param {string} deviceId - The device serial to install the apks to.
+ * @param {string} output - List of modules to be installed (defaults to all of them).
+ *                           Note that the dependent modules will also be installed.
+ *                           Ignored if the device receives a standalone APK.
+ * @param {object} buildApksOpts - Options
+ * @property {string} ks - Path to the keystore that should be used to sign the
+ *                         generated APKs. If not set, the APKs will not be signed. If set, the
+ *                         flag 'ks-key-alias' must also be set.
+ * @property {string} ksKeyAlias - Alias of the key to use in the keystore to sign the generated APKs.
+ * @property {string} ksPass - Alias of the key to use in the keystore to sign the generated APKs.
+ *                             Password of the keystore to use to sign the generated APKs.
+ *                             If provided, must be prefixed with either 'pass:' (if the password
+ *                             is passed in clear text, e.g. 'pass:qwerty') or 'file:' (if the password
+ *                             is the first line of a file, e.g. 'file:/tmp/myPassword.txt'). If this
+ *                             flag is not set, the password will be requested on the prompt.
+ * @property {string} overwrite If set, any previous existing output will be overwritten.                           --overwrite
+ * @property {string} otherOptions - Add additional option
+ * @return {string} A path to apks
+ * @throws {Error} If building apks fails.
+ */
+bundletool.buildApks = async function (bundle, deviceId, output, buildApksOpts = {}) {
+  const java = getJavaForOs();
+  const bundletoolPath = path.resolve(this.helperJarPath, 'bundletool.jar');
+
+  let buildApksArgs = [
+    '-jar', bundletoolPath, 'build-apks',
+    '--bundle', bundle,
+    '--output', output,
+    '--connected-device', '--device-id', deviceId
+  ];
+
+  if (buildApksOpts.ks && buildApksOpts.ksKeyAlias) {
+    buildApksArgs.push('--ks', buildApksOpts.ks);
+    buildApksArgs.push('--ks-key-alias', buildApksOpts.ksKeyAlias);
+  }
+
+  if (buildApksOpts.ksPass) {
+    buildApksArgs.push('--ks-pass', buildApksOpts.ksPass);
+  }
+
+  if (buildApksOpts.overwrite) {
+    buildApksArgs.push('--overwrite');
+  }
+
+  if (buildApksOpts.otherOptions) {
+    buildApksArgs.push(buildApksOpts.otherOptions);
+  }
+
+  log.info(`Build Apks apks with: ${buildApksArgs}`);
+  try {
+    await exec(java, buildApksArgs);
+    return output;
+  } catch (e) {
+    throw new Error(`Failed to build apks. Original error ${e.message}`);
+  }
+};
+
+export default bundletool;

--- a/lib/tools/bundletool.js
+++ b/lib/tools/bundletool.js
@@ -34,6 +34,8 @@ bundletool.version = async function () {
  * @throws {Error} If installation fails. e.g. INSTALL_PARSE_FAILED_NO_CERTIFICATES
  */
 bundletool.installApks = async function (apks, deviceId, modules = []) {
+  // TODO: Append install options after bundletool implement it.
+  // https://github.com/google/bundletool/blob/f855ea639a02216780b2813ce29bd6e927ad4503/src/main/java/com/android/tools/build/bundletool/device/DdmlibDevice.java#L89-L107
   let installArgs = [
     '-jar', path.resolve(this.helperJarPath, 'bundletool.jar'), 'install-apks',
     '--apks', apks, '--device-id', deviceId

--- a/lib/tools/bundletool.js
+++ b/lib/tools/bundletool.js
@@ -13,10 +13,10 @@ let bundletool = {};
  * @throws {Error} If get version fails
  */
 bundletool.version = async function () {
-  const java = getJavaForOs();
-  const bundletoolPath = path.resolve(this.helperJarPath, 'bundletool.jar');
   try {
-    return await exec(java, ['-jar', bundletoolPath, 'version']);
+    return await exec(getJavaForOs(), [
+      '-jar', path.resolve(this.helperJarPath, 'bundletool.jar'), 'version'
+    ]);
   } catch (e) {
     throw new Error(`Could not get bundle tool version. Original error ${e.message}`);
   }
@@ -34,9 +34,10 @@ bundletool.version = async function () {
  * @throws {Error} If installation fails. e.g. INSTALL_PARSE_FAILED_NO_CERTIFICATES
  */
 bundletool.installApks = async function (apks, deviceId, modules = []) {
-  const java = getJavaForOs();
-  const bundletoolPath = path.resolve(this.helperJarPath, 'bundletool.jar');
-  let installArgs = ['-jar', bundletoolPath, 'install-apks', '--apks', apks, '--device-id', deviceId];
+  let installArgs = [
+    '-jar', path.resolve(this.helperJarPath, 'bundletool.jar'), 'install-apks',
+    '--apks', apks, '--device-id', deviceId
+  ];
 
   if (!_.isEmpty(modules)) {
     installArgs.push('--modules', modules.join(','));
@@ -44,7 +45,7 @@ bundletool.installApks = async function (apks, deviceId, modules = []) {
 
   log.info(`Install apks with: ${installArgs}`);
   try {
-    return await exec(java, installArgs);
+    return await exec(getJavaForOs(), installArgs);
   } catch (e) {
     throw new Error(`Failed to install apks. Original error ${e.message}`);
   }
@@ -75,11 +76,8 @@ bundletool.installApks = async function (apks, deviceId, modules = []) {
  * @throws {Error} If building apks fails.
  */
 bundletool.buildApks = async function (bundle, deviceId, output, buildApksOpts = {}) {
-  const java = getJavaForOs();
-  const bundletoolPath = path.resolve(this.helperJarPath, 'bundletool.jar');
-
   let buildApksArgs = [
-    '-jar', bundletoolPath, 'build-apks',
+    '-jar', path.resolve(this.helperJarPath, 'bundletool.jar'), 'build-apks',
     '--bundle', bundle,
     '--output', output,
     '--connected-device', '--device-id', deviceId
@@ -104,7 +102,7 @@ bundletool.buildApks = async function (bundle, deviceId, output, buildApksOpts =
 
   log.info(`Build Apks apks with: ${buildApksArgs}`);
   try {
-    await exec(java, buildApksArgs);
+    await exec(getJavaForOs(), buildApksArgs);
     return output;
   } catch (e) {
     throw new Error(`Failed to build apks. Original error ${e.message}`);

--- a/lib/tools/index.js
+++ b/lib/tools/index.js
@@ -4,6 +4,7 @@ import systemCallMethods from './system-calls.js';
 import apkSigningMethods from './apk-signing.js';
 import apkUtilsMethods from './apk-utils.js';
 import emuMethods from './adb-emu-commands.js';
+import bundletool from './bundletool.js';
 
 Object.assign(
     methods,
@@ -11,7 +12,8 @@ Object.assign(
     systemCallMethods,
     emuMethods,
     apkSigningMethods,
-    apkUtilsMethods
+    apkUtilsMethods,
+    bundletool
 );
 
 export default methods;

--- a/test/unit/bundletool-specs.js
+++ b/test/unit/bundletool-specs.js
@@ -1,0 +1,156 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { withMocks } from 'appium-test-support';
+import * as teen_process from 'teen_process';
+import * as helpers from "../../lib/helpers";
+import path from 'path';
+import ADB from "../../";
+
+chai.use(chaiAsPromised);
+// const bundletoolDummyPath = '/path/to/bundletool.jar',
+const helperJarPath = path.resolve(helpers.rootDir, 'jars'),
+      javaDummyPath = 'java_dummy_path';
+
+const adb = new ADB();
+describe('bundletool', withMocks({teen_process, helpers, adb}, function (mocks) {
+  afterEach(function () {
+    mocks.verify();
+  });
+
+  describe('version', function () {
+    it('can get version', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath, ['-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'version'])
+        .returns('BundleTool 0.6.0');
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      (await adb.version()).should.eq('BundleTool 0.6.0');
+    });
+
+    it('can not get version with raising an error', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath, ['-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'version'])
+          .throws();
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      await adb.version().should.eventually.be.rejected;
+    });
+  });
+
+  describe('installApks', function () {
+    it('can install apks', async function () {
+      mocks.teen_process.expects('exec')
+          .once().withExactArgs(javaDummyPath,
+            ['-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'install-apks', '--apks', 'path/to/apks.apks', '--device-id', 'dummy'])
+          .returns('');
+      mocks.helpers.expects('getJavaForOs')
+          .returns(javaDummyPath);
+      await adb.installApks('path/to/apks.apks', 'dummy');
+    });
+
+    it('can install apks with modules', async function () {
+      mocks.teen_process.expects('exec')
+          .once().withExactArgs(javaDummyPath,
+          ['-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'install-apks', '--apks', 'path/to/apks.apks', '--device-id', 'dummy', '--modules', 'm1,m2'])
+          .returns('');
+      mocks.helpers.expects('getJavaForOs')
+          .returns(javaDummyPath);
+      await adb.installApks('path/to/apks.apks', 'dummy', ['m1', 'm2']);
+    });
+
+    it('can not install apks with raising an error', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath,
+        ['-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'install-apks', '--apks', 'path/to/apks.apks', '--device-id', 'dummy'])
+        .throws();
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      await adb.installApks('path/to/apks.apks', 'dummy').should.eventually.be.rejected;
+    });
+  });
+
+  describe('buildApks', function () {
+    it('build apks with mandatory parameters', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath,
+        [
+          '-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'build-apks',
+          '--bundle', 'path/to/apks.apks',
+          '--output', 'path/to/output',
+          '--connected-device', '--device-id', 'dummySerialNumber'
+        ])
+        .returns('');
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      const result = await adb.buildApks('path/to/apks.apks', 'dummySerialNumber', `path/to/output`);
+      result.should.eq('path/to/output');
+    });
+
+    it('build apks with keystore without pass', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath,
+        [
+          '-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'build-apks',
+          '--bundle', 'path/to/apks.apks',
+          '--output', 'path/to/output',
+          '--connected-device', '--device-id', 'dummySerialNumber',
+          '--ks', 'keystore', '--ks-key-alias', 'keyAlias'
+        ])
+        .returns('');
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      await adb.buildApks('path/to/apks.apks', 'dummySerialNumber', `path/to/output`,
+        {ks: 'keystore', ksKeyAlias: 'keyAlias'});
+    });
+
+    it('build apks with keystore with pass', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath,
+        [
+          '-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'build-apks',
+          '--bundle', 'path/to/apks.apks',
+          '--output', 'path/to/output',
+          '--connected-device', '--device-id', 'dummySerialNumber',
+          '--ks', 'keystore', '--ks-key-alias', 'keyAlias', '--ks-pass', 'pass:text'
+        ])
+        .returns('');
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      await adb.buildApks('path/to/apks.apks', 'dummySerialNumber', `path/to/output`,
+        {ks: 'keystore', ksKeyAlias: 'keyAlias', ksPass: 'pass:text'});
+    });
+
+    it('build apks with other arbitrary parameters', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath,
+        [
+          '-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'build-apks',
+          '--bundle', 'path/to/apks.apks',
+          '--output', 'path/to/output',
+          '--connected-device', '--device-id', 'dummySerialNumber',
+          '--overwrite', '--max-threads 4'
+        ])
+        .returns('');
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      await adb.buildApks('path/to/apks.apks', 'dummySerialNumber', `path/to/output`,
+        {otherOptions: '--max-threads 4', overwrite: true});
+    });
+
+    it('can not build apks with raising an error', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(javaDummyPath,
+        [
+          '-jar', path.resolve(helperJarPath, 'bundletool.jar'), 'build-apks',
+          '--bundle', 'path/to/apks.apks',
+          '--output', 'path/to/output',
+          '--connected-device', '--device-id', 'dummySerialNumber',
+          '--ks', 'keystore', '--ks-key-alias', 'keyAlias'
+        ])
+        .throws();
+      mocks.helpers.expects('getJavaForOs')
+        .returns(javaDummyPath);
+      await adb.buildApks('path/to/apks.apks', 'dummySerialNumber', `path/to/output`).should.eventually.be.rejected;
+    });
+  });
+}));


### PR DESCRIPTION
Google start providing [appbundle](https://developer.android.com/platform/technology/app-bundle/). When we build release module with the app-bundle, `.aab` file is generated. Developers upload the `.aab` to the play console.

We can get `apks` file by https://github.com/google/bundletool on our local. We can install a proper apk included in the `apks` by the bundletool. https://github.com/KazuCocoa/AppBundleSample is an example to install a proper apk for connected device from `.aab` and `.apks`.

In this PR, I've added the 0.8 bundletool. Each command follow https://github.com/KazuCocoa/AppBundleSample which I ensured I could install a apk from aab correctly. (And could launch the installed apk)

We should take care of all of `apk` arguments. So, this is partial implementation.
One concern is a size of bundletool. It's 35MB so far...

What do you think adding `.aab` support?
(Eventyally, we'd like to make it enough to put `aab` and necessary arguments in capability by users. It means this module has a responsible for generating `apks` and install a proper apk for a connected device (which is a test device) via bundletool)

Another option is preparing a guide to get proper `apk` by users from `.aab` like https://codelabs.developers.google.com/codelabs/your-first-dynamic-app/index.html?index=..%2F..%2Fio2018#4 with unziping `.apks` and getting proper standalone apk.