### PR TITLE
add grant multiple permissions in one time adb shell call

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -253,6 +253,28 @@ methods.grantAllPermissions = async function (pkg, apk) {
 };
 
 /**
+ * Grant multiple permissions for the particular package.
+ *
+ * @param {string} pkg - The package name to be processed.
+ * @param {Array<string>} permission - The full name of the permission to be granted.
+ * @throws {Error} If there was an error while changing permissions.
+ */
+methods.grantMultiplePermissions = async function (pkg, permissions = []) {
+  const pCmd = [];
+  for (const permission of permissions) {
+    pCmd.push('pm', 'grant', pkg, permission, ';');
+  }
+  try {
+    // call `adb shell "pm grant io.appium.settings permission1 ; pm grant io.appium.settings  permission2 ; pm grant io.appium.settings permission3 ; "`
+    await this.shell(`"${pCmd.join(' ')}"`);
+  } catch (error) {
+    if (!error.message.includes("not a changeable permission type")) {
+      throw error;
+    }
+  }
+};
+
+/**
  * Grant single permission for the particular package.
  *
  * @param {string} pkg - The package name to be processed.

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -873,6 +873,11 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
           .once().withArgs(['pm', 'grant', 'io.appium.android.apis', 'android.permission.READ_EXTERNAL_STORAGE']);
       await adb.grantPermission('io.appium.android.apis', 'android.permission.READ_EXTERNAL_STORAGE');
     });
+    it('should grant requested multiple permissions', async function () {
+      mocks.adb.expects("shell")
+          .once().withArgs('"pm grant io.appium.settings android.permission.READ_EXTERNAL_STORAGE ; pm grant io.appium.settings android.permission.CHANGE_CONFIGURATION ;"');
+      await adb.grantMultiplePermissions('io.appium.settings', ['android.permission.READ_EXTERNAL_STORAGE', 'android.permission.CHANGE_CONFIGURATION']);
+    });
     it('should revoke requested permission', async function () {
       mocks.adb.expects("shell")
           .once().withArgs(['pm', 'revoke', 'io.appium.android.apis', 'android.permission.READ_EXTERNAL_STORAGE']);


### PR DESCRIPTION
This PR should help https://github.com/appium/appium-android-driver/pull/465 to reduce the cost of calling `adb shell` multiple times.
To call all of commands in a target device's shell, we must send commands in `"...."`