### PR TITLE
Remove set language and country by persist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ node_modules
 coverage
 coverage-e2e
 package-lock.json*
-
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ node_modules
 coverage
 coverage-e2e
 package-lock.json*
+
+.DS_Store

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1544,6 +1544,7 @@ methods.setHttpProxy = async function (proxyHost, proxyPort) {
  * Rebooting the test device is necessary to apply the change.
  */
 methods.deleteHttpProxy = async function () {
+
   const httpProxySettins = [
     'http_proxy',
     'global_http_proxy_host',

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1407,15 +1407,6 @@ methods.getDeviceSysLanguage = async function () {
 };
 
 /**
- * Set the new system language on the device under test.
- *
- * @param {string} language - The new language value.
- */
-methods.setDeviceSysLanguage = async function (language) {
-  return await this.setDeviceProperty("persist.sys.language", language.toLowerCase());
-};
-
-/**
  * @return {string} Current country name on the device under test.
  */
 methods.getDeviceSysCountry = async function () {
@@ -1423,28 +1414,10 @@ methods.getDeviceSysCountry = async function () {
 };
 
 /**
- * Set the new system country on the device under test.
- *
- * @param {string} country - The new country value.
- */
-methods.setDeviceSysCountry = async function (country) {
-  return await this.setDeviceProperty("persist.sys.country", country.toUpperCase());
-};
-
-/**
  * @return {string} Current system locale name on the device under test.
  */
 methods.getDeviceSysLocale = async function () {
   return await this.getDeviceProperty("persist.sys.locale");
-};
-
-/**
- * Set the new system locale on the device under test.
- *
- * @param {string} locale - The new locale value.
- */
-methods.setDeviceSysLocale = async function (locale) {
-  return await this.setDeviceProperty("persist.sys.locale", locale);
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1517,7 +1517,6 @@ methods.setHttpProxy = async function (proxyHost, proxyPort) {
  * Rebooting the test device is necessary to apply the change.
  */
 methods.deleteHttpProxy = async function () {
-
   const httpProxySettins = [
     'http_proxy',
     'global_http_proxy_host',

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -685,16 +685,6 @@ apkUtilsMethods.getDeviceLanguage = async function () {
 };
 
 /**
- * Set the language name of the device under test.
- *
- * @param {string} language - The name of the new device language.
- */
-apkUtilsMethods.setDeviceLanguage = async function (language) {
-  // this method is only used in API < 23
-  await this.setDeviceSysLanguage(language);
-};
-
-/**
  * Get the country name of the device under test.
  *
  * @return {string} The name of device country.
@@ -706,16 +696,6 @@ apkUtilsMethods.getDeviceCountry = async function () {
     country = await this.getDeviceProductCountry();
   }
   return country;
-};
-
-/**
- * Set the country name of the device under test.
- *
- * @param {string} country - The name of the new device country.
- */
-apkUtilsMethods.setDeviceCountry = async function (country) {
-  // this method is only used in API < 23
-  await this.setDeviceSysCountry(country);
 };
 
 /**

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -90,22 +90,7 @@ describe('adb commands', function () {
     ['en', 'fr'].should.contain(await adb.getDeviceSysLanguage());
     ['US', 'EN_US', 'EN', 'FR'].should.contain(await adb.getDeviceSysCountry());
   });
-  it('should set device language and country', async function () {
-    if (parseInt(apiLevel, 10) >= 23) return this.skip(); // eslint-disable-line curly
-    if (process.env.TRAVIS) return this.skip(); // eslint-disable-line curly
-
-    await adb.setDeviceSysLanguage('fr');
-    await adb.setDeviceSysCountry('fr');
-    await adb.reboot();
-    await adb.getDeviceSysLanguage().should.eventually.equal('fr');
-    await adb.getDeviceSysCountry().should.eventually.equal('FR');
-    // cleanup
-    await adb.setDeviceSysLanguage('en');
-    await adb.setDeviceSysCountry('us');
-  });
   it('should get device locale', async function () {
-    if (parseInt(apiLevel, 10) < 23) return this.skip(); // eslint-disable-line curly
-
     await adb.setDeviceSysLocaleViaSettingApp('en', 'US');
     ['us', 'en', 'ca_en', 'en-US'].should.contain(await adb.getDeviceLocale());
   });

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -91,6 +91,8 @@ describe('adb commands', function () {
     ['US', 'EN_US', 'EN', 'FR'].should.contain(await adb.getDeviceSysCountry());
   });
   it('should get device locale', async function () {
+    if (parseInt(apiLevel, 10) < 23) return this.skip(); // eslint-disable-line curly
+
     await adb.setDeviceSysLocaleViaSettingApp('en', 'US');
     ['us', 'en', 'ca_en', 'en-US'].should.contain(await adb.getDeviceLocale());
   });

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -72,16 +72,6 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         (await adb.getDeviceSysLanguage()).should.equal(language);
       });
     });
-    describe('setDeviceSysLanguage', function () {
-      it('should call shell with correct args', async function () {
-        mocks.adb.expects("shell")
-          .once().withExactArgs(['setprop', 'persist.sys.language', language], {
-            privileged: true
-          })
-          .returns("");
-        await adb.setDeviceSysLanguage(language);
-      });
-    });
     describe('getDeviceSysCountry', function () {
       it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
@@ -129,32 +119,12 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         await adb.toggleGPSLocationProvider(false);
       });
     });
-    describe('setDeviceSysCountry', function () {
-      it('should call shell with correct args', async function () {
-        mocks.adb.expects("shell")
-          .once().withExactArgs(['setprop', 'persist.sys.country', country], {
-            privileged: true
-          })
-          .returns("");
-        await adb.setDeviceSysCountry(country);
-      });
-    });
     describe('getDeviceSysLocale', function () {
       it('should call shell with correct args', async function () {
         mocks.adb.expects("shell")
           .once().withExactArgs(['getprop', 'persist.sys.locale'])
           .returns(locale);
         (await adb.getDeviceSysLocale()).should.equal(locale);
-      });
-    });
-    describe('setDeviceSysLocale', function () {
-      it('should call shell with correct args', async function () {
-        mocks.adb.expects("shell")
-          .once().withExactArgs(['setprop', 'persist.sys.locale', locale], {
-            privileged: true
-          })
-          .returns("");
-        await adb.setDeviceSysLocale(locale);
       });
     });
     describe('getDeviceProductLanguage', function () {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -578,18 +578,6 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       (await adb.getDeviceLanguage()).should.equal(language);
     });
   });
-  describe('setDeviceLanguage', function () {
-    it('should call shell one time with correct args when API < 23', async function () {
-      mocks.adb.expects("getApiLevel")
-        .once().returns(21);
-      mocks.adb.expects("shell")
-        .once().withExactArgs(['setprop', 'persist.sys.language', language], {
-          privileged: true
-        })
-        .returns("");
-      await adb.setDeviceLanguage(language);
-    });
-  });
   describe('getDeviceCountry', function () {
     it('should call shell one time with correct args and return country', async function () {
       mocks.adb.expects("shell")
@@ -605,18 +593,6 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .once().withExactArgs(['getprop', 'ro.product.locale.region'])
         .returns(country);
       (await adb.getDeviceCountry()).should.equal(country);
-    });
-  });
-  describe('setDeviceCountry', function () {
-    it('should call shell one time with correct args', async function () {
-      mocks.adb.expects("getApiLevel")
-        .once().returns(21);
-      mocks.adb.expects("shell")
-        .once().withExactArgs(['setprop', 'persist.sys.country', country], {
-          privileged: true
-        })
-        .returns("");
-      await adb.setDeviceCountry(country);
     });
   });
   describe('getDeviceLocale', function () {


### PR DESCRIPTION
closes #380 

We no longer need adb-county/language commands since we currently use io.appium.setting based locale handler.