### PR TITLE
Use the default adbExecTimeout value for uninstall

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -289,26 +289,21 @@ apkUtilsMethods.waitForNotActivity = async function (pkg, act, waitMs = 20000) {
 
 /**
  * @typedef {Object} UninstallOptions
- * @property {number} timeout [20000] - The count of milliseconds to wait until the
+ * @property {number} timeout [adbExecTimeout] - The count of milliseconds to wait until the
  *                                      app is uninstalled.
  * @property {boolean} keepData [false] - Set to true in order to keep the
  *                                        application data and cache folders after uninstall.
  */
 
-const APK_UNINSTALL_TIMEOUT = 20000;
-
 /**
  * Uninstall the given package from the device under test.
  *
  * @param {string} pkg - The name of the package to be uninstalled.
- * @param {?UninstallOptions} options - The set of uninstallation options.
+ * @param {?UninstallOptions} options - The set of uninstall options.
  * @return {boolean} True if the package was found on the device and
  *                   successfully uninstalled.
  */
 apkUtilsMethods.uninstallApk = async function (pkg, options = {}) {
-  options = Object.assign({
-    timeout: APK_UNINSTALL_TIMEOUT
-  }, options);
   log.debug(`Uninstalling ${pkg}`);
   if (!await this.isAppInstalled(pkg)) {
     log.info(`${pkg} was not uninstalled, because it was not present on the device`);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -435,7 +435,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .once().withExactArgs(pkg)
         .returns('');
       mocks.adb.expects('adbExec')
-        .once().withExactArgs(['uninstall', pkg], {timeout: 20000})
+        .once().withExactArgs(['uninstall', pkg], {timeout: undefined})
         .returns('Success');
       (await adb.uninstallApk(pkg)).should.be.true;
     });


### PR DESCRIPTION
There is no point in having a separate default value for uninstallApk