### PR TITLE
Only print out API level once

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -83,14 +83,14 @@ methods.getApiLevel = async function () {
     try {
       const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
       this._apiLevel = parseInt(strOutput.trim(), 10);
+      log.debug(`Device API level: ${this._apiLevel}`);
       if (isNaN(this._apiLevel)) {
-        throw new Error(`The actual output "${strOutput}" cannot be converted to an integer`);
+        throw new Error(`The actual output '${strOutput}' cannot be converted to an integer`);
       }
     } catch (e) {
       throw new Error(`Error getting device API level. Original error: ${e.message}`);
     }
   }
-  log.debug(`Device API level: ${this._apiLevel}`);
   return this._apiLevel;
 };
 


### PR DESCRIPTION
In the normal course of the logs we get the line for API level a number of times, even though the function is memoized. This is wasteful and also makes it seem like we're actually computing it each time.