### PR TITLE
Create directory before push to avoid permission issue

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -966,7 +966,7 @@ methods.rimraf = async function rimraf (path) {
  *                        options.
  */
 methods.push = async function push (localPath, remotePath, opts) {
-  await this.mkdir(path.dirname(remotePath));
+  await this.mkdir(path.posix.dirname(remotePath));
   await this.adbExec(['push', localPath, remotePath], opts);
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -966,6 +966,7 @@ methods.rimraf = async function rimraf (path) {
  *                        options.
  */
 methods.push = async function push (localPath, remotePath, opts) {
+  await this.mkdir(path.dirname(remotePath));
   await this.adbExec(['push', localPath, remotePath], opts);
 };
 

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -247,9 +247,7 @@ describe('adb commands', function () {
       remoteData.toString().should.equal(stringData);
     });
     it('should throw error if it cannot write to the remote file', async function () {
-      let remoteFile = '/foo/bar/remote.txt';
-
-      await adb.push(localFile, remoteFile).should.be.rejectedWith(/\/foo\/bar\/remote.txt/);
+      await adb.push(localFile, '/foo/bar/remote.txt').should.be.rejectedWith(/\/foo/);
     });
   });
 


### PR DESCRIPTION
`pushFile` isn't working on some later versions of Android SDK. 

Was getting error `remote secure_mkdirs failed: Operation not permitted`. Workaround is to create the directory first using `adb shell mkdir` before pushing the file. That directory will have the correct permissions.

(another issue that had this problem: https://github.com/bazelbuild/examples/issues/77)