### PR TITLE
tweak error message for installation

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -398,6 +398,11 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
       throw new Error(output);
     }
   } catch (err) {
+    // adbExec raise an error message to extend adbExecTimeout. But install apk timeout is handled by androidInstallTimeout.
+    if (err.message.includes('adbExecTimeout')) {
+      throw new Error(err.message.replace('adbExecTimeout', 'androidInstallTimeout'));
+    }
+
     // on some systems this will throw an error if the app already
     // exists
     if (!err.message.includes('INSTALL_FAILED_ALREADY_EXISTS')) {

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -166,6 +166,11 @@ apksUtilsMethods.installApks = async function (apks, options = {}) {
     if (_.includes(output, 'INSTALL_FAILED')) {
       throw new Error(output);
     }
+  } catch (err) {
+    // adbExec raise an error message to extend adbExecTimeout. But install apk timeout is handled by androidInstallTimeout.
+    if (err.message.includes('adbExecTimeout')) {
+      throw new Error(err.message.replace('adbExecTimeout', 'androidInstallTimeout'));
+    }
   } finally {
     await fs.rimraf(tmpRoot);
   }


### PR DESCRIPTION
Currently, instalation command raise an error with `adbExecTimeout` capability.
But `androidInstallTimeout` is requred to relax the timeout error. `adbExecTimeout` does not affect the error.

So, only installation commands replace the `adbExecTimeout`  with `androidInstallTimeout` to avoid misunderstanding by users

- before
    ```
    [debug] [BaseDriver] Event 'newSessionStarted' logged at 1550217057573 (16:50:57 GMT+0900 (Japan Standard Time))
    [debug] [W3C] Encountered internal error running command: Error executing adbExec. Original error: 'Command '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s us-mvo.headspin.io\:7102 install /Users/kazu/Downloads/test.apk' timed out after 90000ms'. Try to increase the 90000ms adb execution timeout represented by 'adbExecTimeout' capability
    [debug] [W3C] Error: Command '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s us-mvo.headspin.io\:7102 install /Users/kazu/Downloads/test.apk' timed out after 90000ms
    [debug] [W3C]     at Timeout.setTimeout (/Users/kazu/GitHub/appium/node_modules/teen_process/lib/exec.js:106:19)
    [debug] [W3C]     at listOnTimeout (timers.js:327:15)
    [debug] [W3C]     at processTimers (timers.js:271:5)
    [HTTP] <-- POST /wd/hub/session 500 106650 ms - 1115
    [HTTP]
    ```
- after
    ```
    [debug] [BaseDriver] Event 'newSessionStarted' logged at 1550237316087 (22:28:36 GMT+0900 (Japan Standard Time))
    [debug] [W3C] Encountered internal error running command: Error: Error executing adbExec. Original error: 'Command '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s us-mvo.headspin.io\:7102 install /Users/kazu/Downloads/test.apk' timed out after 90000ms'. Try to increase the 90000ms adb execution timeout represented by 'androidInstallTimeout' capability
    [debug] [W3C]     at ADB.apkUtilsMethods.install (/Users/kazu/GitHub/appium/node_modules/appium-adb/lib/tools/apk-utils.js:402:13)
    [HTTP] <-- POST /wd/hub/session 500 107061 ms - 1129
    [HTTP]
    ```