### PR TITLE
Update dist in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: android
-sudo: required
 jdk: oraclejdk8
-dist: trusty
 addons:
   apt:
     sources:


### PR DESCRIPTION
Clean out the `sudo` and `dist` portions of the Travis config, in preparation for [upcoming changes to defaults](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) in Travis's Linux infrastructure.