### PR TITLE
Respect adbExecTimeout for apk(s) install

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -2,8 +2,7 @@ import _ from 'lodash';
 import os from 'os';
 import path from 'path';
 import methods from './tools/index.js';
-import { rootDir } from './helpers';
-import { DEFAULT_ADB_EXEC_TIMEOUT } from './tools/system-calls';
+import { rootDir, DEFAULT_ADB_EXEC_TIMEOUT } from './helpers';
 
 const DEFAULT_ADB_PORT = 5037;
 const JAR_PATH = path.resolve(rootDir, 'jars');

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,6 +11,7 @@ const APKS_EXTENSION = '.apks';
 const APK_EXTENSION = '.apk';
 const APK_INSTALL_TIMEOUT = 60000;
 const APKS_INSTALL_TIMEOUT = APK_INSTALL_TIMEOUT * 2;
+const DEFAULT_ADB_EXEC_TIMEOUT = 20000; // in milliseconds
 
 /**
  * @typedef {Object} PlatformInfo
@@ -409,4 +410,5 @@ export {
   rootDir, getSdkToolsVersion, getApksignerForOs, getBuildToolsDirs,
   getApkanalyzerForOs, getOpenSslForOs, extractMatchingPermissions, APKS_EXTENSION,
   APK_INSTALL_TIMEOUT, APKS_INSTALL_TIMEOUT, buildInstallArgs, APK_EXTENSION,
+  DEFAULT_ADB_EXEC_TIMEOUT,
 };

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -1,4 +1,6 @@
-import { buildStartCmd, APKS_EXTENSION, buildInstallArgs, APK_INSTALL_TIMEOUT } from '../helpers.js';
+import {
+  buildStartCmd, APKS_EXTENSION, buildInstallArgs,
+  APK_INSTALL_TIMEOUT, DEFAULT_ADB_EXEC_TIMEOUT } from '../helpers.js';
 import { exec } from 'teen_process';
 import log from '../logger.js';
 import path from 'path';
@@ -380,7 +382,7 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
 
   options = Object.assign({
     replace: true,
-    timeout: this.adbExecTimeout || APK_INSTALL_TIMEOUT,
+    timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APK_INSTALL_TIMEOUT : this.adbExecTimeout,
     timeoutCapName: 'androidInstallTimeout',
   }, options);
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -380,7 +380,7 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
 
   options = Object.assign({
     replace: true,
-    timeout: APK_INSTALL_TIMEOUT,
+    timeout: this.adbExecTimeout || APK_INSTALL_TIMEOUT,
     timeoutCapName: 'androidInstallTimeout',
   }, options);
 

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -6,7 +6,8 @@ import { fs, tempDir } from 'appium-support';
 import LRU from 'lru-cache';
 import {
   getJavaForOs, unzipFile, buildInstallArgs,
-  APKS_INSTALL_TIMEOUT, APK_EXTENSION } from '../helpers.js';
+  APKS_INSTALL_TIMEOUT, APK_EXTENSION,
+  DEFAULT_ADB_EXEC_TIMEOUT } from '../helpers.js';
 import AsyncLock from 'async-lock';
 
 const BASE_APK = 'base-master.apk';
@@ -139,7 +140,7 @@ apksUtilsMethods.getDeviceSpec = async function (specLocation) {
  */
 apksUtilsMethods.installApks = async function (apks, options = {}) {
   options = Object.assign({
-    timeout: this.adbExecTimeout || APKS_INSTALL_TIMEOUT,
+    timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APKS_INSTALL_TIMEOUT : this.adbExecTimeout,
     timeoutCapName: 'androidInstallTimeout',
   }, options, {replace: true});
 

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -139,7 +139,7 @@ apksUtilsMethods.getDeviceSpec = async function (specLocation) {
  */
 apksUtilsMethods.installApks = async function (apks, options = {}) {
   options = Object.assign({
-    timeout: APKS_INSTALL_TIMEOUT,
+    timeout: this.adbExecTimeout || APKS_INSTALL_TIMEOUT,
     timeoutCapName: 'androidInstallTimeout',
   }, options, {replace: true});
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -2,7 +2,11 @@ import path from 'path';
 import log from '../logger.js';
 import B from 'bluebird';
 import { system, fs, util, tempDir } from 'appium-support';
-import { getSdkToolsVersion, getBuildToolsDirs, getOpenSslForOs } from '../helpers';
+import {
+  getSdkToolsVersion,
+  getBuildToolsDirs,
+  getOpenSslForOs,
+  DEFAULT_ADB_EXEC_TIMEOUT } from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
@@ -11,7 +15,6 @@ import { quote } from 'shell-quote';
 
 let systemCallMethods = {};
 
-const DEFAULT_ADB_EXEC_TIMEOUT = 20000; // in milliseconds
 const DEFAULT_ADB_REBOOT_RETRIES = 90;
 
 const LINKER_WARNING_REGEXP = /^WARNING: linker.+$/m;


### PR DESCRIPTION
`adbExecTimeout` should have priority over the installation default timeouts if it is set to non-default value