### PR TITLE
Add methods for `adb reverse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ console.log(await adb.getPIDsByName('com.android.phone'));
 - `pull`
 - `processExists`
 - `forwardPort`
+- `reversePort` (ApiLevel >=21)
 - `forwardAbstractPort`
 - `ping`
 - `restart`

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1016,6 +1016,39 @@ methods.removePortForward = async function (systemPort) {
 };
 
 /**
+ * Get TCP port forwarding with adb on the device under test.
+ * @return {Array.<String>} The output of the corresponding adb command. An array contains each forwarding line of output
+ */
+methods.getReverseList = async function () {
+  log.debug(`List reverse forwarding ports`);
+  let connections = await this.adbExec(['reverse', '--list']);
+  return connections.split('\n');
+};
+
+/**
+ * Setup TCP port forwarding with adb on the device under test.
+ *
+ * @param {string|number} devicePort - The number of the remote device port.
+ * @param {string|number} systemPort - The number of the local system port.
+ */
+methods.reversePort = async function (devicePort, systemPort) {
+  log.debug(`Forwarding device: ${devicePort} to system: ${systemPort}`);
+  await this.adbExec(['reverse', `tcp:${devicePort}`, `tcp:${systemPort}`]);
+};
+
+/**
+ * Remove TCP port forwarding with adb on the device under test. The forwarding
+ * for the given port should be setup with {@link #forwardPort} first.
+ *
+ * @param {string|number} devicePort - The number of the remote device port
+ *                                     to remove forwarding on.
+ */
+methods.removePortReverse = async function (devicePort) {
+  log.debug(`Removing reverse forwarded port socket connection: ${devicePort} `);
+  await this.adbExec(['reverse', `--remove`, `tcp:${devicePort}`]);
+};
+
+/**
  * Setup TCP port forwarding with adb on the device under test. The difference
  * between {@link #forwardPort} is that this method does setup for an abstract
  * local port.

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -990,7 +990,7 @@ methods.processExists = async function (processName) {
 methods.getForwardList = async function () {
   log.debug(`List forwarding ports`);
   const connections = await this.adbExec(['forward', '--list']);
-  return connections.split(EOL);
+  return connections.split(EOL).filter((line) => Boolean(line.trim()));
 };
 
 /**
@@ -1023,7 +1023,7 @@ methods.removePortForward = async function (systemPort) {
 methods.getReverseList = async function () {
   log.debug(`List reverse forwarding ports`);
   const connections = await this.adbExec(['reverse', '--list']);
-  return connections.split(EOL);
+  return connections.split(EOL).filter((line) => Boolean(line.trim()));
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -5,6 +5,7 @@ import path from 'path';
 import _ from 'lodash';
 import { fs, util } from 'appium-support';
 import net from 'net';
+import { EOL } from 'os';
 import Logcat from '../logcat';
 import { sleep, waitForCondition } from 'asyncbox';
 import { SubProcess } from 'teen_process';
@@ -988,8 +989,8 @@ methods.processExists = async function (processName) {
  */
 methods.getForwardList = async function () {
   log.debug(`List forwarding ports`);
-  let connections = await this.adbExec(['forward', '--list']);
-  return connections.split('\n');
+  const connections = await this.adbExec(['forward', '--list']);
+  return connections.split(EOL);
 };
 
 /**
@@ -1021,12 +1022,13 @@ methods.removePortForward = async function (systemPort) {
  */
 methods.getReverseList = async function () {
   log.debug(`List reverse forwarding ports`);
-  let connections = await this.adbExec(['reverse', '--list']);
-  return connections.split('\n');
+  const connections = await this.adbExec(['reverse', '--list']);
+  return connections.split(EOL);
 };
 
 /**
  * Setup TCP port forwarding with adb on the device under test.
+ * Only available for API 21+.
  *
  * @param {string|number} devicePort - The number of the remote device port.
  * @param {string|number} systemPort - The number of the local system port.

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -106,6 +106,16 @@ describe('adb commands', function () {
     (await adb.adbExec([`forward`, `--list`])).should.not.contain('tcp:8200');
 
   });
+  it('should reverse forward the port', async function () {
+    await adb.reversePort(4724, 4724);
+  });
+  it('should remove reverse forwarded port', async function () {
+    await adb.reversePort(6790, 8200);
+    (await adb.adbExec([`reverse`, `--list`])).should.contain('tcp:6790');
+    await adb.removePortReverse(6790);
+    (await adb.adbExec([`reverse`, `--list`])).should.not.contain('tcp:6790');
+
+  });
   it('should start logcat from adb', async function () {
     await adb.startLogcat();
     let logs = adb.logcat.getLogs();

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -541,7 +541,23 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         mocks.adb.expects('adbExec')
             .once().withExactArgs(['forward', `--remove`, `tcp:${sysPort}`])
             .returns('');
-        await adb.removePortForward(sysPort, devicePort);
+        await adb.removePortForward(sysPort);
+      });
+    });
+    describe('reversePort', function () {
+      const sysPort = 12345,
+            devicePort = 54321;
+      it('reversePort should call shell with correct args', async function () {
+        mocks.adb.expects('adbExec')
+          .once().withExactArgs(['reverse', `tcp:${devicePort}`, `tcp:${sysPort}`])
+          .returns('');
+        await adb.reversePort(devicePort, sysPort);
+      });
+      it('removePortReverse should call shell with correct args', async function () {
+        mocks.adb.expects('adbExec')
+            .once().withExactArgs(['reverse', `--remove`, `tcp:${devicePort}`])
+            .returns('');
+        await adb.removePortReverse(devicePort);
       });
     });
     describe('ping', function () {


### PR DESCRIPTION
Added methods for `adb reverse`, a command similar to `adb forward` that lets you reverse a socket connection. 


