### PR TITLE
Km/can set timeoutcapname

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -351,6 +351,8 @@ apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = 
  * @typedef {Object} InstallOptions
  * @property {number} timeout [60000] - The count of milliseconds to wait until the
  *                                      app is installed.
+ * @property {string} timeoutCapName [androidInstallTimeout] - The timeout option name
+ *                                                             users can increase the timeout.
  * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
  *                                                 packages installation.
  * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -379,13 +379,14 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
   options = Object.assign({
     replace: true,
     timeout: APK_INSTALL_TIMEOUT,
+    timeoutCapName: 'androidInstallTimeout',
   }, options);
 
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
   try {
     const output = await this.adbExec(['install', ...installArgs, appPath], {
       timeout: options.timeout,
-      timeoutCapName: 'androidInstallTimeout',
+      timeoutCapName: options.timeoutCapName,
     });
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -138,6 +138,7 @@ apksUtilsMethods.getDeviceSpec = async function (specLocation) {
 apksUtilsMethods.installApks = async function (apks, options = {}) {
   options = Object.assign({
     timeout: APKS_INSTALL_TIMEOUT,
+    timeoutCapName: 'androidInstallTimeout',
   }, options, {replace: true});
 
   const tmpRoot = await tempDir.openDir();
@@ -159,7 +160,7 @@ apksUtilsMethods.installApks = async function (apks, options = {}) {
       JSON.stringify(apkPathsToInstall.map((x) => path.basename(x))));
     const output = await this.adbExec(['install-multiple', ...installArgs, ...apkPathsToInstall], {
       timeout: options.timeout,
-      timeoutCapName: 'androidInstallTimeout',
+      timeoutCapName: options.timeoutCapName,
     });
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -118,6 +118,8 @@ apksUtilsMethods.getDeviceSpec = async function (specLocation) {
  * @typedef {Object} InstallApksOptions
  * @property {?number|string} timeout [20000] - The number of milliseconds to wait until
  *                                              the installation is completed
+ * @property {string} timeoutCapName [androidInstallTimeout] - The timeout option name
+ *                                                             users can increase the timeout.
  * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
  *                                                 packages installation.
  * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard


### PR DESCRIPTION
Would like to set the `timeoutCapName` for `uiautomator2ServerInstallTimeout` which is called in UIA2 driver

---

e.g. https://github.com/appium/appium-uiautomator2-driver/blob/879a801dedfe5b7f9f5a5de5d1412394854513d0/lib/uiautomator2.js#L97-L99