### PR TITLE
update setHttpProxy and add deleteHttpProxy

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1514,7 +1514,7 @@ methods.getScreenDensity = async function () {
 };
 
 /**
- * Setup HTTP proxy in device settings.
+ * Setup HTTP proxy in device global settings.
  *
  * @param {string} proxyHost - The host name of the proxy.
  * @param {string|number} proxyPort - The port number to be set.
@@ -1528,10 +1528,19 @@ methods.setHttpProxy = async function (proxyHost, proxyPort) {
     throw new Error(`Call to setHttpProxy method with undefined proxy_port ${proxy}`);
   }
   await this.setSetting('global', 'http_proxy', proxy);
-  await this.setSetting('secure', 'http_proxy', proxy);
-  await this.setSetting('system', 'http_proxy', proxy);
-  await this.setSetting('system', 'global_http_proxy_host', proxyHost);
-  await this.setSetting('system', 'global_http_proxy_port', proxyPort);
+  await this.setSetting('global', 'global_http_proxy_host', proxyHost);
+  await this.setSetting('global', 'global_http_proxy_port', proxyPort);
+};
+
+/**
+ * Delete HTTP proxy in device global settings.
+ * Rebooting the test device is necessary to apply the change.
+ */
+methods.deleteHttpProxy = async function () {
+  await this.shell(['settings', 'delete', 'global', 'http_proxy']);
+  await this.shell(['settings', 'delete', 'global', 'global_http_proxy_host']);
+  await this.shell(['settings', 'delete', 'global', 'global_http_proxy_port']);
+  await this.shell(['settings', 'delete', 'global', 'global_http_proxy_exclusion_list']);
 };
 
 /**

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -1108,11 +1108,18 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       let proxyHost = "http://localhost";
       let proxyPort = 4723;
       mocks.adb.expects('setSetting').once().withExactArgs('global', 'http_proxy', `${proxyHost}:${proxyPort}`);
-      mocks.adb.expects('setSetting').once().withExactArgs('secure', 'http_proxy', `${proxyHost}:${proxyPort}`);
-      mocks.adb.expects('setSetting').once().withExactArgs('system', 'http_proxy', `${proxyHost}:${proxyPort}`);
-      mocks.adb.expects('setSetting').once().withExactArgs('system', 'global_http_proxy_host', proxyHost);
-      mocks.adb.expects('setSetting').once().withExactArgs('system', 'global_http_proxy_port', proxyPort);
+      mocks.adb.expects('setSetting').once().withExactArgs('global', 'global_http_proxy_host', proxyHost);
+      mocks.adb.expects('setSetting').once().withExactArgs('global', 'global_http_proxy_port', proxyPort);
       await adb.setHttpProxy(proxyHost, proxyPort);
+    });
+  });
+  describe('deleteHttpProxy', function () {
+    it('should call setSetting method with correct args', async function () {
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'delete', 'global', 'http_proxy']);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'delete', 'global', 'global_http_proxy_host']);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'delete', 'global', 'global_http_proxy_port']);
+      mocks.adb.expects('shell').once().withExactArgs(['settings', 'delete', 'global', 'global_http_proxy_exclusion_list']);
+      await adb.deleteHttpProxy();
     });
   });
   describe('setSetting', function () {


### PR DESCRIPTION
- Update `setHttpProxy`
    - When I set the proxy in `secure` and `system` like the previous implementation, I could not delete them via `adb shell settings delete`. The setting remained. The proxy worked only `global`.
- Add `deleteHttpProxy`
    - They were generated after adding `this.setSetting('global', 'http_proxy', proxy)`

After this work, I would like to add two mobile commands to set/delete http proxy.

- note
    - After deleting the global settings, we must reboot device both emulators and real devices to apply the change
        - I tested.
        - Thus, I'm thinking to add `adb.reboot` when I implement mobile command to delete http proxy
    - I considered implementing the proxy logic in `io.appium.settings` using `WifiConfiguration` like other settings such as locale. but we probably must use reflection to achieve it. Some methods were changed/moved/deleted in recent Android API which we should have got via reflection. So, via adb command is much reasonable than it since the adb command worked Android 9 as well. (I confirmed it on Android 4 and 6 as well.)