### PR TITLE
Only patch apksigner path on Windows

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -50,7 +50,7 @@ apkSigningMethods.executeApksigner = async function (args = []) {
     let binaryPath = apksignerPath;
     if (system.isWindows() && util.isSubPath(binaryPath, originalFolder)) {
       // Workaround for https://github.com/nodejs/node-v0.x-archive/issues/25895
-      binaryPath = path.basename(apksignerPath);
+      binaryPath = path.basename(binaryPath);
     }
     const {stdout, stderr} = await exec(binaryPath, args, {
       cwd: originalFolder

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -47,11 +47,14 @@ apkSigningMethods.executeApksigner = async function (args = []) {
   const apkSigner = await getApksignerForOs(this);
   const originalFolder = path.dirname(apkSigner);
   const getApksignerOutput = async (apksignerPath) => {
-    // Use cwd to workaround https://github.com/nodejs/node-v0.x-archive/issues/25895
-    const {stdout, stderr} = await exec(
-      util.isSubPath(apksignerPath, originalFolder) ? path.basename(apksignerPath) : apksignerPath, args, {
-        cwd: originalFolder
-      });
+    let binaryPath = apksignerPath;
+    if (system.isWindows() && util.isSubPath(binaryPath, originalFolder)) {
+      // Workaround for https://github.com/nodejs/node-v0.x-archive/issues/25895
+      binaryPath = path.basename(apksignerPath);
+    }
+    const {stdout, stderr} = await exec(binaryPath, args, {
+      cwd: originalFolder
+    });
     for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
       if (!stream) {
         continue;

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -40,7 +40,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.helpers.expects("getApksignerForOs")
         .returns(apksignerDummyPath);
       mocks.teen_process.expects("exec")
-        .once().withExactArgs(path.basename(apksignerDummyPath), ['sign',
+        .once().withExactArgs(apksignerDummyPath, ['sign',
           '--key', defaultKeyPath, '--cert', defaultCertPath, selendroidTestApp],
           {cwd: path.dirname(apksignerDummyPath)})
         .returns({});
@@ -52,7 +52,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.helpers.expects("getApksignerForOs")
         .returns(apksignerDummyPath);
       mocks.teen_process.expects("exec")
-        .once().withExactArgs(path.basename(apksignerDummyPath), ['sign',
+        .once().withExactArgs(apksignerDummyPath, ['sign',
           '--key', defaultKeyPath, '--cert', defaultCertPath, selendroidTestApp],
           {cwd: path.dirname(apksignerDummyPath)})
         .throws();
@@ -77,7 +77,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.helpers.expects("getApksignerForOs")
         .returns(apksignerDummyPath);
       mocks.teen_process.expects("exec")
-        .withExactArgs(path.basename(apksignerDummyPath), ['sign',
+        .withExactArgs(apksignerDummyPath, ['sign',
           '--ks', keystorePath,
           '--ks-key-alias', keyAlias,
           '--ks-pass', `pass:${password}`,
@@ -169,7 +169,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.helpers.expects("getApksignerForOs")
         .twice().returns(apksignerDummyPath);
       mocks.teen_process.expects("exec")
-        .once().withExactArgs(path.basename(apksignerDummyPath),
+        .once().withExactArgs(apksignerDummyPath,
           ['verify', '--print-certs', selendroidTestApp],
           {cwd: path.dirname(apksignerDummyPath)})
         .returns({


### PR DESCRIPTION
It looks like on *nix systems the workaround does not work as expected and the binary is not found even if `cwd` is set. See https://travis-ci.org/appium/appium-espresso-driver/jobs/457348839 for more details. 
So we only perform patching on Windows now