### PR TITLE
simplify changing locale

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -783,12 +783,11 @@ apkUtilsMethods.ensureCurrentLocale = async function (language, country, script 
 apkUtilsMethods.setDeviceLanguageCountry = async function (language, country, script = null) {
   let hasLanguage = language && _.isString(language);
   let hasCountry = country && _.isString(country);
-  if (!hasLanguage && !hasCountry) {
-    log.warn(`setDeviceLanguageCountry requires language or country.`);
+  if (!hasLanguage || !hasCountry) {
+    log.warn(`setDeviceLanguageCountry requires language or country at least`);
     log.warn(`Got language: '${language}' and country: '${country}'`);
     return;
   }
-  let wasSettingChanged = false;
   let apiLevel = await this.getApiLevel();
 
   language = (language || '').toLowerCase();
@@ -797,51 +796,19 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country, sc
   if (apiLevel < 23) {
     let curLanguage = (await this.getDeviceLanguage()).toLowerCase();
     let curCountry = (await this.getDeviceCountry()).toUpperCase();
-    if (hasLanguage && language !== curLanguage) {
-      await this.setDeviceLanguage(language);
-      wasSettingChanged = true;
-    }
-    if (hasCountry && country !== curCountry) {
-      await this.setDeviceCountry(country);
-      wasSettingChanged = true;
+
+    if (language !== curLanguage || country !== curCountry) {
+      await this.setDeviceSysLocaleViaSettingApp(language, country);
     }
   } else {
     let curLocale = await this.getDeviceLocale();
 
-    if (apiLevel === 23) {
-      let locale;
-      if (!hasCountry) {
-        locale = language;
-      } else if (!hasLanguage) {
-        locale = country;
-      } else {
-        locale = `${language}-${country}`;
-      }
-
-      log.debug(`Current locale: '${curLocale}'; requested locale: '${locale}'`);
-      if (locale.toLowerCase() !== curLocale.toLowerCase()) {
-        await this.setDeviceSysLocale(locale);
-        wasSettingChanged = true;
-      }
-    } else { // API >= 24
-      if (!hasCountry || !hasLanguage) {
-        log.warn(`setDeviceLanguageCountry requires both language and country to be set for API 24+`);
-        log.warn(`Got language: '${language}' and country: '${country}'`);
-        return;
-      }
-
-      // zh-Hans-CN : zh-CN
-      const localeCode = script ? `${language}-${script}-${country}` : `${language}-${country}`;
-      log.debug(`Current locale: '${curLocale}'; requested locale: '${localeCode}'`);
-      if (localeCode.toLowerCase() !== curLocale.toLowerCase()) {
-        await this.setDeviceSysLocaleViaSettingApp(language, country, script);
-      }
+    // zh-Hans-CN : zh-CN
+    const localeCode = script ? `${language}-${script}-${country}` : `${language}-${country}`;
+    log.debug(`Current locale: '${curLocale}'; requested locale: '${localeCode}'`);
+    if (localeCode.toLowerCase() !== curLocale.toLowerCase()) {
+      await this.setDeviceSysLocaleViaSettingApp(language, country, script);
     }
-  }
-
-  if (wasSettingChanged) {
-    log.info("Rebooting the device in order to apply new locale via 'setting persist.sys.locale' command.");
-    await this.reboot();
   }
 };
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -784,7 +784,7 @@ apkUtilsMethods.setDeviceLanguageCountry = async function (language, country, sc
   let hasLanguage = language && _.isString(language);
   let hasCountry = country && _.isString(country);
   if (!hasLanguage || !hasCountry) {
-    log.warn(`setDeviceLanguageCountry requires language or country at least`);
+    log.warn(`setDeviceLanguageCountry requires language and country at least`);
     log.warn(`Got language: '${language}' and country: '${country}'`);
     return;
   }

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -714,25 +714,28 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       mocks.adb.expects('getDeviceLanguage').never();
       mocks.adb.expects('getDeviceCountry').never();
       mocks.adb.expects('getDeviceLocale').never();
-      mocks.adb.expects('setDeviceLanguage').never();
-      mocks.adb.expects('setDeviceCountry').never();
-      mocks.adb.expects('setDeviceLocale').never();
+      mocks.adb.expects('setDeviceSysLocaleViaSettingApp').never();
       mocks.adb.expects('reboot').never();
       await adb.setDeviceLanguageCountry();
     });
+    it('should return if language or country are not passed', async function () {
+      mocks.adb.expects('getDeviceLanguage').never();
+      mocks.adb.expects('getDeviceCountry').never();
+      mocks.adb.expects('getDeviceLocale').never();
+      mocks.adb.expects('setDeviceSysLocaleViaSettingApp').never();
+      mocks.adb.expects('reboot').never();
+      await adb.setDeviceLanguageCountry('us');
+    });
     it('should set language, country and reboot the device when API < 23', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
-          .once().returns(22);
+        .once().returns(22);
       mocks.adb.expects("getDeviceLanguage").withExactArgs()
-          .once().returns("fr");
+        .once().returns("fr");
       mocks.adb.expects("getDeviceCountry").withExactArgs()
-          .once().returns("");
-      mocks.adb.expects("setDeviceLanguage").withExactArgs(language)
-          .once().returns("");
-      mocks.adb.expects("setDeviceCountry").withExactArgs(country)
-          .once().returns("");
-      mocks.adb.expects("reboot")
-          .once().returns("");
+        .once().returns("");
+      mocks.adb.expects("setDeviceSysLocaleViaSettingApp").withExactArgs(language, country)
+        .once().returns("");
+      mocks.adb.expects('reboot').never();
       await adb.setDeviceLanguageCountry(language, country);
     });
     it('should not set language and country if it does not change when API < 23', async function () {
@@ -741,35 +744,13 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       mocks.adb.expects('getDeviceLanguage').once().returns('en');
       mocks.adb.expects('getDeviceCountry').once().returns('US');
       mocks.adb.expects('getDeviceLocale').never();
-      mocks.adb.expects('setDeviceLanguage').never();
-      mocks.adb.expects('setDeviceCountry').never();
-      mocks.adb.expects('setDeviceLocale').never();
+      mocks.adb.expects('setDeviceSysLocaleViaSettingApp').never();
       mocks.adb.expects('reboot').never();
       await adb.setDeviceLanguageCountry(language.toLowerCase(), country.toLowerCase());
     });
-    it('should set locale when API is 23', async function () {
+    it('should call set locale via setting app when API 23+', async function () {
       mocks.adb.expects("getApiLevel").withExactArgs()
           .once().returns(23);
-      mocks.adb.expects("getDeviceLocale").withExactArgs()
-          .once().returns('fr-FR');
-      mocks.adb.expects("setDeviceSysLocale").withExactArgs(locale)
-          .once().returns('fr-FR');
-      mocks.adb.expects("reboot")
-          .once().returns("");
-      await adb.setDeviceLanguageCountry(language, country);
-    });
-    it('should not set language and country if it does not change when API is 23', async function () {
-      mocks.adb.expects("getApiLevel").withExactArgs()
-          .once().returns(23);
-      mocks.adb.expects("getDeviceLocale").withExactArgs()
-          .once().returns(locale);
-      mocks.adb.expects('setDeviceSysLocale').never();
-      mocks.adb.expects('reboot').never();
-      await adb.setDeviceLanguageCountry(language, country);
-    });
-    it('should call set locale via setting app when API 24+', async function () {
-      mocks.adb.expects("getApiLevel").withExactArgs()
-          .once().returns(24);
       mocks.adb.expects("getDeviceLocale").withExactArgs()
           .once().returns('fr-FR');
       mocks.adb.expects("setDeviceSysLocaleViaSettingApp").withExactArgs(language, country, null)


### PR DESCRIPTION
Currently, Appium tries to reboot devices when a user change locale since Appium change locales via adb command for API level 23- devices. It doesn't work for real devices without root permission.

We don't need to reboot devices if we change them through  `io.appium.setting` while we need to set `language` and `locale` in caps so far. <= breaking change. (We can keep previous spec if we update io.appium.settings)

I ensured this works on Android 4.2(api level 17) and 6.0(api level 23) real devices.


Below log is an example to change locale via `persist.sys.locale` (but it does not work)

```
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell appops set io.appium.settings android\:mock_location allow'
[debug] [ADB] Device API level: 23
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell getprop persist.sys.locale'
[debug] [ADB] Current device property 'persist.sys.locale': ja-JP
[debug] [ADB] Current locale: 'ja-JP'; requested locale: 'en-US'
[debug] [ADB] Device API level: 23
[debug] [ADB] Setting device property 'persist.sys.locale' to 'en-US'
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell setprop persist.sys.locale en-US'
[ADB] Rebooting the device in order to apply new locale via 'setting persist.sys.locale' command.
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell stop'
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell setprop sys.boot_completed 0'
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell start'
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell getprop sys.boot_completed'
[debug] [ADB] Current device property 'sys.boot_completed': 1
[debug] [ADB] Device API level: 23
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell getprop persist.sys.locale'
[debug] [ADB] Current device property 'persist.sys.locale': ja-JP
[debug] [AndroidDriver] Shutting down Android driver
[debug] [AndroidDriver] Called deleteSession but bootstrap wasn't active
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s CB5A22LZ79 shell am force-stop io.appium.unlock'
```