### PR TITLE
Prefer pgrep over pidof for process id detection

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1151,7 +1151,9 @@ methods.getPIDsByName = async function (name) {
   }
   if (this._isPgrepAvailable || this._isPidofAvailable) {
     const shellCommand = this._isPgrepAvailable
-      ? ['pgrep', '-f', `^${_.escapeRegExp(name)}$`]
+      // The -f option is not available for pgrep on all platforms,
+      // so we default to the lookup by the last 15 chars of the process name
+      ? ['pgrep', `^${_.escapeRegExp(name.slice(-15))}$`]
       : ['pidof', name];
     try {
       return (await this.shell(shellCommand))

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1147,7 +1147,7 @@ methods.getPIDsByName = async function (name) {
     const pgrepOutput = _.trim(await this.shell(['pgrep --help; echo $?']));
     this._isPgrepAvailable = parseInt(_.last(pgrepOutput.split(/\s+/)), 10) === 0;
     if (this._isPgrepAvailable) {
-      this._canPgrepUseFullCmdLineSearch = pgrepOutput.test(/^-f\b/m);
+      this._canPgrepUseFullCmdLineSearch = /^-f\b/m.test(pgrepOutput);
     } else {
       this._isPidofAvailable = parseInt(await this.shell(['pidof --help > /dev/null; echo $?']), 10) === 0;
     }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1142,17 +1142,24 @@ methods.removeLogcatListener = function (listener) {
  */
 methods.getPIDsByName = async function (name) {
   log.debug(`Getting IDs of all '${name}' processes`);
-  if (!_.isBoolean(this._isPidofAvailable)) {
-    this._isPidofAvailable = parseInt(await this.shell(['pidof --help > /dev/null; echo $?']), 10) === 0;
+  if (!_.isBoolean(this._isPgrepAvailable)) {
+    // pgrep is in priority, since pidof has been reported of having bugs on some platforms
+    this._isPgrepAvailable = parseInt(await this.shell(['pgrep --help > /dev/null; echo $?']), 10) === 0;
+    if (!this._isPgrepAvailable && !_.isBoolean(this._isPidofAvailable)) {
+      this._isPidofAvailable = parseInt(await this.shell(['pidof --help > /dev/null; echo $?']), 10) === 0;
+    }
   }
-  if (this._isPidofAvailable) {
+  if (this._isPgrepAvailable || this._isPidofAvailable) {
+    const shellCommand = this._isPgrepAvailable
+      ? ['pgrep', '-f', `^${_.escapeRegExp(name)}$`]
+      : ['pidof', name];
     try {
-      return (await this.shell(['pidof', name]))
+      return (await this.shell(shellCommand))
         .split(/\s+/)
         .map((x) => parseInt(x, 10))
         .filter((x) => _.isInteger(x));
     } catch (e) {
-      // error code 1 is returned if the pidof utility did not find any processes
+      // error code 1 is returned if the utility did not find any processes
       // with the given name
       if (e.code === 1) {
         return [];

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1144,16 +1144,19 @@ methods.getPIDsByName = async function (name) {
   log.debug(`Getting IDs of all '${name}' processes`);
   if (!_.isBoolean(this._isPgrepAvailable)) {
     // pgrep is in priority, since pidof has been reported of having bugs on some platforms
-    this._isPgrepAvailable = parseInt(await this.shell(['pgrep --help > /dev/null; echo $?']), 10) === 0;
-    if (!this._isPgrepAvailable && !_.isBoolean(this._isPidofAvailable)) {
+    const pgrepOutput = _.trim(await this.shell(['pgrep --help; echo $?']));
+    this._isPgrepAvailable = parseInt(_.last(pgrepOutput.split(/\s+/)), 10) === 0;
+    if (this._isPgrepAvailable) {
+      this._canPgrepUseFullCmdLineSearch = pgrepOutput.test(/^-f\b/m);
+    } else {
       this._isPidofAvailable = parseInt(await this.shell(['pidof --help > /dev/null; echo $?']), 10) === 0;
     }
   }
   if (this._isPgrepAvailable || this._isPidofAvailable) {
     const shellCommand = this._isPgrepAvailable
-      // The -f option is not available for pgrep on all platforms,
-      // so we default to the lookup by the last 15 chars of the process name
-      ? ['pgrep', `^${_.escapeRegExp(name.slice(-15))}$`]
+      ? (this._canPgrepUseFullCmdLineSearch
+        ? ['pgrep', '-f', `^${_.escapeRegExp(name)}$`]
+        : ['pgrep', `^${_.escapeRegExp(name.slice(-15))}$`])
       : ['pidof', name];
     try {
       return (await this.shell(shellCommand))

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -592,7 +592,7 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         adb._isPidofAvailable = false;
         adb._isPgrepAvailable = true;
         mocks.adb.expects('shell')
-          .once().withExactArgs(['pgrep', '-f', `^${_.escapeRegExp(contactManagerPackage)}$`])
+          .once().withExactArgs(['pgrep', `^${_.escapeRegExp(contactManagerPackage.slice(-15))}$`])
           .returns('5078\n5079\n');
         (await adb.getPIDsByName(contactManagerPackage)).should.eql([5078, 5079]);
       });


### PR DESCRIPTION
pgrep is in priority, since pidof has been reported of having bugs on some platforms. It sometimes returns a big list of ids, which includes the ones for already terminated instances of the queried process.