### PR TITLE
Correct comment for restartAdb

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -216,7 +216,7 @@ systemCallMethods.getDevicesWithRetry = async function (timeoutMs = 20000) {
 };
 
 /**
- * Restart adb server if _this.suppressKillServer_ property is true.
+ * Restart adb server, unless _this.suppressKillServer_ property is true.
  */
 systemCallMethods.restartAdb = async function () {
   if (this.suppressKillServer) {


### PR DESCRIPTION
Currently the code comment for `restartAdb` is incorrect. It says that `restartAdb` restarts the adb server _if_ `suppressKillServer` is true. The actual behavior is the opposite, though. `restartAdb` restarts the adb server _unless_ `suppressKillServer` is true. This PR simply changes the comment.