### PR TITLE
Only apply caching if remoteAppsCacheLimit is greater than zero

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -472,16 +472,21 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
     timeoutCapName: 'androidInstallTimeout',
   }, options);
 
-  const cachedRemotePath = await this.cacheApk(appPath, {
-    timeout: options.timeout,
-  });
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
+  const installOpts = {
+    timeout: options.timeout,
+    timeoutCapName: options.timeoutCapName,
+  };
+  let installMethod = async () => await this.adbExec(['install', ...installArgs, appPath], installOpts);
+  if (this.remoteAppsCacheLimit > 0) {
+    const cachedRemotePath = await this.cacheApk(appPath, {
+      timeout: options.timeout,
+    });
+    installMethod = async () => await this.shell(['pm', 'install', ...installArgs, cachedRemotePath], installOpts);
+  }
   try {
     const started = process.hrtime();
-    const output = await this.shell(['pm', 'install', ...installArgs, cachedRemotePath], {
-      timeout: options.timeout,
-      timeoutCapName: options.timeoutCapName,
-    });
+    const output = await installMethod();
     const [seconds, nanos] = process.hrtime(started);
     log.info(`The installation of '${path.basename(appPath)}' took ${(seconds + nanos / 1e9).toFixed(3)}s`);
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -477,16 +477,26 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
     timeout: options.timeout,
     timeoutCapName: options.timeoutCapName,
   };
-  let installMethod = async () => await this.adbExec(['install', ...installArgs, appPath], installOpts);
+  let performAppInstall = async () => await this.adbExec([
+    'install',
+    ...installArgs,
+    appPath
+  ], installOpts);
+  // this.remoteAppsCacheLimit <= 0 means no caching should be applied
   if (this.remoteAppsCacheLimit > 0) {
     const cachedRemotePath = await this.cacheApk(appPath, {
       timeout: options.timeout,
     });
-    installMethod = async () => await this.shell(['pm', 'install', ...installArgs, cachedRemotePath], installOpts);
+    performAppInstall = async () => await this.shell([
+      'pm',
+      'install',
+      ...installArgs,
+      cachedRemotePath
+    ], installOpts);
   }
   try {
     const started = process.hrtime();
-    const output = await installMethod();
+    const output = await performAppInstall();
     const [seconds, nanos] = process.hrtime(started);
     log.info(`The installation of '${path.basename(appPath)}' took ${(seconds + nanos / 1e9).toFixed(3)}s`);
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?


### PR DESCRIPTION
Sometimes it might be needed to disable caching (for example in cloud, where devices are reset automatically after each test)