### PR TITLE
Properly handle ls attributes presence for different API levels

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -373,15 +373,15 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
   try {
     const errorMarker = '_ERROR_';
     let lsOutput = null;
-    if (this._areExtendedLsOptionsSupported === true || !util.hasValue(this._areExtendedLsOptionsSupported)) {
-      lsOutput = await this.shell([`ls -t -1 ${REMOTE_CACHE_ROOT} || echo ${errorMarker}`]);
+    if (this._areExtendedLsOptionsSupported === true || !_.isBoolean(this._areExtendedLsOptionsSupported)) {
+      lsOutput = await this.shell([`ls -t -1 ${REMOTE_CACHE_ROOT} 2>&1 || echo ${errorMarker}`]);
     }
     if (!_.isString(lsOutput) || (lsOutput.includes(errorMarker) && !lsOutput.includes(REMOTE_CACHE_ROOT))) {
-      if (!util.hasValue(this._areExtendedLsOptionsSupported)) {
+      if (!_.isBoolean(this._areExtendedLsOptionsSupported)) {
         log.debug('The current Android API does not support extended ls options. ' +
           'Defaulting to no-options call');
       }
-      lsOutput = await this.shell([`ls ${REMOTE_CACHE_ROOT} || echo ${errorMarker}`]);
+      lsOutput = await this.shell([`ls ${REMOTE_CACHE_ROOT} 2>&1 || echo ${errorMarker}`]);
       this._areExtendedLsOptionsSupported = false;
     } else {
       this._areExtendedLsOptionsSupported = true;

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -395,7 +395,7 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
         .filter(Boolean)
     ));
   } catch (e) {
-    log.debug(`Got an error '${e.message}' while getting the list of files in the cache. ` +
+    log.debug(`Got an error '${e.message.trim()}' while getting the list of files in the cache. ` +
       `Assuming the cache does not exist yet`);
     await this.shell(['mkdir', '-p', REMOTE_CACHE_ROOT]);
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -371,7 +371,29 @@ apkUtilsMethods.cacheApk = async function (apkPath, options = {}) {
   const remoteCachedFiles = [];
   // Get current contents of the remote cache or create it for the first time
   try {
-    remoteCachedFiles.push(...(await this.ls(REMOTE_CACHE_ROOT, ['-t', '-1'])));
+    const errorMarker = '_ERROR_';
+    let lsOutput = null;
+    if (this._areExtendedLsOptionsSupported === true || !util.hasValue(this._areExtendedLsOptionsSupported)) {
+      lsOutput = await this.shell([`ls -t -1 ${REMOTE_CACHE_ROOT} || echo ${errorMarker}`]);
+    }
+    if (!_.isString(lsOutput) || (lsOutput.includes(errorMarker) && !lsOutput.includes(REMOTE_CACHE_ROOT))) {
+      if (!util.hasValue(this._areExtendedLsOptionsSupported)) {
+        log.debug('The current Android API does not support extended ls options. ' +
+          'Defaulting to no-options call');
+      }
+      lsOutput = await this.shell([`ls ${REMOTE_CACHE_ROOT} || echo ${errorMarker}`]);
+      this._areExtendedLsOptionsSupported = false;
+    } else {
+      this._areExtendedLsOptionsSupported = true;
+    }
+    if (lsOutput.includes(errorMarker)) {
+      throw new Error(lsOutput.substring(0, lsOutput.indexOf(errorMarker)));
+    }
+    remoteCachedFiles.push(...(
+      lsOutput.split('\n')
+        .map((x) => x.trim())
+        .filter(Boolean)
+    ));
   } catch (e) {
     log.debug(`Got an error '${e.message}' while getting the list of files in the cache. ` +
       `Assuming the cache does not exist yet`);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -465,7 +465,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       adb._areExtendedLsOptionsSupported = true;
       mocks.adb.expects('shell')
         .once()
-        .withExactArgs([`ls -t -1 ${REMOTE_CACHE_ROOT} || echo _ERROR_`])
+        .withExactArgs([`ls -t -1 ${REMOTE_CACHE_ROOT} 2>&1 || echo _ERROR_`])
         .returns(_.range(adb.remoteAppsCacheLimit + 2)
           .map((x) => `${x}.apk`)
           .join('\r\n')
@@ -488,7 +488,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       adb._areExtendedLsOptionsSupported = true;
       mocks.adb.expects('ls')
         .once()
-        .withExactArgs([`ls -t -1 ${REMOTE_CACHE_ROOT} || echo _ERROR_`])
+        .withExactArgs([`ls -t -1 ${REMOTE_CACHE_ROOT} 2>&1 || echo _ERROR_`])
         .returns('');
       mocks.fs.expects('hash')
         .withExactArgs(apkPath)

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -462,9 +462,14 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
   describe('cacheApk', function () {
     it('should remove extra apks from the cache', async function () {
       const apkPath = '/dummy/foo.apk';
-      mocks.adb.expects('ls')
+      adb._areExtendedLsOptionsSupported = true;
+      mocks.adb.expects('shell')
         .once()
-        .returns(_.range(adb.remoteAppsCacheLimit + 2).map((x) => `${x}.apk`));
+        .withExactArgs([`ls -t -1 ${REMOTE_CACHE_ROOT} || echo _ERROR_`])
+        .returns(_.range(adb.remoteAppsCacheLimit + 2)
+          .map((x) => `${x}.apk`)
+          .join('\r\n')
+        );
       mocks.fs.expects('hash')
         .withExactArgs(apkPath)
         .returns('1');
@@ -480,9 +485,11 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     it('should add apk into the cache if it is not there yet', async function () {
       const apkPath = '/dummy/foo.apk';
       const hash = '12345';
+      adb._areExtendedLsOptionsSupported = true;
       mocks.adb.expects('ls')
         .once()
-        .returns([]);
+        .withExactArgs([`ls -t -1 ${REMOTE_CACHE_ROOT} || echo _ERROR_`])
+        .returns('');
       mocks.fs.expects('hash')
         .withExactArgs(apkPath)
         .returns(hash);


### PR DESCRIPTION
Android API 28 does not align each file in ls output into a separate row (`-1` option is needed for that). Although the older APIs don't support such option at all and return an error if it is provided. This PR tries to properly handle both cases