### PR TITLE
Remove the unused javaVersion option

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -23,7 +23,6 @@ const DEFAULT_OPTS = {
   logcat: null,
   binaries: {},
   instrumentProc: null,
-  javaVersion: null,
   suppressKillServer: null,
   jars: {},
   helperJarPath: JAR_PATH,


### PR DESCRIPTION
Related to https://github.com/appium/appium-android-driver/pull/491