### PR TITLE
Fix reboot for Android O

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -787,7 +787,7 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
       }
       // this device needs adb to be running as root to stop.
       // so try to restart the daemon
-      log.debug('Device requires adb to be running as root in order to reboot. Restarting daemon');
+      log.debug('Device requires adb to be running as root in order to reboot when running stop command. Restarting daemon');
       await this.root();
       await this.shell(['stop']);
     }
@@ -801,7 +801,7 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
       }
       // this device needs adb to be running as root to start.
       // so try to restart the daemon
-      log.debug('Device requires adb to be running as root in order to reboot. Restarting daemon');
+      log.debug('Device requires adb to be running as root in order to reboot when running start command. Restarting daemon');
       await this.root();
       await this.shell(['start']);
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -779,6 +779,7 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
  */
 systemCallMethods.runPrivilegedShell = async function (args) {
   try {
+    this.isRoot = false;
     await this.shell(args);
   } catch (err) {
     if (!err.message.includes('must be root')) {
@@ -787,10 +788,8 @@ systemCallMethods.runPrivilegedShell = async function (args) {
     // this device needs adb to be running as root to run the specific command.
     // so try to restart the daemon
     log.debug(`Device requires adb to be running as root in order to run "adb shell ${quote(args)}". Restarting daemon`);
-    await this.root();
+    this.isRoot = await this.root();
     await this.shell(args);
-  } finally {
-    await this.unroot();
   }
 };
 
@@ -813,7 +812,12 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
     // we don't want the stack trace, so no log.errorAndThrow
     let msg = 'Waiting for reboot. This takes time';
     log.debug(msg);
+    throw new Error(msg);
   });
+  // unroot if needed
+  if (this.isRoot) {
+    this.isRoot = !await this.unroot();
+  }
 };
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -813,7 +813,6 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
     // we don't want the stack trace, so no log.errorAndThrow
     let msg = 'Waiting for reboot. This takes time';
     log.debug(msg);
-    throw new Error(msg);
   });
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -793,8 +793,18 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
     }
     await B.delay(2000); // let the emu finish stopping;
     await this.setDeviceProperty('sys.boot_completed', 0);
-    await this.root();
-    await this.shell(['start']);
+    try {
+      await this.shell(['start']);
+    } catch (err) {
+      if (err.message.indexOf('must be root') === -1) {
+        throw err;
+      }
+      // this device needs adb to be running as root to start.
+      // so try to restart the daemon
+      log.debug('Device requires adb to be running as root in order to reboot. Restarting daemon');
+      await this.root();
+      await this.shell(['start']);
+    }
     await retryInterval(retries, 1000, async () => {
       let booted = await this.getDeviceProperty('sys.boot_completed');
       if (booted === '1') {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -776,7 +776,7 @@ systemCallMethods.privilegedShell = async function (args) {
   try {
     await this.shell(args);
   } catch (err) {
-    if (err.message.includes('must be root') === -1) {
+    if (err.message.includes('must be root')) {
       throw err;
     }
     // this device needs adb to be running as root to run the specific command.

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -804,6 +804,7 @@ systemCallMethods.runPrivilegedShell = async function (args) {
 systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES) {
   let isRoot = false;
   isRoot = await this.runPrivilegedShell(['stop']);
+  // TODO - Figure out a condition in adb so we can replace this static delay with a waitForCondition
   await B.delay(EMU_STOP_TIMEOUT); // let the emu finish stopping;
   await this.setDeviceProperty('sys.boot_completed', 0);
   isRoot = await this.runPrivilegedShell(['start']);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -806,7 +806,7 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
   isRoot = await this.runPrivilegedShell(['stop']);
   // TODO - Figure out a condition in adb so we can replace this static delay with a waitForCondition
   await B.delay(EMU_STOP_TIMEOUT); // let the emu finish stopping;
-  await this.setDeviceProperty('sys.boot_completed', 0);
+  isRoot = await this.runPrivilegedShell(['setprop', 'sys.boot_completed', 0]);
   isRoot = await this.runPrivilegedShell(['start']);
   await retryInterval(retries, 1000, async () => {
     if ((await this.getDeviceProperty('sys.boot_completed')) === '1') {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -801,10 +801,10 @@ systemCallMethods.runPrivilegedShell = async function (args) {
  * @throws {Error} If the device failed to reboot and number of retries is exceeded.
  */
 systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES) {
-  await this.privilegedShell(['stop']);
+  await this.runPrivilegedShell(['stop']);
   await B.delay(EMU_STOP_TIMEOUT); // let the emu finish stopping;
   await this.setDeviceProperty('sys.boot_completed', 0);
-  await this.privilegedShell(['start']);
+  await this.runPrivilegedShell(['start']);
   await retryInterval(retries, 1000, async () => {
     let booted = await this.getDeviceProperty('sys.boot_completed');
     if (booted === '1') {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -803,12 +803,11 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
       let booted = await this.getDeviceProperty('sys.boot_completed');
       if (booted === '1') {
         return;
-      } else {
-        // we don't want the stack trace, so no log.errorAndThrow
-        let msg = 'Waiting for reboot. This takes time';
-        log.debug(msg);
-        throw new Error(msg);
       }
+      // we don't want the stack trace, so no log.errorAndThrow
+      let msg = 'Waiting for reboot. This takes time';
+      log.debug(msg);
+      throw new Error(msg);
     });
   } finally {
     await this.unroot();

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -814,7 +814,6 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
     log.debug(msg);
     throw new Error(msg);
   });
-  // unroot if needed
   if (this.isRoot) {
     this.isRoot = !await this.unroot();
   }
@@ -850,6 +849,7 @@ systemCallMethods.root = async function () {
  */
 systemCallMethods.unroot = async function () {
   try {
+    log.debug("Removing root privileges. Restarting adb daemon");
     await exec(this.executable.path, ['unroot']);
     return true;
   } catch (err) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -773,9 +773,9 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
 };
 
 /**
- * Tries to run privileged shell commands without root, otherwise elevates privileges and run them again
+ * Tries to run privileged shell command without root, otherwise elevates privileges and run them again
  *
- * @param {args} array - Shell arguments commands
+ * @param {args} Array<string> - Shell arguments commands
  */
 systemCallMethods.runPrivilegedShell = async function (args) {
   let isRoot = false;
@@ -807,8 +807,7 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
   await this.setDeviceProperty('sys.boot_completed', 0);
   isRoot = await this.runPrivilegedShell(['start']);
   await retryInterval(retries, 1000, async () => {
-    let booted = await this.getDeviceProperty('sys.boot_completed');
-    if (booted === '1') {
+    if ((await this.getDeviceProperty('sys.boot_completed')) === '1') {
       return;
     }
     // we don't want the stack trace, so no log.errorAndThrow

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -772,7 +772,12 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
   });
 };
 
-systemCallMethods.privilegedShell = async function (args) {
+/**
+ * Tries to run privileged shell commands without root, otherwise elevates privileges and run them again
+ *
+ * @param {args} array - Shell arguments commands
+ */
+systemCallMethods.runPrivilegedShell = async function (args) {
   try {
     await this.shell(args);
   } catch (err) {
@@ -781,9 +786,11 @@ systemCallMethods.privilegedShell = async function (args) {
     }
     // this device needs adb to be running as root to run the specific command.
     // so try to restart the daemon
-    log.debug(`Device requires adb to be running as root in order to run "adb shell ${args.join(",")}". Restarting daemon`);
+    log.debug(`Device requires adb to be running as root in order to run "adb shell ${quote(args)}". Restarting daemon`);
     await this.root();
     await this.shell(args);
+  } finally {
+    await this.unroot();
   }
 };
 
@@ -794,24 +801,20 @@ systemCallMethods.privilegedShell = async function (args) {
  * @throws {Error} If the device failed to reboot and number of retries is exceeded.
  */
 systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES) {
-  try {
-    await this.privilegedShell(['stop']);
-    await B.delay(EMU_STOP_TIMEOUT); // let the emu finish stopping;
-    await this.setDeviceProperty('sys.boot_completed', 0);
-    await this.privilegedShell(['start']);
-    await retryInterval(retries, 1000, async () => {
-      let booted = await this.getDeviceProperty('sys.boot_completed');
-      if (booted === '1') {
-        return;
-      }
-      // we don't want the stack trace, so no log.errorAndThrow
-      let msg = 'Waiting for reboot. This takes time';
-      log.debug(msg);
-      throw new Error(msg);
-    });
-  } finally {
-    await this.unroot();
-  }
+  await this.privilegedShell(['stop']);
+  await B.delay(EMU_STOP_TIMEOUT); // let the emu finish stopping;
+  await this.setDeviceProperty('sys.boot_completed', 0);
+  await this.privilegedShell(['start']);
+  await retryInterval(retries, 1000, async () => {
+    let booted = await this.getDeviceProperty('sys.boot_completed');
+    if (booted === '1') {
+      return;
+    }
+    // we don't want the stack trace, so no log.errorAndThrow
+    let msg = 'Waiting for reboot. This takes time';
+    log.debug(msg);
+    throw new Error(msg);
+  });
 };
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -781,7 +781,7 @@ systemCallMethods.runPrivilegedShell = async function (args) {
   try {
     await this.shell(args);
   } catch (err) {
-    if (err.message.includes('must be root')) {
+    if (!err.message.includes('must be root')) {
       throw err;
     }
     // this device needs adb to be running as root to run the specific command.

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -776,6 +776,7 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
  * Tries to run privileged shell command without root, otherwise elevates privileges and run them again
  *
  * @param {args} Array<string> - Shell arguments commands
+ * @return {boolean} True if the device was switched to root.
  */
 systemCallMethods.runPrivilegedShell = async function (args) {
   let isRoot = false;

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -793,6 +793,7 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
     }
     await B.delay(2000); // let the emu finish stopping;
     await this.setDeviceProperty('sys.boot_completed', 0);
+    await this.root();
     await this.shell(['start']);
     await retryInterval(retries, 1000, async () => {
       let booted = await this.getDeviceProperty('sys.boot_completed');

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -778,8 +778,8 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
  * @param {args} array - Shell arguments commands
  */
 systemCallMethods.runPrivilegedShell = async function (args) {
+  let isRoot = false;
   try {
-    this.isRoot = false;
     await this.shell(args);
   } catch (err) {
     if (!err.message.includes('must be root')) {
@@ -788,9 +788,10 @@ systemCallMethods.runPrivilegedShell = async function (args) {
     // this device needs adb to be running as root to run the specific command.
     // so try to restart the daemon
     log.debug(`Device requires adb to be running as root in order to run "adb shell ${quote(args)}". Restarting daemon`);
-    this.isRoot = await this.root();
+    isRoot = await this.root();
     await this.shell(args);
   }
+  return isRoot;
 };
 
 /**
@@ -800,10 +801,11 @@ systemCallMethods.runPrivilegedShell = async function (args) {
  * @throws {Error} If the device failed to reboot and number of retries is exceeded.
  */
 systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES) {
-  await this.runPrivilegedShell(['stop']);
+  let isRoot = false;
+  isRoot = await this.runPrivilegedShell(['stop']);
   await B.delay(EMU_STOP_TIMEOUT); // let the emu finish stopping;
   await this.setDeviceProperty('sys.boot_completed', 0);
-  await this.runPrivilegedShell(['start']);
+  isRoot = await this.runPrivilegedShell(['start']);
   await retryInterval(retries, 1000, async () => {
     let booted = await this.getDeviceProperty('sys.boot_completed');
     if (booted === '1') {
@@ -814,8 +816,8 @@ systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES)
     log.debug(msg);
     throw new Error(msg);
   });
-  if (this.isRoot) {
-    this.isRoot = !await this.unroot();
+  if (isRoot) {
+    await this.unroot();
   }
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -20,6 +20,7 @@ const DEVICE_NOT_FOUND_ERROR_REGEXP = new RegExp(`error: device ('.+' )?not foun
 const DEVICE_CONNECTING_ERROR_REGEXP = new RegExp('error: device still connecting', 'i');
 
 const CERTS_ROOT = '/system/etc/security/cacerts';
+const EMU_STOP_TIMEOUT = 2000;
 
 /**
  * Retrieve full path to the given binary.
@@ -771,6 +772,21 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
   });
 };
 
+systemCallMethods.privilegedShell = async function (args) {
+  try {
+    await this.shell(args);
+  } catch (err) {
+    if (err.message.includes('must be root') === -1) {
+      throw err;
+    }
+    // this device needs adb to be running as root to run the specific command.
+    // so try to restart the daemon
+    log.debug(`Device requires adb to be running as root in order to run "adb shell ${args.join(",")}". Restarting daemon`);
+    await this.root();
+    await this.shell(args);
+  }
+};
+
 /**
  * Reboot the current device and wait until it is completed.
  *
@@ -779,32 +795,10 @@ systemCallMethods.waitForDevice = async function (appDeviceReadyTimeout = 30) {
  */
 systemCallMethods.reboot = async function (retries = DEFAULT_ADB_REBOOT_RETRIES) {
   try {
-    try {
-      await this.shell(['stop']);
-    } catch (err) {
-      if (err.message.indexOf('must be root') === -1) {
-        throw err;
-      }
-      // this device needs adb to be running as root to stop.
-      // so try to restart the daemon
-      log.debug('Device requires adb to be running as root in order to reboot when running stop command. Restarting daemon');
-      await this.root();
-      await this.shell(['stop']);
-    }
-    await B.delay(2000); // let the emu finish stopping;
+    await this.privilegedShell(['stop']);
+    await B.delay(EMU_STOP_TIMEOUT); // let the emu finish stopping;
     await this.setDeviceProperty('sys.boot_completed', 0);
-    try {
-      await this.shell(['start']);
-    } catch (err) {
-      if (err.message.indexOf('must be root') === -1) {
-        throw err;
-      }
-      // this device needs adb to be running as root to start.
-      // so try to restart the daemon
-      log.debug('Device requires adb to be running as root in order to reboot when running start command. Restarting daemon');
-      await this.root();
-      await this.shell(['start']);
-    }
+    await this.privilegedShell(['start']);
     await retryInterval(retries, 1000, async () => {
       let booted = await this.getDeviceProperty('sys.boot_completed');
       if (booted === '1') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-adb",
-  "version": "6.25.0",
+  "version": "6.25.1",
   "description": "Android Debug Bridge interface",
   "main": "./build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-adb",
-  "version": "6.25.1",
+  "version": "6.25.0",
   "description": "Android Debug Bridge interface",
   "main": "./build/index.js",
   "scripts": {


### PR DESCRIPTION
In Android O emulators reboot it's failing due to root issues. 

```bash
Error: Error executing adbExec. Original error: 'Command '/mnt/android/android-sdk-linux/platform-tools/adb -P 5037 shell start' exited with code 1'; Stderr: 'start: must be root'; Code: '1'
    Error: Error executing adbExec. Original error: 'Command '/mnt/android/android-sdk-linux/platform-tools/adb -P 5037 shell start' exited with code 1'; Stderr: 'start: must be root'; Code: '1'
2018/11/06 16:43:53 ui:     at ADB.execFunc$ (/tmp/chromeInstaller/node_modules/appium-adb/lib/tools/system-calls.js:317:13)
 ```

Adding root before calling shell starts fixes the issue. 