### PR TITLE
Only retry adbExec if it is a protocol or device not found error

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -289,17 +289,17 @@ systemCallMethods.adbExecEmu = async function (cmd) {
  */
 systemCallMethods.adbExec = async function (cmd, opts = {}) {
   if (!cmd) {
-    throw new Error("You need to pass in a command to adbExec()");
+    throw new Error('You need to pass in a command to adbExec()');
   }
+
   // setting default timeout for each command to prevent infinite wait.
   opts.timeout = opts.timeout || this.adbExecTimeout || DEFAULT_ADB_EXEC_TIMEOUT;
 
-  let execFunc = async () => {
+  cmd = _.isArray(cmd) ? cmd : [cmd];
+
+  const execFunc = async () => {
     try {
-      if (!(cmd instanceof Array)) {
-        cmd = [cmd];
-      }
-      let args = this.executable.defaultArgs.concat(cmd);
+      const args = this.executable.defaultArgs.concat(cmd);
       log.debug(`Running '${this.executable.path} ${quote(args)}'`);
       let {stdout} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
@@ -315,12 +315,13 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         log.info(`Error sending command, reconnecting device and retrying: ${cmd}`);
         await sleep(1000);
         await this.getDevicesWithRetry();
+
+        // try again
+        return await execFunc();
       }
 
       if (e.code === 0 && e.stdout) {
-        let stdout = e.stdout;
-        stdout = stdout.replace(LINKER_WARNING_REGEXP, '').trim();
-        return stdout;
+        return e.stdout.replace(LINKER_WARNING_REGEXP, '').trim();
       }
 
       e.message = `Error executing adbExec. Original error: '${e.message}'; ` +
@@ -329,7 +330,7 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
     }
   };
 
-  return await retry(2, execFunc);
+  return await execFunc();
 };
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -297,7 +297,9 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
 
   cmd = _.isArray(cmd) ? cmd : [cmd];
 
+  let callCount = 0;
   const execFunc = async () => {
+    callCount++;
     try {
       const args = this.executable.defaultArgs.concat(cmd);
       log.debug(`Running '${this.executable.path} ${quote(args)}'`);
@@ -316,8 +318,10 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         await sleep(1000);
         await this.getDevicesWithRetry();
 
-        // try again
-        return await execFunc();
+        // try again one time
+        if (callCount <= 1) {
+          return await execFunc();
+        }
       }
 
       if (e.code === 0 && e.stdout) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -297,9 +297,8 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
 
   cmd = _.isArray(cmd) ? cmd : [cmd];
 
-  let callCount = 0;
+  let adbRetried = false;
   const execFunc = async () => {
-    callCount++;
     try {
       const args = this.executable.defaultArgs.concat(cmd);
       log.debug(`Running '${this.executable.path} ${quote(args)}'`);
@@ -319,7 +318,8 @@ systemCallMethods.adbExec = async function (cmd, opts = {}) {
         await this.getDevicesWithRetry();
 
         // try again one time
-        if (callCount <= 1) {
+        if (adbRetried) {
+          adbRetried = true;
           return await execFunc();
         }
       }

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -27,7 +27,9 @@ describe('apk utils', function () {
   };
 
   before(async function () {
-    adb = await ADB.createADB();
+    adb = await ADB.createADB({
+      adbExecTimeout: process.env.TRAVIS ? 60000 : 40000,
+    });
   });
   it('should be able to check status of third party app', async function () {
     (await adb.isAppInstalled('com.android.phone')).should.be.true;

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -21,7 +21,7 @@ let apiLevel = process.env.API_LEVEL ||
                API_LEVEL_MAP[parseFloat(platformVersion).toString()];
 apiLevel = parseInt(apiLevel, 10);
 
-let MOCHA_TIMEOUT = process.env.TRAVIS ? 240000 : 60000;
-let MOCHA_LONG_TIMEOUT = MOCHA_TIMEOUT * 10;
+const MOCHA_TIMEOUT = process.env.TRAVIS ? 240000 : 60000;
+const MOCHA_LONG_TIMEOUT = MOCHA_TIMEOUT * 10;
 
 export { apiLevel, platformVersion, avdName, MOCHA_TIMEOUT, MOCHA_LONG_TIMEOUT };


### PR DESCRIPTION
After some discussion with @mykola-mokhnach we decided to try to retry _only_ when in the special cases of a protocol or device not found error.

No one knows why exactly the `retry` is necessary. If things get flakey it can be returned and noted.