### PR TITLE
Change 'windows' to 'displays'

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -390,7 +390,7 @@ function buildInstallArgs (apiLevel, options = {}) {
   if (options.useSdcard) {
     result.push('-s');
   }
-  if (options.grantPermissions) {
+  if (options.grantPermissions || apiLevel >= 28) {
     if (apiLevel < 23) {
       log.debug(`Skipping permissions grant option, since ` +
                 `the current API level ${apiLevel} does not support applications ` +

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -390,7 +390,7 @@ function buildInstallArgs (apiLevel, options = {}) {
   if (options.useSdcard) {
     result.push('-s');
   }
-  if (options.grantPermissions || apiLevel >= 28) {
+  if (options.grantPermissions) {
     if (apiLevel < 23) {
       log.debug(`Skipping permissions grant option, since ` +
                 `the current API level ${apiLevel} does not support applications ` +

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -87,6 +87,7 @@ methods.getApiLevel = async function getApiLevel () {
 
       // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
       if (apiLevel === 28 && (await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
+        log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
         apiLevel = 29;
       }
       this._apiLevel = apiLevel;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -86,8 +86,10 @@ methods.getApiLevel = async function getApiLevel () {
       let apiLevel = parseInt(strOutput.trim(), 10);
 
       // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
-      if ((await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
-        apiLevel = 29;
+      if (apiLevel === 28) {
+        if ((await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
+          apiLevel = 29;
+        }
       }
       this._apiLevel = apiLevel;
       log.debug(`Device API level: ${this._apiLevel}`);

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -83,7 +83,13 @@ methods.getApiLevel = async function getApiLevel () {
   if (!_.isInteger(this._apiLevel)) {
     try {
       const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
-      this._apiLevel = parseInt(strOutput.trim(), 10);
+      let apiLevel = parseInt(strOutput.trim(), 10);
+
+      // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
+      if ((await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
+        apiLevel = 29;
+      }
+      this._apiLevel = apiLevel;
       log.debug(`Device API level: ${this._apiLevel}`);
       if (isNaN(this._apiLevel)) {
         throw new Error(`The actual output '${strOutput}' cannot be converted to an integer`);

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -86,10 +86,8 @@ methods.getApiLevel = async function getApiLevel () {
       let apiLevel = parseInt(strOutput.trim(), 10);
 
       // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
-      if (apiLevel === 28) {
-        if ((await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
-          apiLevel = 29;
-        }
+      if (apiLevel === 28 && (await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
+        apiLevel = 29;
       }
       this._apiLevel = apiLevel;
       log.debug(`Device API level: ${this._apiLevel}`);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -168,6 +168,8 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
 apkUtilsMethods.getFocusedPackageAndActivity = async function getFocusedPackageAndActivity () {
   log.debug('Getting focused package and activity');
   const apiLevel = await this.getApiLevel();
+
+  // With version 29, Android changed the dumpsys syntax
   const dumpsysArg = apiLevel >= 29 ? 'displays' : 'windows';
   const cmd = ['dumpsys', 'window', dumpsysArg];
   const nullFocusedAppRe = new RegExp(/^\s*mFocusedApp=null/, 'm');

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -153,6 +153,20 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
 };
 
 /**
+ * Helper method to call `adb dumpsys window windows/displays`
+ */
+apkUtilsMethods.dumpsys = async function () {
+  const apiLevel = await this.getApiLevel();
+
+  // With version 29, Android changed the dumpsys syntax
+  const dumpsysArg = apiLevel >= 29 ? 'displays' : 'windows';
+  const cmd = ['dumpsys', 'window', dumpsysArg];
+
+  return await this.shell(cmd);
+
+};
+
+/**
  * @typedef {Object} PackageActivityInfo
  * @property {?string} appPackage - The name of application package,
  *                                  for example 'com.acme.app'.
@@ -167,11 +181,6 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
  */
 apkUtilsMethods.getFocusedPackageAndActivity = async function getFocusedPackageAndActivity () {
   log.debug('Getting focused package and activity');
-  const apiLevel = await this.getApiLevel();
-
-  // With version 29, Android changed the dumpsys syntax
-  const dumpsysArg = apiLevel >= 29 ? 'displays' : 'windows';
-  const cmd = ['dumpsys', 'window', dumpsysArg];
   const nullFocusedAppRe = new RegExp(/^\s*mFocusedApp=null/, 'm');
   // https://regex101.com/r/xZ8vF7/1
   const focusedAppRe = new RegExp('^\\s*mFocusedApp.+Record\\{.*\\s([^\\s\\/\\}]+)' +
@@ -180,7 +189,7 @@ apkUtilsMethods.getFocusedPackageAndActivity = async function getFocusedPackageA
   const currentFocusAppRe = new RegExp('^\\s*mCurrentFocus.+\\{.+\\s([^\\s\\/]+)\\/([^\\s]+)\\b', 'm');
 
   try {
-    const stdout = await this.shell(cmd);
+    const stdout = await this.dumpsys();
     // The order matters here
     for (const pattern of [focusedAppRe, currentFocusAppRe]) {
       const match = pattern.exec(stdout);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -167,7 +167,9 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
  */
 apkUtilsMethods.getFocusedPackageAndActivity = async function getFocusedPackageAndActivity () {
   log.debug('Getting focused package and activity');
-  const cmd = ['dumpsys', 'window', 'windows'];
+  const apiLevel = await this.getApiLevel();
+  const dumpsysArg = apiLevel >= 29 ? 'displays' : 'windows';
+  const cmd = ['dumpsys', 'window', dumpsysArg];
   const nullFocusedAppRe = new RegExp(/^\s*mFocusedApp=null/, 'm');
   // https://regex101.com/r/xZ8vF7/1
   const focusedAppRe = new RegExp('^\\s*mFocusedApp.+Record\\{.*\\s([^\\s\\/\\}]+)' +

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -54,7 +54,7 @@ describe('apk utils', function () {
       await adb.install(contactManagerPath);
       await adb.startUri('content://contacts/people', 'com.android.contacts');
       await retryInterval(10, 500, async () => {
-        res = await adb.shell(['dumpsys', 'window', 'windows']);
+        res = await adb.dumpsys();
         // depending on apilevel, app might show up as active in one of these
         // two dumpsys output formats
         let focusRe1 = '(mCurrentFocus.+\\.PeopleActivity)';

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -48,7 +48,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     it('should parse correctly and return true', async function () {
       const pkg = 'dummy.package';
       mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'package', pkg])
+        .twice().withExactArgs(['dumpsys', 'package', pkg])
         .returns(`Packages:
           Package [${pkg}] (2469669):
             userId=2000`);
@@ -196,8 +196,8 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
 
   describe('getFocusedPackageAndActivity', function () {
     it('should parse correctly and return package and activity', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/${act} t181}}}\n` +
                  `mCurrentFocus=Window{4330b6c0 com.android.settings/com.android.settings.SubSettings paused=false}`);
@@ -207,8 +207,8 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       appActivity.should.equal(act);
     });
     it('should parse correctly and return package and activity when a comma is present', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{20fe217e token=Token{21878739 ` +
                  `ActivityRecord{16425300 u0 ${pkg}/${act}, isShadow:false t10}}}`);
 
@@ -217,8 +217,8 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       appActivity.should.equal(act);
     });
     it('should parse correctly and return package and activity of only mCurrentFocus is set', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=null\n  mCurrentFocus=Window{4330b6c0 u0 ${pkg}/${act} paused=false}`);
 
       let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
@@ -226,16 +226,16 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       appActivity.should.equal(act);
     });
     it('should return null if mFocusedApp=null', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns('mFocusedApp=null');
       let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
       should.not.exist(appPackage);
       should.not.exist(appActivity);
     });
     it('should return null if mCurrentFocus=null', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns('mCurrentFocus=null');
       let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
       should.not.exist(appPackage);
@@ -244,60 +244,59 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
   });
   describe('waitForActivityOrNot', function () {
     it('should call shell once and should return', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/${act} t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, act, false);
     });
     it('should call shell multiple times and return', async function () {
-      mocks.adb.expects('shell').onCall(0)
+      mocks.adb.expects('dumpsys')
         .returns('mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ' +
                  'ActivityRecord{2c7c4318 u0 foo/bar t181}}}');
-      mocks.adb.expects('shell')
+      mocks.adb.expects('dumpsys')
         .returns('mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ' +
                  'ActivityRecord{2c7c4318 u0 com.example.android.contactmanager/.ContactManager t181}}}');
 
       await adb.waitForActivityOrNot(pkg, act, false);
     });
     it('should call shell once return for not', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns('mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ' +
                  'ActivityRecord{c 0 foo/bar t181}}}');
 
       await adb.waitForActivityOrNot(pkg, act, true);
     });
     it('should call shell multiple times and return for not', async function () {
-      mocks.adb.expects('shell').onCall(0)
+      mocks.adb.expects('dumpsys')
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/${act} t181}}}`);
-      mocks.adb.expects('shell')
+      mocks.adb.expects('dumpsys')
         .returns('mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ' +
                  'ActivityRecord{2c7c4318 u0 foo/bar t181}}}');
       await adb.waitForActivityOrNot(pkg, act, true);
     });
     it('should be able to get first of a comma-separated list of activities', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, '.ContactManager, .OtherManager', false);
     });
     it('should be able to get second of a comma-separated list of activities', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.OtherManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, '.ContactManager, .OtherManager', false);
     });
     it('should fail if no activity in a comma-separated list is available', async function () {
-      mocks.adb.expects('shell')
+      mocks.adb.expects('dumpsys')
         .atLeast(1)
-        .withExactArgs(['dumpsys', 'window', 'windows'])
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/${act} t181}}}`);
 
@@ -305,56 +304,56 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .should.eventually.be.rejected;
     });
     it('should be able to match activities if waitActivity is a wildcard', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, `*`, false);
     });
     it('should be able to match activities if waitActivity is shortened and contains a whildcard', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, `.*Manager`, false);
     });
     it('should be able to match activities if waitActivity contains a wildcard alternative to activity', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, `${pkg}.*`, false);
     });
     it('should be able to match activities if waitActivity contains a wildcard on head', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, `*.contactmanager.ContactManager`, false);
     });
     it('should be able to match activities if waitActivity contains a wildcard across a pkg name and an activity name', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, `com.*Manager`, false);
     });
     it('should be able to match activities if waitActivity contains wildcards in both a pkg name and an activity name', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u ${pkg}/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, `com.*.contactmanager.*Manager`, false);
     });
     it('should fail if activity not to match from regexp activities', async function () {
-      mocks.adb.expects('shell')
-        .atLeast(1).withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .atLeast(1)
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
                  `ActivityRecord{2 u com.example.android.supermanager/.SuperManager t181}}}`);
 
@@ -362,48 +361,48 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .should.eventually.be.rejected;
     });
     it('should be able to get an activity that is an inner class', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
           `ActivityRecord{2 u ${pkg}/.Settings$AppDrawOverlaySettingsActivity t181}}}`);
 
       await adb.waitForActivityOrNot(pkg, '.Settings$AppDrawOverlaySettingsActivity', false);
     });
     it('should be able to get first activity from first package in a comma-separated list of packages + activities', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
           `ActivityRecord{2 u com.android.settings/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
     });
     it('should be able to get first activity from second package in a comma-separated list of packages + activities', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
           `ActivityRecord{2 u com.example.android.supermanager/.ContactManager t181}}}`);
 
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
     });
     it('should be able to get second activity from first package in a comma-separated list of packages + activities', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
           `ActivityRecord{2 u com.android.settings/.OtherManager t181}}}`);
 
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
     });
     it('should be able to get second activity from second package in a comma-separated list of packages', async function () {
-      mocks.adb.expects('shell')
-        .once().withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .once()
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
           `ActivityRecord{2 u com.example.android.supermanager/.OtherManager t181}}}`);
 
       await adb.waitForActivityOrNot('com.android.settings,com.example.android.supermanager', '.ContactManager,.OtherManager', false);
     });
     it('should fail to get activity when focused activity matches none of the provided list of packages', async function () {
-      mocks.adb.expects('shell')
-        .atLeast(1).withExactArgs(['dumpsys', 'window', 'windows'])
+      mocks.adb.expects('dumpsys')
+        .atLeast(1)
         .returns(`mFocusedApp=AppWindowToken{38600b56 token=Token{9ea1171 ` +
           `ActivityRecord{2 u com.otherpackage/.ContactManager t181}}}`);
 
@@ -1091,6 +1090,20 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         isExceptionThrown = true;
       }
       isExceptionThrown.should.be.true;
+    });
+  });
+  describe('dumpsys', function () {
+    it('should call shell with dumpsys args for sdk < 29', async function () {
+      mocks.adb.expects('getApiLevel').returns(28);
+      mocks.adb.expects('shell').withArgs(['getprop', 'ro.build.version.sdk']).onCall(0);
+      mocks.adb.expects('shell').withArgs(['dumpsys', 'window', 'windows']).onCall(1);
+      await adb.dumpsys();
+    });
+    it('should call `dumpsys window displays` for sdk >= 29', async function () {
+      mocks.adb.expects('getApiLevel').returns(29);
+      mocks.adb.expects('shell').withArgs(['getprop', 'ro.build.version.sdk']).onCall(0);
+      mocks.adb.expects('shell').withArgs(['dumpsys', 'window', 'displays']).onCall(1);
+      await adb.dumpsys();
     });
   });
 }));


### PR DESCRIPTION
As of Android SDK 29 (Android Q), this apk (com.google.android.permissioncontroller) opens prior to the AUT opening to prompt the user which permissions to allow. 

https://user-images.githubusercontent.com/852574/54451599-6faa6e80-4710-11e9-8917-95126af79e79.png

^ This breaks tests and makes the AUT not start.

The way around this (what this PR does) is automatically grants all permissions for SDK level 29+ on install. Automatically granting this permission makes it bypass this APK.

This would be a breaking change though, so I'd like other opinions.

The choices are
1. Always grant permissions automatically, thus deprecating `autoGrantPermissions` capability. Add a new capability, something like `revokePermissions`, which takes an array of permissions and revokes them after app is started
1. Use UiAutomator to select the "Continue" button when it encounters the `permissioncontroller` apk. Although by the looks of it, this would do the same thing, because it would allow all permissions by default.
1. Use UiAutomator to unselect all permissions on the list. This should maintain backwards compatibility, but seems kind of hacky.

(thank you to @sridharreddysuram123 for showing me the fix for this)