### PR TITLE
Fix setting of default values

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -613,10 +613,6 @@ apkUtilsMethods.getApplicationInstallState = async function getApplicationInstal
  * @throws {Error} If an unexpected error happens during install.
  */
 apkUtilsMethods.installOrUpgrade = async function installOrUpgrade (appPath, pkg = null, options = {}) {
-  options = _.defaults({
-    timeout: APK_INSTALL_TIMEOUT,
-  }, options);
-
   if (!pkg) {
     const apkInfo = await this.getApkInfo(appPath);
     pkg = apkInfo.name;

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -471,11 +471,12 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
     return await this.installApks(appPath, options);
   }
 
-  options = _.defaults({
+  options = _.cloneDeep(options);
+  _.defaults(options, {
     replace: true,
     timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APK_INSTALL_TIMEOUT : this.adbExecTimeout,
     timeoutCapName: 'androidInstallTimeout',
-  }, options);
+  });
 
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
   const installOpts = {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -471,7 +471,7 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
     return await this.installApks(appPath, options);
   }
 
-  options = Object.assign({
+  options = _.defaults({
     replace: true,
     timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APK_INSTALL_TIMEOUT : this.adbExecTimeout,
     timeoutCapName: 'androidInstallTimeout',
@@ -613,9 +613,9 @@ apkUtilsMethods.getApplicationInstallState = async function getApplicationInstal
  * @throws {Error} If an unexpected error happens during install.
  */
 apkUtilsMethods.installOrUpgrade = async function installOrUpgrade (appPath, pkg = null, options = {}) {
-  if (!util.hasValue(options.timeout)) {
-    options.timeout = APK_INSTALL_TIMEOUT;
-  }
+  options = _.defaults({
+    timeout: APK_INSTALL_TIMEOUT,
+  }, options);
 
   if (!pkg) {
     const apkInfo = await this.getApkInfo(appPath);

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -139,7 +139,7 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
  * @throws {Error} If the .apks bundle cannot be installed
  */
 apksUtilsMethods.installApks = async function installApks (apks, options = {}) {
-  options = Object.assign({
+  options = _.defaults({
     timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APKS_INSTALL_TIMEOUT : this.adbExecTimeout,
     timeoutCapName: 'androidInstallTimeout',
   }, options, {replace: true});

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -139,10 +139,12 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
  * @throws {Error} If the .apks bundle cannot be installed
  */
 apksUtilsMethods.installApks = async function installApks (apks, options = {}) {
-  options = _.defaults({
+  options = _.cloneDeep(options);
+  _.defaults(options, {
     timeout: this.adbExecTimeout === DEFAULT_ADB_EXEC_TIMEOUT ? APKS_INSTALL_TIMEOUT : this.adbExecTimeout,
     timeoutCapName: 'androidInstallTimeout',
-  }, options, {replace: true});
+  });
+  Object.assign(options, {replace: true});
 
   const tmpRoot = await tempDir.openDir();
   try {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -295,6 +295,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
     throw new Error('You need to pass in a command to adbExec()');
   }
 
+  opts = _.cloneDeep(opts);
   // setting default timeout for each command to prevent infinite wait.
   opts.timeout = opts.timeout || this.adbExecTimeout || DEFAULT_ADB_EXEC_TIMEOUT;
   opts.timeoutCapName = opts.timeoutCapName || 'adbExecTimeout'; // For error message

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -349,6 +349,9 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
 
 /**
  * @typedef {Object} ShellExecOptions
+ * @property {?string} timeoutCapName [adbExecTimeout] - the name of the corresponding Appium's timeout capability
+ * (used in the error messages).
+ * @property {?number} timeout [adbExecTimeout] - command execution timeout.
  * @property {?boolean} privileged [falsy] - Whether to run the given command as root.
  * @property {?boolean} keepPrivileged [falsy] - Whether to keep root mode after command execution is completed.
  *

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -1008,7 +1008,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 1
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).atLeast(1).returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
       mocks.adb.expects('install').withArgs(apkPath, {replace: true}).once().returns(true);
       await adb.installOrUpgrade(apkPath);
     });

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -1008,8 +1008,8 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       mocks.adb.expects('getPackageInfo').once().returns({
         versionCode: 1
       });
-      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, {replace: true, timeout: 60000}).once().returns(true);
+      mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).atLeast(1).returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, {replace: true}).once().returns(true);
       await adb.installOrUpgrade(apkPath);
     });
     it('should perform upgrade if older package version is installed, but version codes are not maintained', async function () {
@@ -1023,7 +1023,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         versionName: '1.0.0',
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, {replace: true, timeout: 60000}).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, {replace: true}).once().returns(true);
       await adb.installOrUpgrade(apkPath);
     });
     it('should perform upgrade if the same version is installed, but version codes are different', async function () {
@@ -1037,7 +1037,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         versionName: '2.0.0',
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, {replace: true, timeout: 60000}).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, {replace: true}).once().returns(true);
       await adb.installOrUpgrade(apkPath);
     });
     it('should uninstall and re-install if older package version is installed and upgrade fails', async function () {
@@ -1049,9 +1049,9 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         versionCode: 1
       });
       mocks.adb.expects('isAppInstalled').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, {replace: true, timeout: 60000}).once().throws();
+      mocks.adb.expects('install').withArgs(apkPath, {replace: true}).once().throws();
       mocks.adb.expects('uninstallApk').withExactArgs(pkgId).once().returns(true);
-      mocks.adb.expects('install').withArgs(apkPath, {replace: false, timeout: 60000}).once().returns(true);
+      mocks.adb.expects('install').withArgs(apkPath, {replace: false}).once().returns(true);
       await adb.installOrUpgrade(apkPath);
     });
     it('should throw an exception if upgrade and reinstall fail', async function () {


### PR DESCRIPTION
Object.assign is sometimes not exactly we'd like to use for setting the default values. For example:

```js

d = _.defaults({a: 1}, {b:2}, {c:undefined, a:undefined});
JSON.stringify(d) //{ "a":1,"b":2}
```

```js
d = Object.assign({a: 1}, {b:2}, {c:undefined, a:undefined});
JSON.stringify(d) //{ "a":1undefined, "b":2, "c": undefined}
```

Addresses https://github.com/appium/appium/issues/12409