### PR TITLE
Introduce apk caching

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -26,7 +26,8 @@ const DEFAULT_OPTS = {
   jars: {},
   helperJarPath: JAR_PATH,
   adbPort: DEFAULT_ADB_PORT,
-  adbExecTimeout: DEFAULT_ADB_EXEC_TIMEOUT
+  adbExecTimeout: DEFAULT_ADB_EXEC_TIMEOUT,
+  remoteAppsCacheLimit: 10,
 };
 
 class ADB {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -23,10 +23,7 @@ apkUtilsMethods.APP_INSTALL_STATE = {
   OLDER_VERSION_INSTALLED: 'olderVersionInstalled',
 };
 const REMOTE_CACHE_ROOT = '/data/local/tmp/appium_cache';
-const REMOTE_CACHE_ENTRIES_LIMIT = parseInt(process.env.APPIUM_ANDROID_REMOTE_APK_CACHE_LIMIT || 10, 10);
-const REMOTE_CACHE = new LRU({
-  max: REMOTE_CACHE_ENTRIES_LIMIT,
-});
+
 
 /**
  * Check whether the particular package is present on the device under test.
@@ -386,14 +383,22 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
     log.info(`The application at '${apkPath}' is already cached to '${remotePath}'`);
   } else {
     log.info(`Caching the application at '${apkPath}' to '${remotePath}'`);
+    const started = process.hrtime();
     await this.push(apkPath, remotePath, {timeout: options.timeout});
+    const [seconds, nanos] = process.hrtime(started);
+    log.info(`The upload of '${path.basename(apkPath)}' took ${(seconds + nanos / 1000000000.0).toFixed(2)}s`);
   }
-  REMOTE_CACHE.set(appHash, remotePath);
+  if (!this.remoteAppsCache) {
+    this.remoteAppsCache = new LRU({
+      max: this.remoteAppsCacheLimit,
+    });
+  }
+  this.remoteAppsCache.set(appHash, remotePath);
   // If the remote cache exceeds REMOTE_CACHE_ENTRIES_LIMIT, remove least recently used entries
   const entriesToCleanup = remoteCachedFiles
     .map((x) => path.posix.join(REMOTE_CACHE_ROOT, x))
-    .filter((x) => !REMOTE_CACHE.has(path.posix.parse(x).name))
-    .slice(REMOTE_CACHE_ENTRIES_LIMIT);
+    .filter((x) => !this.remoteAppsCache.has(path.posix.parse(x).name))
+    .slice(this.remoteAppsCacheLimit);
   if (!_.isEmpty(entriesToCleanup)) {
     try {
       await this.shell(['rm', '-f', ...entriesToCleanup]);
@@ -448,10 +453,13 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
   });
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
   try {
+    const started = process.hrtime();
     const output = await this.shell(['pm', 'install', ...installArgs, cachedRemotePath], {
       timeout: options.timeout,
       timeoutCapName: options.timeoutCapName,
     });
+    const [seconds, nanos] = process.hrtime(started);
+    log.info(`The installation of '${path.basename(appPath)}' took ${(seconds + nanos / 1000000000.0).toFixed(2)}s`);
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;
     log.debug(`Install command stdout: ${truncatedOutput}`);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -443,7 +443,9 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
     timeoutCapName: 'androidInstallTimeout',
   }, options);
 
-  const cachedRemotePath = await this.cacheApk(appPath, options);
+  const cachedRemotePath = await this.cacheApk(appPath, {
+    timeout: options.timeout,
+  });
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
   try {
     const output = await this.shell(['pm', 'install', ...installArgs, cachedRemotePath], {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -23,7 +23,7 @@ apkUtilsMethods.APP_INSTALL_STATE = {
   OLDER_VERSION_INSTALLED: 'olderVersionInstalled',
 };
 const REMOTE_CACHE_ROOT = '/data/local/tmp/appium_cache';
-const REMOTE_CACHE_ENTRIES_LIMIT = 10;
+const REMOTE_CACHE_ENTRIES_LIMIT = parseInt(process.env.APPIUM_ANDROID_REMOTE_APK_CACHE_LIMIT || 10, 10);
 const REMOTE_CACHE = new LRU({
   max: REMOTE_CACHE_ENTRIES_LIMIT,
 });
@@ -440,6 +440,7 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
   options = Object.assign({
     replace: true,
     timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APK_INSTALL_TIMEOUT : this.adbExecTimeout,
+    timeoutCapName: 'androidInstallTimeout',
   }, options);
 
   const cachedRemotePath = await this.cacheApk(appPath, options);
@@ -447,6 +448,7 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
   try {
     const output = await this.shell(['pm', 'install', ...installArgs, cachedRemotePath], {
       timeout: options.timeout,
+      timeoutCapName: options.timeoutCapName,
     });
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -386,7 +386,9 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
     const started = process.hrtime();
     await this.push(apkPath, remotePath, {timeout: options.timeout});
     const [seconds, nanos] = process.hrtime(started);
-    log.info(`The upload of '${path.basename(apkPath)}' took ${(seconds + nanos / 1000000000.0).toFixed(2)}s`);
+    const {size} = await fs.stat(apkPath);
+    log.info(`The upload of '${path.basename(apkPath)}' (${util.toReadableSizeString(size)}) ` +
+      `took ${(seconds + nanos / 1000000000.0).toFixed(2)}s`);
   }
   if (!this.remoteAppsCache) {
     this.remoteAppsCache = new LRU({

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -978,4 +978,5 @@ apkUtilsMethods.pullApk = async function pullApk (pkg, tmpDir) {
   return tmpApp;
 };
 
+export { REMOTE_CACHE_ROOT };
 export default apkUtilsMethods;

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -23,9 +23,9 @@ apkUtilsMethods.APP_INSTALL_STATE = {
   OLDER_VERSION_INSTALLED: 'olderVersionInstalled',
 };
 const REMOTE_CACHE_ROOT = '/data/local/tmp/appium_cache';
-const REMOTE_CACHE_SIZE = 10;
+const REMOTE_CACHE_ENTRIES_LIMIT = 10;
 const REMOTE_CACHE = new LRU({
-  max: REMOTE_CACHE_SIZE,
+  max: REMOTE_CACHE_ENTRIES_LIMIT,
 });
 
 /**
@@ -372,6 +372,7 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
   const appHash = await fs.hash(apkPath);
   const remotePath = path.posix.join(REMOTE_CACHE_ROOT, `${appHash}.apk`);
   const remoteCachedFiles = [];
+  // Get current contents of the remote cache or create it for the first time
   try {
     remoteCachedFiles.push(...(await this.ls(REMOTE_CACHE_ROOT, ['-t', '-1'])));
   } catch (e) {
@@ -380,17 +381,19 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
     await this.shell(['mkdir', '-p', REMOTE_CACHE_ROOT]);
   }
   log.debug(`The count of applications in the cache: ${remoteCachedFiles.length}`);
-  if (_.isEmpty(remoteCachedFiles.filter((x) => path.posix.parse(x).name === appHash))) {
+  // Push the apk to the remote cache if needed
+  if (remoteCachedFiles.find((x) => path.posix.parse(x).name === appHash)) {
+    log.info(`The application at '${apkPath}' is already cached to '${remotePath}'`);
+  } else {
     log.info(`Caching the application at '${apkPath}' to '${remotePath}'`);
     await this.push(apkPath, remotePath, {timeout: options.timeout});
-  } else {
-    log.info(`The application at '${apkPath}' is already cached to '${remotePath}'`);
   }
   REMOTE_CACHE.set(appHash, remotePath);
+  // If the remote cache exceeds REMOTE_CACHE_ENTRIES_LIMIT, remove least recently used entries
   const entriesToCleanup = remoteCachedFiles
     .map((x) => path.posix.join(REMOTE_CACHE_ROOT, x))
     .filter((x) => !REMOTE_CACHE.has(path.posix.parse(x).name))
-    .slice(REMOTE_CACHE_SIZE);
+    .slice(REMOTE_CACHE_ENTRIES_LIMIT);
   if (!_.isEmpty(entriesToCleanup)) {
     try {
       await this.shell(['rm', '-f', ...entriesToCleanup]);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -388,7 +388,7 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
     const [seconds, nanos] = process.hrtime(started);
     const {size} = await fs.stat(apkPath);
     log.info(`The upload of '${path.basename(apkPath)}' (${util.toReadableSizeString(size)}) ` +
-      `took ${(seconds + nanos / 1000000000.0).toFixed(2)}s`);
+      `took ${(seconds + nanos / 1e9).toFixed(3)}s`);
   }
   if (!this.remoteAppsCache) {
     this.remoteAppsCache = new LRU({
@@ -461,7 +461,7 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
       timeoutCapName: options.timeoutCapName,
     });
     const [seconds, nanos] = process.hrtime(started);
-    log.info(`The installation of '${path.basename(appPath)}' took ${(seconds + nanos / 1000000000.0).toFixed(2)}s`);
+    log.info(`The installation of '${path.basename(appPath)}' took ${(seconds + nanos / 1e9).toFixed(3)}s`);
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;
     log.debug(`Install command stdout: ${truncatedOutput}`);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -9,6 +9,7 @@ import { retryInterval } from 'asyncbox';
 import { fs, util, mkdirp } from 'appium-support';
 import semver from 'semver';
 import os from 'os';
+import LRU from 'lru-cache';
 
 let apkUtilsMethods = {};
 
@@ -21,6 +22,11 @@ apkUtilsMethods.APP_INSTALL_STATE = {
   SAME_VERSION_INSTALLED: 'sameVersionInstalled',
   OLDER_VERSION_INSTALLED: 'olderVersionInstalled',
 };
+const REMOTE_CACHE_ROOT = '/data/local/tmp/appium_cache';
+const REMOTE_CACHE_SIZE = 10;
+const REMOTE_CACHE = new LRU({
+  max: REMOTE_CACHE_SIZE,
+});
 
 /**
  * Check whether the particular package is present on the device under test.
@@ -350,6 +356,54 @@ apkUtilsMethods.installFromDevicePath = async function (apkPathOnDevice, opts = 
 };
 
 /**
+ * @typedef {Object} CachingOptions
+ * @property {?number} timeout [adbExecTimeout] - The count of milliseconds to wait until the
+ *                                                app is uploaded to the remote location.
+ */
+
+/**
+ * Caches the given APK at a remote location to speed up further APK deployments.
+ *
+ * @param {string} apkPath - Full path to the apk on the local FS
+ * @param {?CachingOptions} options - Caching options
+ * @returns {string} - Full path to the cached apk on the remote file system
+ */
+apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
+  const appHash = await fs.hash(apkPath);
+  const remotePath = path.posix.join(REMOTE_CACHE_ROOT, `${appHash}.apk`);
+  const remoteCachedFiles = [];
+  try {
+    remoteCachedFiles.push(...(await this.ls(REMOTE_CACHE_ROOT, ['-t', '-1'])));
+  } catch (e) {
+    log.debug(`Got an error '${e.message}' while getting the list of files in the cache. ` +
+      `Assuming the cache does not exist yet`);
+    await this.shell(['mkdir', '-p', REMOTE_CACHE_ROOT]);
+  }
+  log.debug(`The count of applications in the cache: ${remoteCachedFiles.length}`);
+  if (_.isEmpty(remoteCachedFiles.filter((x) => path.posix.parse(x).name === appHash))) {
+    log.info(`Caching the application at '${apkPath}' to '${remotePath}'`);
+    await this.push(apkPath, remotePath, {timeout: options.timeout});
+  } else {
+    log.info(`The application at '${apkPath}' is already cached to '${remotePath}'`);
+  }
+  REMOTE_CACHE.set(appHash, remotePath);
+  const entriesToCleanup = remoteCachedFiles
+    .map((x) => path.posix.join(REMOTE_CACHE_ROOT, x))
+    .filter((x) => !REMOTE_CACHE.has(path.posix.parse(x).name))
+    .slice(REMOTE_CACHE_SIZE);
+  if (!_.isEmpty(entriesToCleanup)) {
+    try {
+      await this.shell(['rm', '-f', ...entriesToCleanup]);
+      log.debug(`Deleted ${entriesToCleanup.length} expired application cache entries`);
+    } catch (e) {
+      log.warn(`Cannot delete ${entriesToCleanup.length} expired application cache entries. ` +
+        `Original error: ${e.message}`);
+    }
+  }
+  return remotePath;
+};
+
+/**
  * @typedef {Object} InstallOptions
  * @property {number} timeout [60000] - The count of milliseconds to wait until the
  *                                      app is installed.
@@ -383,14 +437,13 @@ apkUtilsMethods.install = async function (appPath, options = {}) {
   options = Object.assign({
     replace: true,
     timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APK_INSTALL_TIMEOUT : this.adbExecTimeout,
-    timeoutCapName: 'androidInstallTimeout',
   }, options);
 
+  const cachedRemotePath = await this.cacheApk(appPath, options);
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
   try {
-    const output = await this.adbExec(['install', ...installArgs, appPath], {
+    const output = await this.shell(['pm', 'install', ...installArgs, cachedRemotePath], {
       timeout: options.timeout,
-      timeoutCapName: options.timeoutCapName,
     });
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -477,6 +477,29 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         ]);
       await adb.cacheApk(apkPath);
     });
+    it('should add apk into the cache if it is not there yet', async function () {
+      const apkPath = '/dummy/foo.apk';
+      const hash = '12345';
+      mocks.adb.expects('ls')
+        .once()
+        .returns([]);
+      mocks.fs.expects('hash')
+        .withExactArgs(apkPath)
+        .returns(hash);
+      mocks.adb.expects('shell')
+        .once()
+        .withExactArgs(['mkdir', '-p', REMOTE_CACHE_ROOT])
+        .returns();
+      mocks.adb.expects('push')
+        .once()
+        .withArgs(apkPath, `${REMOTE_CACHE_ROOT}/${hash}.apk`)
+        .returns();
+      mocks.fs.expects('stat')
+        .once()
+        .withExactArgs(apkPath)
+        .returns({size: 1});
+      await adb.cacheApk(apkPath);
+    });
   });
   describe('install', function () {
     it('should call shell with correct arguments', async function () {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -464,9 +464,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .once().returns(23);
       mocks.adb.expects('cacheApk')
         .once().withExactArgs('foo', {
-          replace: true,
           timeout: 60000,
-          timeoutCapName: 'androidInstallTimeout'
         })
         .returns('bar');
       mocks.adb.expects('shell')
@@ -482,9 +480,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .once().returns(23);
       mocks.adb.expects('cacheApk')
         .once().withExactArgs('foo', {
-          replace: false,
           timeout: 60000,
-          timeoutCapName: 'androidInstallTimeout'
         })
         .returns('bar');
       mocks.adb.expects('shell')

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -451,7 +451,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     });
   });
   describe('installFromDevicePath', function () {
-    it('should call forceStop and adbExec with correct arguments', async function () {
+    it('should call shell with correct arguments', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs(['pm', 'install', '-r', 'foo'], {})
         .returns('');
@@ -459,19 +459,39 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     });
   });
   describe('install', function () {
-    it('should call forceStop and adbExec with correct arguments', async function () {
+    it('should call shell with correct arguments', async function () {
       mocks.adb.expects('getApiLevel')
         .once().returns(23);
-      mocks.adb.expects('adbExec')
-        .once().withExactArgs(['install', '-r', 'foo'], {timeout: 60000, timeoutCapName: 'androidInstallTimeout'})
+      mocks.adb.expects('cacheApk')
+        .once().withExactArgs('foo', {
+          replace: true,
+          timeout: 60000,
+          timeoutCapName: 'androidInstallTimeout'
+        })
+        .returns('bar');
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['pm', 'install', '-r', 'bar'], {
+          timeout: 60000,
+          timeoutCapName: 'androidInstallTimeout'
+        })
         .returns('');
       await adb.install('foo');
     });
-    it('should call forceStop and adbExec with correct arguments when not replacing', async function () {
+    it('should call shell with correct arguments when not replacing', async function () {
       mocks.adb.expects('getApiLevel')
         .once().returns(23);
-      mocks.adb.expects('adbExec')
-        .once().withExactArgs(['install', 'foo'], {timeout: 60000, timeoutCapName: 'androidInstallTimeout'})
+      mocks.adb.expects('cacheApk')
+        .once().withExactArgs('foo', {
+          replace: false,
+          timeout: 60000,
+          timeoutCapName: 'androidInstallTimeout'
+        })
+        .returns('bar');
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['pm', 'install', 'bar'], {
+          timeout: 60000,
+          timeoutCapName: 'androidInstallTimeout'
+        })
         .returns('');
       await adb.install('foo', {replace: false});
     });


### PR DESCRIPTION
Normal call of `adb install` internally uploads the apk to the remote fs, executes `pm install` on it and then deleted the apk (see https://android.googlesource.com/platform/tools/base/+/master/ddmlib/src/main/java/com/android/ddmlib/Device.java#879). With Appium, though, it is usually necessary to reinstall a package multiple times and uploading it to the device for each install is time-consuming, especially for bigger APKs. This  PR automatically puts an APK into the internal cache, which can contain up to 10 items in order to save time for upload. In case the size of the remote cache reaches the size limit the algorithm will clean out the outdated items.