### PR TITLE
add a note about screen locked [skip ci]

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -129,6 +129,10 @@ async function getApkanalyzerForOs (sysHelpers) {
  * Checks mShowingLockscreen or mDreamingLockscreen in dumpsys output to determine
  * if lock screen is showing
  *
+ * A note: `adb shell dumpsys trust` has better peformacne to detect if the screen
+ * is locked with `adb dumpsys window` and grep it.
+ * But the trust command does not work for `Swipe` unlock pattern.
+ *
  * @param {string} dumpsys - The output of dumpsys window command.
  * @return {boolean} True if lock screen is showing.
  */


### PR DESCRIPTION
This is just a note.

When I took a look at `adb shell dumpsys trust`, the command had good performance than grep dumpsys window to detect screen is locked or not. But the `trust` command does not return `deviceLocked=1` if we set the lock pattern as `Swipe` while the screen is locked.
So, i would leave a note about it. (Except for the `Swipe` case, it returns proper `deviceLocked` state.)

```
$ time adb shell dumpsys trust
Trust manager state:
 User "Owner" (id=0, flags=0x13) (current): trusted=0, trustManaged=0, deviceLocked=1, strongAuthRequired=0x0
   Enabled agents:
    com.google.android.gms/.auth.trustagent.GoogleTrustAgent
     bound=1, connected=1, managingTrust=0, trusted=0
   Events:
    #0  02-04 17:23:56.619 DevicePolicyChanged:
    #1  02-04 17:23:56.619 DevicePolicyChanged:
    #2  02-04 17:23:13.600 AgentConnected: agent=GoogleTrustAgent
    #3  02-04 17:11:46.002 RevokeTrust: agent=GoogleTrustAgent
    #4  02-04 17:11:45.998 AgentStopped: agent=GoogleTrustAgent
    #5  02-04 17:11:39.432 DevicePolicyChanged:
    #6  02-04 17:11:39.431 DevicePolicyChanged:
    #7  02-04 16:40:51.459 DevicePolicyChanged:
    #8  02-04 16:40:47.459 DevicePolicyChanged:
    #9  02-04 11:37:06.088 DevicePolicyChanged:
    #10 02-04 11:35:42.545 AgentConnected: agent=GoogleTrustAgent


real	0m0.022s
user	0m0.002s
sys	0m0.003s

$ time adb shell dumpsys window | grep "DreamingLockscreen"
    mShowingDream=false mDreamingLockscreen=true mDreamingSleepToken=null

real    0m0.042s
user    0m0.003s
sys    0m0.005s
```