### PR TITLE
Use pidof utility for process id detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ example:
 import ADB from 'appium-adb';
 
 const adb = await ADB.createADB();
-console.log(await adb.getPIDsByName('m.android.phone'));
+console.log(await adb.getPIDsByName('com.android.phone'));
 ```
 
 ### List of methods:

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1153,27 +1153,43 @@ methods.removeLogcatListener = function (listener) {
  * @return {Array.<number>} The list of matched process IDs or an empty list.
  */
 methods.getPIDsByName = async function (name) {
-  log.debug(`Getting all processes with ${name}`);
+  log.debug(`Getting IDs of all '${name}' processes`);
   try {
+    return (await this.shell(['pidof', name]))
+      .split(/\s+/)
+      .map((x) => parseInt(x, 10))
+      .filter((x) => _.isInteger(x));
+  } catch (e) {
+    // error code 1 is returned if the pidof utility did not find any processes
+    // with the given name
+    if (e.code === 1) {
+      return [];
+    }
+    // error code 127 is returned if the pidof utility itself is not found
+    if (e.code !== 127) {
+      log.debug(`pidof error code: ${e.code}`);
+      throw new Error(`Could not extract process ID of '${name}': ${e.stderr}`);
+    }
+
+    log.debug('Using ps-based PID detection');
     // ps <comm> where comm is last 15 characters of package name
     if (name.length > 15) {
       name = name.substr(name.length - 15);
     }
-    let stdout = (await this.shell(["ps"])).trim();
-    let pids = [];
-    for (let line of stdout.split("\n")) {
-      if (line.indexOf(name) !== -1) {
-        let match = /[^\t ]+[\t ]+([0-9]+)/.exec(line);
-        if (match) {
-          pids.push(parseInt(match[1], 10));
-        } else {
-          throw new Error(`Could not extract PID from ps output: ${line}`);
-        }
+    const stdout = (await this.shell(["ps"])).trim();
+    const pids = [];
+    for (const line of stdout.split("\n")) {
+      if (!line.includes(name)) {
+        continue;
       }
+
+      const match = /[^\t ]+[\t ]+([0-9]+)/.exec(line);
+      if (!match) {
+        throw new Error(`Could not extract PID from ps output: ${line}`);
+      }
+      pids.push(parseInt(match[1], 10));
     }
     return pids;
-  } catch (e) {
-    throw new Error(`Unable to get pids for ${name}. Orginial error: ${e.message}`);
   }
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -973,25 +973,13 @@ methods.pull = async function (remotePath, localPath) {
  *
  * @param {string} processName - The name of the process to be checked.
  * @return {boolean} True if the given process is running.
- * @throws {error} If the given process name is not a valid class name.
+ * @throws {Error} If the given process name is not a valid class name.
  */
 methods.processExists = async function (processName) {
-  try {
-    if (!this.isValidClass(processName)) {
-      throw new Error(`Invalid process name: ${processName}`);
-    }
-    let stdout = await this.shell("ps");
-    for (let line of stdout.split(/\r?\n/)) {
-      line = line.trim().split(/\s+/);
-      let pkgColumn = line[line.length - 1];
-      if (pkgColumn && pkgColumn.indexOf(processName) !== -1) {
-        return true;
-      }
-    }
-    return false;
-  } catch (e) {
-    throw new Error(`Error finding if process exists. Original error: ${e.message}`);
+  if (!this.isValidClass(processName)) {
+    throw new Error(`Invalid process name: ${processName}`);
   }
+  return !_.isEmpty(await this.getPIDsByName(processName));
 };
 
 /**
@@ -1154,42 +1142,44 @@ methods.removeLogcatListener = function (listener) {
  */
 methods.getPIDsByName = async function (name) {
   log.debug(`Getting IDs of all '${name}' processes`);
-  try {
-    return (await this.shell(['pidof', name]))
-      .split(/\s+/)
-      .map((x) => parseInt(x, 10))
-      .filter((x) => _.isInteger(x));
-  } catch (e) {
-    // error code 1 is returned if the pidof utility did not find any processes
-    // with the given name
-    if (e.code === 1) {
-      return [];
-    }
-    // error code 127 is returned if the pidof utility itself is not found
-    if (e.code !== 127) {
+  if (!_.isBoolean(this._isPidofAvailable)) {
+    this._isPidofAvailable = parseInt(await this.shell(['pidof --help > /dev/null; echo $?']), 10) === 0;
+  }
+  if (this._isPidofAvailable) {
+    try {
+      return (await this.shell(['pidof', name]))
+        .split(/\s+/)
+        .map((x) => parseInt(x, 10))
+        .filter((x) => _.isInteger(x));
+    } catch (e) {
+      // error code 1 is returned if the pidof utility did not find any processes
+      // with the given name
+      if (e.code === 1) {
+        return [];
+      }
       throw new Error(`Could not extract process ID of '${name}': ${e.message}`);
     }
-
-    log.debug('Using ps-based PID detection');
-    // ps <comm> where comm is last 15 characters of package name
-    if (name.length > 15) {
-      name = name.substr(name.length - 15);
-    }
-    const stdout = (await this.shell(["ps"])).trim();
-    const pids = [];
-    for (const line of stdout.split("\n")) {
-      if (!line.includes(name)) {
-        continue;
-      }
-
-      const match = /[^\t ]+[\t ]+([0-9]+)/.exec(line);
-      if (!match) {
-        throw new Error(`Could not extract PID from ps output: ${line}`);
-      }
-      pids.push(parseInt(match[1], 10));
-    }
-    return pids;
   }
+
+  log.debug('Using ps-based PID detection');
+  // ps <comm> where comm is last 15 characters of package name
+  if (name.length > 15) {
+    name = name.substr(name.length - 15);
+  }
+  const stdout = (await this.shell(['ps'])).trim();
+  const pids = [];
+  for (const line of stdout.split('\n')) {
+    if (!line.includes(name)) {
+      continue;
+    }
+
+    const match = /[^\t ]+[\t ]+([0-9]+)/.exec(line);
+    if (!match) {
+      throw new Error(`Could not extract PID from ps output: ${line}`);
+    }
+    pids.push(parseInt(match[1], 10));
+  }
+  return pids;
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1167,7 +1167,6 @@ methods.getPIDsByName = async function (name) {
     }
     // error code 127 is returned if the pidof utility itself is not found
     if (e.code !== 127) {
-      log.debug(`pidof error code: ${e.code}`);
       throw new Error(`Could not extract process ID of '${name}': ${e.message}`);
     }
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1168,7 +1168,7 @@ methods.getPIDsByName = async function (name) {
     // error code 127 is returned if the pidof utility itself is not found
     if (e.code !== 127) {
       log.debug(`pidof error code: ${e.code}`);
-      throw new Error(`Could not extract process ID of '${name}': ${e.stderr}`);
+      throw new Error(`Could not extract process ID of '${name}': ${e.message}`);
     }
 
     log.debug('Using ps-based PID detection');

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -323,8 +323,9 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         return stdout;
       }
 
-      throw new Error(`Error executing adbExec. Original error: '${e.message}'; ` +
-                      `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
+      e.message = `Error executing adbExec. Original error: '${e.message}'; ` +
+        `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`;
+      throw e;
     }
   };
 

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -67,7 +67,7 @@ describe('adb commands', function () {
     (await adb.ping()).should.be.true;
   });
   it('getPIDsByName should return pids', async function () {
-    (await adb.getPIDsByName('m.android.phone')).should.have.length.above(0);
+    (await adb.getPIDsByName('com.android.phone')).should.have.length.above(0);
   });
   it('killProcessesByName should kill process', async function () {
     await adb.install(contactManagerPath);

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -579,9 +579,17 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
     describe('getPIDsByName', function () {
       it('should call shell and parse pids correctly', async function () {
         mocks.adb.expects("shell")
-          .once().withExactArgs(['ps'])
-          .returns(psOutput);
+          .once().withExactArgs(['pidof', contactManagerPackage])
+          .returns('5078\n');
         (await adb.getPIDsByName(contactManagerPackage))[0].should.equal(5078);
+      });
+      it('should call shell and return an empty list if no processes are running', async function () {
+        const err = new Error();
+        err.code = 1;
+        mocks.adb.expects("shell")
+          .once().withExactArgs(['pidof', contactManagerPackage])
+          .throws(err);
+        (await adb.getPIDsByName(contactManagerPackage)).length.should.eql(0);
       });
     });
     describe('killProcessesByName', function () {

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -28,8 +28,6 @@ const apiLevel = 21,
       enabled=true exported=true processName=com.android.inputmethod.latin
       permission=android.permission.BIND_INPUT_METHOD
       flags=0x0`,
-      psOutput = `USER     PID   PPID  VSIZE  RSS     WCHAN    PC   NAME
-u0_a101   5078  3129  487404 37044 ffffffff b76ce565 S com.example.android.contactmanager`,
       contactManagerPackage = 'com.example.android.contactmanager',
       model = `Android SDK built for X86_64`,
       manufacturer = `unknown`,
@@ -511,15 +509,15 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
     });
     describe('processExists', function () {
       it('should call shell with correct args and should find process', async function () {
-        mocks.adb.expects("shell")
-          .once().withExactArgs("ps")
-          .returns(psOutput);
+        mocks.adb.expects("getPIDsByName")
+          .once().withExactArgs(contactManagerPackage)
+          .returns([123]);
         (await adb.processExists(contactManagerPackage)).should.be.true;
       });
       it('should call shell with correct args and should not find process', async function () {
-        mocks.adb.expects("shell")
-          .once().withExactArgs("ps")
-          .returns("foo");
+        mocks.adb.expects("getPIDsByName")
+          .once().withExactArgs(contactManagerPackage)
+          .returns([]);
         (await adb.processExists(contactManagerPackage)).should.be.false;
       });
     });
@@ -578,12 +576,14 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
     });
     describe('getPIDsByName', function () {
       it('should call shell and parse pids correctly', async function () {
+        adb._isPidofAvailable = true;
         mocks.adb.expects("shell")
           .once().withExactArgs(['pidof', contactManagerPackage])
           .returns('5078\n');
         (await adb.getPIDsByName(contactManagerPackage))[0].should.equal(5078);
       });
       it('should call shell and return an empty list if no processes are running', async function () {
+        adb._isPidofAvailable = true;
         const err = new Error();
         err.code = 1;
         mocks.adb.expects("shell")


### PR DESCRIPTION
According to the platform documentation the pidof utility should be available on all devices since API 23. Older devices might have it or might have not. In such case we fallback to the previous ps-based PID detection method.
Partially addresses https://github.com/appium/appium-adb/issues/395