### PR TITLE
Fix: Restart ADB server when devices go offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage
 coverage-e2e
 package-lock.json*
 .DS_Store
+bugreport-*

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -34,12 +34,12 @@ jobs:
       displayName: Run tests
     - task: PublishTestResults@2
       condition: always()
-      name: Publish Test Results
+      displayName: Publish Test Results
       inputs:
         testResultsFiles: ${{ parameters.MOCHA_FILE }}
     - task: PublishPipelineArtifact@0
       condition: always()
-      name: Publish Logcat to Artifacts
+      displayName: Publish Logcat to Artifacts
       inputs:
         artifactName: ${{ parameters.name }}-logcat
         targetPath: logcat.txt

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -26,7 +26,7 @@ jobs:
       displayName: Install Node dependencies
     - script: npm test
       displayName: NPM Test
-    - script: adb logcat -d > logcat.txt
+    - script: adb logcat > logcat.txt &
       displayName: Capture Logcat
     - script: bash ci-jobs/scripts/start-emulator.sh
       displayName: Create and run Emulator 

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -27,7 +27,9 @@ jobs:
     - script: npm test
       displayName: NPM Test
     - script: bash ci-jobs/scripts/start-emulator.sh
-      displayName: Create and run Emulator
+      displayName: Create and run Emulator 
+    - script: npm run build
+      displayName: Build
     - script: ${{ parameters.script }}
       displayName: Run tests
     - task: PublishTestResults@2

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -24,8 +24,6 @@ jobs:
         versionSpec: ${{ parameters.NODE_VERSION }}
     - script: npm install
       displayName: Install Node dependencies
-    - script: npm test
-      displayName: NPM Test
     - script: adb logcat > logcat.txt &
       displayName: Capture Logcat
     - script: bash ci-jobs/scripts/start-emulator.sh
@@ -41,6 +39,6 @@ jobs:
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: ${{ parameters.name }}-logcat
-        target: logcat.txt
+        targetPath: logcat.txt
 
   

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -26,6 +26,8 @@ jobs:
       displayName: Install Node dependencies
     - script: npm test
       displayName: NPM Test
+    - script: adb logcat > logcat.txt
+      displayName: Capture Logcat
     - script: bash ci-jobs/scripts/start-emulator.sh
       displayName: Create and run Emulator 
     - script: npm run build
@@ -36,3 +38,9 @@ jobs:
       condition: always()
       inputs:
         testResultsFiles: ${{ parameters.MOCHA_FILE }}
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: ${{ parameters.name }}-logcat
+        target: logcat.txt
+
+  

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -26,7 +26,7 @@ jobs:
       displayName: Install Node dependencies
     - script: npm test
       displayName: NPM Test
-    - script: adb logcat > logcat.txt
+    - script: adb logcat -d > logcat.txt
       displayName: Capture Logcat
     - script: bash ci-jobs/scripts/start-emulator.sh
       displayName: Create and run Emulator 

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -34,9 +34,12 @@ jobs:
       displayName: Run tests
     - task: PublishTestResults@2
       condition: always()
+      name: Publish Test Results
       inputs:
         testResultsFiles: ${{ parameters.MOCHA_FILE }}
     - task: PublishPipelineArtifact@0
+      condition: always()
+      name: Publish Logcat to Artifacts
       inputs:
         artifactName: ${{ parameters.name }}-logcat
         targetPath: logcat.txt

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -478,7 +478,7 @@ methods.setIME = async function setIME (imeId) {
 /**
  * Get the default input method on the device under test.
  *
- * @return {string} The name of the default input method.
+ * @return {string} The name of the default input method or null if none found.
  */
 methods.defaultIME = async function defaultIME () {
   try {
@@ -1461,16 +1461,22 @@ methods.getDeviceProperty = async function getDeviceProperty (property) {
 };
 
 /**
+ * @typedef setPropOpts
+ * @property {boolean} privileged - Do we run setProp as a privileged command?
+ */
+
+/**
  * Set the particular property of the device under test.
  *
  * @param {string} property - The name of the property. This name should
  *                            be known to _adb shell setprop_ tool.
  * @param {string} val - The new property value.
- * @param {boolean} privileged - Do we need to set root access for call to 'setProp'?
+ * @param {setPropOpts} opts
  *
  * @throws {error} If _setprop_ utility fails to change property value.
  */
-methods.setDeviceProperty = async function setDeviceProperty (prop, val, privileged = true) {
+methods.setDeviceProperty = async function setDeviceProperty (prop, val, opts = {}) {
+  const {privileged} = opts;
   log.debug(`Setting device property '${prop}' to '${val}'`);
   await this.shell(['setprop', prop, val], {
     privileged,

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1476,7 +1476,7 @@ methods.getDeviceProperty = async function getDeviceProperty (property) {
  * @throws {error} If _setprop_ utility fails to change property value.
  */
 methods.setDeviceProperty = async function setDeviceProperty (prop, val, opts = {}) {
-  const {privileged} = opts;
+  const {privileged = true} = opts;
   log.debug(`Setting device property '${prop}' to '${val}'`);
   await this.shell(['setprop', prop, val], {
     privileged,

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1303,10 +1303,8 @@ methods.killProcessByPID = async function killProcessByPID (pid) {
         throw e;
       }
       log.info(`Cannot kill PID ${pid} due to insufficient permissions. Retrying as root`);
-      try {
-        let {isSuccessful} = await this.root();
-        becameRoot = isSuccessful;
-      } catch (ign) {}
+      let {isSuccessful} = await this.root();
+      becameRoot = isSuccessful;
       await this.shell(['kill', '-0', pid]);
     }
     const timeoutMs = 1000;
@@ -1462,7 +1460,7 @@ methods.getDeviceProperty = async function getDeviceProperty (property) {
 
 /**
  * @typedef {object} setPropOpts
- * @property {boolean} privileged - Do we run setProp as a privileged command?
+ * @property {boolean} privileged - Do we run setProp as a privileged command? Default true.
  */
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1301,7 +1301,8 @@ methods.killProcessByPID = async function killProcessByPID (pid) {
       }
       log.info(`Cannot kill PID ${pid} due to insufficient permissions. Retrying as root`);
       try {
-        becameRoot = await this.root();
+        let {isSuccessful} = await this.root();
+        becameRoot = isSuccessful;
       } catch (ign) {}
       await this.shell(['kill', '-0', pid]);
     }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -478,7 +478,7 @@ methods.setIME = async function setIME (imeId) {
 /**
  * Get the default input method on the device under test.
  *
- * @return {string} The name of the default input method or null if none found.
+ * @return {?string} The name of the default input method
  */
 methods.defaultIME = async function defaultIME () {
   try {
@@ -1461,7 +1461,7 @@ methods.getDeviceProperty = async function getDeviceProperty (property) {
 };
 
 /**
- * @typedef setPropOpts
+ * @typedef {object} setPropOpts
  * @property {boolean} privileged - Do we run setProp as a privileged command?
  */
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1466,13 +1466,14 @@ methods.getDeviceProperty = async function getDeviceProperty (property) {
  * @param {string} property - The name of the property. This name should
  *                            be known to _adb shell setprop_ tool.
  * @param {string} val - The new property value.
+ * @param {boolean} privileged - Do we need to set root access for call to 'setProp'?
  *
  * @throws {error} If _setprop_ utility fails to change property value.
  */
-methods.setDeviceProperty = async function setDeviceProperty (prop, val) {
+methods.setDeviceProperty = async function setDeviceProperty (prop, val, privileged = true) {
   log.debug(`Setting device property '${prop}' to '${val}'`);
   await this.shell(['setprop', prop, val], {
-    privileged: true,
+    privileged,
   });
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1109,7 +1109,7 @@ methods.restart = async function restart () {
     await this.waitForDevice(60);
     await this.startLogcat();
   } catch (e) {
-    throw new Error(`Restart failed. Orginial error: ${e.message}`);
+    throw new Error(`Restart failed. Original error: ${e.message}`);
   }
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -483,6 +483,9 @@ methods.setIME = async function setIME (imeId) {
 methods.defaultIME = async function defaultIME () {
   try {
     let engine = await this.getSetting('secure', 'default_input_method');
+    if (engine === 'null') {
+      return null;
+    }
     return engine.trim();
   } catch (e) {
     throw new Error(`Error getting default IME. Original error: ${e.message}`);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -857,7 +857,7 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
  * @return {boolean} True if the device is rooted.
  */
 systemCallMethods.root = async function root (unroot = false) {
-  let cmd = unroot ? 'unroot' : 'root';
+  const cmd = unroot ? 'unroot' : 'root';
   let wasAlreadyRooted = false;
   try {
     let {stdout} = await exec(this.executable.path, [cmd]);
@@ -879,8 +879,7 @@ systemCallMethods.root = async function root (unroot = false) {
 
     // If 'closed' was in the stderr (e.g.: `adb: unable to connect for root: closed\n"`) then the
     // device probably went offline, so restart ADB
-    console.log('!!!!!!!!!', err, JSON.stringify(err));
-    if (stderr.toLowerCase().includes('closed')) {
+    if (stderr.toLowerCase().includes('closed') || stderr.toLowerCase().includes('device offline')) {
       log.warn(`${cmd} caused device to go offline. Restarting adb.`);
       await this.restartAdb();
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -832,14 +832,19 @@ systemCallMethods.waitForDevice = async function waitForDevice (appDeviceReadyTi
  */
 systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_RETRIES) {
   try {
-    await this.shell(['stop'], {
-      privileged: true,
-    });
+    // Get root access so we can run the following shell commands that require root access
+    const {wasAlreadyRooted} = await this.root();
+
+    // Stop and re-start the device
+    await this.shell(['stop']);
     await B.delay(2000); // let the emu finish stopping;
-    await this.setDeviceProperty('sys.boot_completed', 0);
-    await this.shell(['start'], {
-      privileged: true,
-    });
+    await this.setDeviceProperty('sys.boot_completed', 0, false);
+    await this.shell(['start']);
+
+    // Return root state to what it was before
+    if (!wasAlreadyRooted) {
+      await this.unroot();
+    }
   } catch (e) {
     const {message} = e;
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -375,6 +375,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
     keepPrivileged,
   } = opts;
   let shouldRestoreUser = false;
+  let isRoot = await this.isRoot();
   if (privileged) {
     try {
       shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root');
@@ -383,9 +384,9 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
         // Do not show the warning for real devices, where root is locked
         log.warn(`Cannot run adbd as root. Original error: ${err.message}`);
       }
+      // adb 'root' can cause device to go offline, restart if so
+      await this.restartAdbIfDevicesOffline();
     }
-    // adb 'root' can cause device to go offline, restart if so
-    await this.restartAdbIfDevicesOffline();
   }
   let didCommandFail = false;
   try {
@@ -401,9 +402,10 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
         await this.adbExec(['unroot'], opts);
       } catch (err) {
         log.warn(`Cannot run adbd as non-root. Original error: ${err.message}`);
+
+        // adb 'unroot' can cause device to go offline, restart if so
+        await this.restartAdbIfDevicesOffline();
       }
-      // adb 'unroot' can cause device to go offline, restart if so
-      await this.restartAdbIfDevicesOffline();
     }
   }
 };
@@ -877,23 +879,21 @@ systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevice
  *                   if the switch failed.
  */
 systemCallMethods.root = async function root () {
-  let isRootSuccessful = true;
   try {
-    let {stdout} = await retryInterval(10, 1000, async () => await exec(this.executable.path, ['root']));
+    let {stdout} = await exec(this.executable.path, ['root']);
 
     // on real devices in some situations we get an error in the stdout
     if (stdout && stdout.indexOf('adbd cannot run as root') !== -1) {
       throw new Error(stdout.trim());
     }
+    return true;
   } catch (err) {
     log.warn(`Unable to root adb daemon: '${err.message}'. Continuing.`);
-    isRootSuccessful = false;
+    // adb 'root' can cause device to go offline, restart if so
+    await this.restartAdbIfDevicesOffline();
+
+    return false;
   }
-
-  // adb 'root' can cause device to go offline, restart if so
-  await this.restartAdbIfDevicesOffline();
-
-  return isRootSuccessful;
 };
 
 /**
@@ -903,17 +903,15 @@ systemCallMethods.root = async function root () {
  *                   if the switch failed.
  */
 systemCallMethods.unroot = async function unroot () {
-  let isUnrootSuccessful = true;
   try {
-    await retryInterval(10, 1000, async () => await exec(this.executable.path, ['unroot']));
+    await exec(this.executable.path, ['unroot']);
+    return true;
   } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
-    isUnrootSuccessful = false;
+    // adb 'unroot' can cause device to go offline, restart if so
+    await this.restartAdbIfDevicesOffline();
+    return false;
   }
-  // adb 'unroot' can cause device to go offline, restart if so
-  await this.restartAdbIfDevicesOffline();
-
-  return isUnrootSuccessful;
 };
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -399,7 +399,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } finally {
     if (privileged && shouldRestoreUser && (!keepPrivileged || didCommandFail)) {
       try {
-        await this.adbExec(['unroot'], opts);
+        await this.unroot();
       } catch (err) {
         log.warn(`Cannot run adbd as non-root. Original error: ${err.message}`);
 
@@ -875,8 +875,7 @@ systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevice
 /**
  * Switch adb server to root mode.
  * @param {boolean} unroot - Should we unroot instead of root? (default false)
- * @return {boolean} True of the switch was successful or false
- *                   if the switch failed.
+ * @return {boolean} True if the device is rooted.
  */
 systemCallMethods.root = async function root (unroot = false) {
   let cmd = unroot ? 'unroot' : 'root';

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -381,12 +381,12 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
     log.info(`'adb shell ${cmd}' requires root access. Attempting to gain root access now.`);
     const {wasAlreadyRooted} = await this.root();
     shouldRestoreUser = !wasAlreadyRooted;
+    log.info(wasAlreadyRooted ? 'Device already had root access' : 'Root access successfully gained');
   }
   let didCommandFail = false;
   try {
     try {
       const res = await this.adbExec(_.isArray(cmd) ? ['shell', ...cmd] : ['shell', cmd], opts);
-      console.log('$$$$$$$$$res', res, JSON.stringify(res));
       return res;
     } catch (err) {
       didCommandFail = true;
@@ -897,7 +897,7 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (un
     // If 'closed' was in the stderr (e.g.: `adb: unable to connect for root: closed\n"`) then the
     // device probably went offline, so restart ADB
     if (stderr.toLowerCase().includes('closed') || stderr.toLowerCase().includes('device offline')) {
-      log.warn(`${cmd} caused device to go offline. Restarting adb.`);
+      log.warn(`Attempt to 'adb ${cmd}' caused device to go offline. Restarting adb.`);
       await this.restartAdb();
     }
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -379,15 +379,18 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   let shouldRestoreUser = false;
   if (privileged) {
     log.info(`'adb shell ${cmd}' requires root access. Attempting to gain root access now.`);
-    const {wasAlreadyRooted} = await this.root();
+    const {wasAlreadyRooted, isSuccessful} = await this.root();
     shouldRestoreUser = !wasAlreadyRooted;
-    log.info(wasAlreadyRooted ? 'Device already had root access' : 'Root access successfully gained');
+    if (wasAlreadyRooted) {
+      log.info('Device already had root access');
+    } else {
+      log.info(isSuccessful ? 'Root access successfully gained' : 'Could not gain root access');
+    }
   }
   let didCommandFail = false;
   try {
     try {
-      const res = await this.adbExec(_.isArray(cmd) ? ['shell', ...cmd] : ['shell', cmd], opts);
-      return res;
+      return await this.adbExec(_.isArray(cmd) ? ['shell', ...cmd] : ['shell', cmd], opts);
     } catch (err) {
       didCommandFail = true;
       throw err;
@@ -395,7 +398,9 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } finally {
     // Return the 'root' state to what it was before 'shell' was called
     if (privileged && shouldRestoreUser && (!keepPrivileged || didCommandFail)) {
-      await this.unroot();
+      log.info(`Call to '${cmd}' completed. Returning device to original unrooted state.`);
+      const {isSuccessful} = await this.unroot();
+      log.info(isSuccessful ? 'Returned device to unrooted state' : 'Could not return device to unrooted state');
     }
   }
 };
@@ -899,9 +904,10 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (un
     const {stderr = '', message} = err;
     log.warn(`Unable to ${cmd} adb daemon. Original error: '${message}'. Stderr: '${stderr}'. Continuing.`);
 
-    // If 'closed' was in the stderr (e.g.: `adb: unable to connect for root: closed\n"`) then the
-    // device probably went offline, so restart ADB
-    if (stderr.toLowerCase().includes('closed') || stderr.toLowerCase().includes('device offline')) {
+    // Check the output of the stdErr to see if there's any clues that show that the device went offline
+    // and if it did go offline, restart ADB
+    const s = stderr.toLowerCase();
+    if (s.includes('closed') || s.includes('device offline')) {
       log.warn(`Attempt to 'adb ${cmd}' caused device to go offline. Restarting adb.`);
       await this.restartAdb();
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -856,6 +856,16 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
 };
 
 /**
+ * Restart adb but only if no devices are connected
+ */
+systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevicesOffline () {
+  const connectedDevices = await this.getConnectedDevices();
+  if (connectedDevices.length === 0) {
+    this.restartAdb();
+  }
+};
+
+/**
  * Switch adb server to root mode.
  *
  * @return {boolean} True of the switch was successful or false
@@ -873,7 +883,8 @@ systemCallMethods.root = async function root () {
     return true;
   } catch (err) {
     log.warn(`Unable to root adb daemon: '${err.message}'. Restarting adb and continuing`);
-    await this.restartAdb();
+    // This sometimes causes adb to go offline so may need to restart
+    await this.restartAdbIfDevicesOffline();
     return false;
   }
 };
@@ -890,7 +901,7 @@ systemCallMethods.unroot = async function unroot () {
     return true;
   } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Restarting adb and continuing`);
-    await this.restartAdb();
+    await this.restartAdbIfDevicesOffline();
     return false;
   }
 };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -872,7 +872,8 @@ systemCallMethods.root = async function root () {
 
     return true;
   } catch (err) {
-    log.warn(`Unable to root adb daemon: '${err.message}'. Continuing`);
+    log.warn(`Unable to root adb daemon: '${err.message}'. Restarting adb and continuing`);
+    await this.restartAdb();
     return false;
   }
 };
@@ -888,7 +889,7 @@ systemCallMethods.unroot = async function unroot () {
     await exec(this.executable.path, ['unroot']);
     return true;
   } catch (err) {
-    log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
+    log.warn(`Unable to unroot adb daemon: '${err.message}'. Restarting adb and continuing`);
     await this.restartAdb();
     return false;
   }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -867,6 +867,7 @@ systemCallMethods.root = async function root (unroot = false) {
       if (stdout.includes('adbd cannot run as root')) {
         throw new Error(stdout.trim());
       }
+      // if the device was already rooted, return that in the result
       if (stdout.includes('already running as root')) {
         wasAlreadyRooted = true;
       }
@@ -875,13 +876,16 @@ systemCallMethods.root = async function root (unroot = false) {
   } catch (err) {
     const {stderr = ''} = err;
     log.warn(`Unable to ${cmd} adb daemon. Original error: '${stderr}'. Continuing.`);
-    // adb 'root' can cause device to go offline, restart if so
+
+    // If 'closed' was in the stderr (e.g.: `adb: unable to connect for root: closed\n"`) then the
+    // device probably went offline, so restart ADB
+    console.log('!!!!!!!!!', err, JSON.stringify(err));
     if (stderr.toLowerCase().includes('closed')) {
       log.warn(`${cmd} caused device to go offline. Restarting adb.`);
       await this.restartAdb();
     }
 
-    return {isRooted: unroot};
+    return {isRooted: !!unroot, wasAlreadyRooted};
   }
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -377,16 +377,6 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   let shouldRestoreUser = false;
   if (privileged) {
     await this.root();
-    /*try {
-      shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root');
-    } catch (err) {
-      if (!err.message.includes('adbd cannot run as root')) {
-        // Do not show the warning for real devices, where root is locked
-        log.warn(`Cannot run adbd as root. Original error: ${err.message}`);
-      }
-      // adb 'root' can cause device to go offline, restart if so
-      await this.restartAdbIfDevicesOffline();
-    }*/
   }
   let didCommandFail = false;
   try {
@@ -862,17 +852,6 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
 };
 
 /**
- * Restart adb but only if no devices are connected
- */
-systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevicesOffline () {
-  const connectedDevices = await this.getConnectedDevices();
-  if (connectedDevices.length === 0) {
-    log.debug('No devices connected. Restarting adb.');
-    await this.restartAdb();
-  }
-};
-
-/**
  * Switch adb server to root mode.
  * @param {boolean} unroot - Should we unroot instead of root? (default false)
  * @return {boolean} True if the device is rooted.
@@ -888,10 +867,12 @@ systemCallMethods.root = async function root (unroot = false) {
     }
     return true;
   } catch (err) {
-    console.log('!!!!!!!!!!!!!!', err, JSON.stringify(err));
-    log.warn(`Unable to ${cmd} adb daemon: '${err.message}'. Continuing.`);
+    const {stderr = ''} = err;
+    log.warn(`Unable to ${cmd} adb daemon. Original error: '${stderr}'. Continuing.`);
     // adb 'root' can cause device to go offline, restart if so
-    await this.restartAdbIfDevicesOffline();
+    if (stderr.toLowerCase().includes('closed')) {
+      await this.restartAdbIfDevicesOffline();
+    }
 
     return false;
   }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -832,7 +832,7 @@ systemCallMethods.waitForDevice = async function waitForDevice (appDeviceReadyTi
  */
 systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_RETRIES) {
   try {
-    // Get root access so we can run the following shell commands that require root access
+    // Get root access so we can run the next shell commands which require root access
     const {wasAlreadyRooted} = await this.root();
 
     // Stop and re-start the device

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -376,7 +376,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } = opts;
   let shouldRestoreUser = false;
   if (privileged) {
-    const {wasAlreadyRooted} = await retry(3, this.root);
+    const {wasAlreadyRooted} = await this.root();
     shouldRestoreUser = !wasAlreadyRooted;
   }
   let didCommandFail = false;
@@ -825,14 +825,25 @@ systemCallMethods.waitForDevice = async function waitForDevice (appDeviceReadyTi
  * @throws {Error} If the device failed to reboot and number of retries is exceeded.
  */
 systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_RETRIES) {
-  await this.shell(['stop'], {
-    privileged: true,
-  });
-  await B.delay(2000); // let the emu finish stopping;
-  await this.setDeviceProperty('sys.boot_completed', 0);
-  await this.shell(['start'], {
-    privileged: true,
-  });
+  try {
+    await this.shell(['stop'], {
+      privileged: true,
+    });
+    await B.delay(2000); // let the emu finish stopping;
+    await this.setDeviceProperty('sys.boot_completed', 0);
+    await this.shell(['start'], {
+      privileged: true,
+    });
+  } catch (e) {
+    const {message} = e;
+
+    // provide a helpful error message if the reason reboot failed was because it couldn't gain root access
+    if (message.includes('must be root')) {
+      throw new Error(`Could not reboot device. Rebooting requires root access and ` +
+        `attempt to get root access on device failed with error: '${message}'`);
+    }
+    throw e;
+  }
   const started = process.hrtime();
   await retryInterval(retries, 1000, async () => {
     if ((await this.getDeviceProperty('sys.boot_completed')) === '1') {
@@ -847,16 +858,16 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
 
 /**
  * @typedef {Object} rootResult
- * @property {boolean} isRooted True if the device is rooted now
+ * @property {boolean} isSuccessful True if the call to root/unroot was successful
  * @property {boolean} wasAlreadyRooted True if the device was already rooted
  */
 
 /**
  * Switch adb server to root mode.
  * @param {boolean} unroot - Should we unroot instead of root? (default false)
- * @return {boolean} True if the device is rooted.
+ * @return {rootResult}
  */
-systemCallMethods.root = async function root (unroot = false) {
+systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (unroot) {
   const cmd = unroot ? 'unroot' : 'root';
   let wasAlreadyRooted = false;
   try {
@@ -872,10 +883,10 @@ systemCallMethods.root = async function root (unroot = false) {
         wasAlreadyRooted = true;
       }
     }
-    return {isRooted: !unroot, wasAlreadyRooted};
+    return {isSuccessful: true, wasAlreadyRooted};
   } catch (err) {
-    const {stderr = ''} = err;
-    log.warn(`Unable to ${cmd} adb daemon. Original error: '${stderr}'. Continuing.`);
+    const {stderr = '', message} = err;
+    log.warn(`Unable to ${cmd} adb daemon. Original error: '${message}'. Stderr: '${stderr}'. Continuing.`);
 
     // If 'closed' was in the stderr (e.g.: `adb: unable to connect for root: closed\n"`) then the
     // device probably went offline, so restart ADB
@@ -884,18 +895,25 @@ systemCallMethods.root = async function root (unroot = false) {
       await this.restartAdb();
     }
 
-    return {isRooted: !!unroot, wasAlreadyRooted};
+    return {isSuccessful: false, wasAlreadyRooted};
   }
+};
+
+/**
+ * Switch adb server to root mode
+ * @return {rootResult}
+ */
+systemCallMethods.root = async function root () {
+  return await this.changeUserPrivileges(false);
 };
 
 /**
  * Switch adb server to non-root mode.
  *
- * @return {boolean} True of the switch was successful or false
- *                   if the switch failed.
+ * @return {rootResult}
  */
 systemCallMethods.unroot = async function unroot () {
-  await this.root(true);
+  return await this.changeUserPrivileges(true);
 };
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -374,20 +374,26 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
     privileged,
     keepPrivileged,
   } = opts;
+
+  // If the command requires privileges, root this device
   let shouldRestoreUser = false;
   if (privileged) {
+    log.info(`'adb shell ${cmd}' requires root access. Attempting to gain root access now.`);
     const {wasAlreadyRooted} = await this.root();
     shouldRestoreUser = !wasAlreadyRooted;
   }
   let didCommandFail = false;
   try {
     try {
-      return await this.adbExec(_.isArray(cmd) ? ['shell', ...cmd] : ['shell', cmd], opts);
+      const res = await this.adbExec(_.isArray(cmd) ? ['shell', ...cmd] : ['shell', cmd], opts);
+      console.log('$$$$$$$$$res', res, JSON.stringify(res));
+      return res;
     } catch (err) {
       didCommandFail = true;
       throw err;
     }
   } finally {
+    // Return the 'root' state to what it was before 'shell' was called
     if (privileged && shouldRestoreUser && (!keepPrivileged || didCommandFail)) {
       await this.unroot();
     }
@@ -837,7 +843,7 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
   } catch (e) {
     const {message} = e;
 
-    // provide a helpful error message if the reason reboot failed was because it couldn't gain root access
+    // provide a helpful error message if the reason reboot failed was because ADB couldn't gain root access
     if (message.includes('must be root')) {
       throw new Error(`Could not reboot device. Rebooting requires root access and ` +
         `attempt to get root access on device failed with error: '${message}'`);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -377,11 +377,14 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   let shouldRestoreUser = false;
   if (privileged) {
     try {
-      shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root');
+      shouldRestoreUser = retryInterval(10, 1000, async () =>
+        !(await this.adbExec(['root'], opts)).includes('already running as root')
+      );
     } catch (err) {
       if (!err.message.includes('adbd cannot run as root')) {
         // Do not show the warning for real devices, where root is locked
         log.warn(`Cannot run adbd as root. Original error: ${err.message}`);
+        // adb 'root' can cause device to go offline, restart if so
         await this.restartAdbIfDevicesOffline();
       }
     }
@@ -397,7 +400,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } finally {
     if (privileged && shouldRestoreUser && (!keepPrivileged || didCommandFail)) {
       try {
-        await this.adbExec(['unroot'], opts);
+        retryInterval(10, 1000, async () => await this.adbExec(['unroot'], opts));
       } catch (err) {
         log.warn(`Cannot run adbd as non-root. Original error: ${err.message}`);
         await this.restartAdbIfDevicesOffline();
@@ -875,7 +878,7 @@ systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevice
  */
 systemCallMethods.root = async function root () {
   try {
-    let {stdout} = await exec(this.executable.path, ['root']);
+    let {stdout} = await retryInterval(10, 1000, async () => await exec(this.executable.path, ['root']));
 
     // on real devices in some situations we get an error in the stdout
     if (stdout && stdout.indexOf('adbd cannot run as root') !== -1) {
@@ -885,7 +888,7 @@ systemCallMethods.root = async function root () {
     return true;
   } catch (err) {
     log.warn(`Unable to root adb daemon: '${err.message}'. Restarting adb and continuing`);
-    // This sometimes causes adb to go offline so may need to restart
+    // adb 'root' can cause device to go offline, restart if so
     await this.restartAdbIfDevicesOffline();
     return false;
   }
@@ -899,10 +902,11 @@ systemCallMethods.root = async function root () {
  */
 systemCallMethods.unroot = async function unroot () {
   try {
-    await exec(this.executable.path, ['unroot']);
+    await retryInterval(10, 1000, async () => await exec(this.executable.path, ['unroot']));
     return true;
   } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Restarting adb and continuing`);
+    // adb 'unroot' can cause device to go offline, restart if so
     await this.restartAdbIfDevicesOffline();
     return false;
   }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -888,7 +888,7 @@ systemCallMethods.root = async function root () {
       throw new Error(stdout.trim());
     }
   } catch (err) {
-    log.warn(`Unable to root adb daemon: '${err.message}'. Restarting adb and continuing`);
+    log.warn(`Unable to root adb daemon: '${err.message}'. Continuing.`);
     isRootSuccessful = false;
   }
 
@@ -909,7 +909,7 @@ systemCallMethods.unroot = async function unroot () {
   try {
     await retryInterval(10, 1000, async () => await exec(this.executable.path, ['unroot']));
   } catch (err) {
-    log.warn(`Unable to unroot adb daemon: '${err.message}'. Restarting adb and continuing`);
+    log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
     isUnrootSuccessful = false;
   }
   // adb 'unroot' can cause device to go offline, restart if so

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -376,7 +376,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } = opts;
   let shouldRestoreUser = false;
   if (privileged) {
-    const {wasAlreadyRooted} = await this.root();
+    const {wasAlreadyRooted} = await retry(3, this.root);
     shouldRestoreUser = !wasAlreadyRooted;
   }
   let didCommandFail = false;

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -884,6 +884,13 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
  */
 systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (isElevated) {
   const cmd = isElevated ? 'root' : 'unroot';
+
+  // If it's already rooted, our job is done. No need to root it again.
+  const isRoot = await this.isRoot();
+  if ((isRoot && isElevated) || (!isRoot && !isElevated)) {
+    return {isSuccessful: true, wasAlreadyRooted: isRoot};
+  }
+
   let wasAlreadyRooted = false;
   try {
     let {stdout} = await exec(this.executable.path, [cmd]);
@@ -921,10 +928,6 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (is
  * @return {rootResult}
  */
 systemCallMethods.root = async function root () {
-  // If it's already rooted, our job is done. No need to root it again.
-  if (await this.isRoot()) {
-    return {isSuccessful: true, wasAlreadyRooted: true};
-  }
   return await this.changeUserPrivileges(true);
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -889,6 +889,7 @@ systemCallMethods.unroot = async function unroot () {
     return true;
   } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
+    await this.restartAdb();
     return false;
   }
 };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -384,10 +384,10 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
       if (!err.message.includes('adbd cannot run as root')) {
         // Do not show the warning for real devices, where root is locked
         log.warn(`Cannot run adbd as root. Original error: ${err.message}`);
-        // adb 'root' can cause device to go offline, restart if so
-        await this.restartAdbIfDevicesOffline();
       }
     }
+    // adb 'root' can cause device to go offline, restart if so
+    await this.restartAdbIfDevicesOffline();
   }
   let didCommandFail = false;
   try {
@@ -403,8 +403,9 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
         retryInterval(10, 1000, async () => await this.adbExec(['unroot'], opts));
       } catch (err) {
         log.warn(`Cannot run adbd as non-root. Original error: ${err.message}`);
-        await this.restartAdbIfDevicesOffline();
       }
+      // adb 'unroot' can cause device to go offline, restart if so
+      await this.restartAdbIfDevicesOffline();
     }
   }
 };
@@ -877,6 +878,7 @@ systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevice
  *                   if the switch failed.
  */
 systemCallMethods.root = async function root () {
+  let isRootSuccessful = true;
   try {
     let {stdout} = await retryInterval(10, 1000, async () => await exec(this.executable.path, ['root']));
 
@@ -884,14 +886,15 @@ systemCallMethods.root = async function root () {
     if (stdout && stdout.indexOf('adbd cannot run as root') !== -1) {
       throw new Error(stdout.trim());
     }
-
-    return true;
   } catch (err) {
     log.warn(`Unable to root adb daemon: '${err.message}'. Restarting adb and continuing`);
-    // adb 'root' can cause device to go offline, restart if so
-    await this.restartAdbIfDevicesOffline();
-    return false;
+    isRootSuccessful = false;
   }
+
+  // adb 'root' can cause device to go offline, restart if so
+  await this.restartAdbIfDevicesOffline();
+
+  return isRootSuccessful;
 };
 
 /**
@@ -901,15 +904,17 @@ systemCallMethods.root = async function root () {
  *                   if the switch failed.
  */
 systemCallMethods.unroot = async function unroot () {
+  let isUnrootSuccessful = true;
   try {
     await retryInterval(10, 1000, async () => await exec(this.executable.path, ['unroot']));
-    return true;
   } catch (err) {
     log.warn(`Unable to unroot adb daemon: '${err.message}'. Restarting adb and continuing`);
-    // adb 'unroot' can cause device to go offline, restart if so
-    await this.restartAdbIfDevicesOffline();
-    return false;
+    isUnrootSuccessful = false;
   }
+  // adb 'unroot' can cause device to go offline, restart if so
+  await this.restartAdbIfDevicesOffline();
+
+  return isUnrootSuccessful;
 };
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -377,7 +377,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   let shouldRestoreUser = false;
   if (privileged) {
     try {
-      shouldRestoreUser = retryInterval(10, 1000, async () =>
+      shouldRestoreUser = await retryInterval(10, 1000, async () =>
         !(await this.adbExec(['root'], opts)).includes('already running as root')
       );
     } catch (err) {
@@ -867,7 +867,8 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
 systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevicesOffline () {
   const connectedDevices = await this.getConnectedDevices();
   if (connectedDevices.length === 0) {
-    this.restartAdb();
+    log.debug('No devices connected. Restarting adb.');
+    await this.restartAdb();
   }
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -398,9 +398,8 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } finally {
     // Return the 'root' state to what it was before 'shell' was called
     if (privileged && shouldRestoreUser && (!keepPrivileged || didCommandFail)) {
-      log.info(`Call to '${cmd}' completed. Returning device to original unrooted state.`);
       const {isSuccessful} = await this.unroot();
-      log.info(isSuccessful ? 'Returned device to unrooted state' : 'Could not return device to unrooted state');
+      log.debug(isSuccessful ? 'Returned device to unrooted state' : 'Could not return device to unrooted state');
     }
   }
 };
@@ -842,7 +841,9 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
     // Stop and re-start the device
     await this.shell(['stop']);
     await B.delay(2000); // let the emu finish stopping;
-    await this.setDeviceProperty('sys.boot_completed', 0, {privileged: false});
+    await this.setDeviceProperty('sys.boot_completed', 0, {
+      privileged: false // no need to set privileged true because device already rooted
+    });
     await this.shell(['start']);
   } catch (e) {
     const {message} = e;
@@ -878,7 +879,7 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
  */
 
 /**
- * Switch adb server to root mode.
+ * Switch adb server root privileges.
  * @param {boolean} isElevated - Should we elevate to to root or unroot? (default true)
  * @return {rootResult}
  */
@@ -891,14 +892,13 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (is
     return {isSuccessful: true, wasAlreadyRooted: isRoot};
   }
 
-  let wasAlreadyRooted = false;
+  let wasAlreadyRooted = isRoot;
   try {
     let {stdout} = await exec(this.executable.path, [cmd]);
 
     // on real devices in some situations we get an error in the stdout
     if (stdout) {
       if (stdout.includes('adbd cannot run as root')) {
-        log.warn('Cannot run device as root');
         return {isSuccessful: false, wasAlreadyRooted};
       }
       // if the device was already rooted, return that in the result
@@ -913,8 +913,7 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (is
 
     // Check the output of the stdErr to see if there's any clues that show that the device went offline
     // and if it did go offline, restart ADB
-    const s = stderr.toLowerCase();
-    if (s.includes('closed') || s.includes('device offline')) {
+    if (['closed', 'device offline'].includes((x) => stderr.toLowerCase().includes(x))) {
       log.warn(`Attempt to 'adb ${cmd}' caused device to go offline. Restarting adb.`);
       await this.restartAdb();
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -836,11 +836,9 @@ systemCallMethods.waitForDevice = async function waitForDevice (appDeviceReadyTi
  * @throws {Error} If the device failed to reboot and number of retries is exceeded.
  */
 systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_RETRIES) {
-  let wasAlreadyRooted;
+  // Get root access so we can run the next shell commands which require root access
+  const { wasAlreadyRooted } = await this.root();
   try {
-    // Get root access so we can run the next shell commands which require root access
-    wasAlreadyRooted = (await this.root()).wasAlreadyRooted;
-
     // Stop and re-start the device
     await this.shell(['stop']);
     await B.delay(2000); // let the emu finish stopping;
@@ -894,6 +892,7 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (is
     if (stdout) {
       if (stdout.includes('adbd cannot run as root')) {
         log.warn('Cannot run device as root');
+        return {isSuccessful: false, wasAlreadyRooted};
       }
       // if the device was already rooted, return that in the result
       if (stdout.includes('already running as root')) {
@@ -922,6 +921,10 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (is
  * @return {rootResult}
  */
 systemCallMethods.root = async function root () {
+  // If it's already rooted, our job is done. No need to root it again.
+  if (await this.isRoot()) {
+    return {isSuccessful: true, wasAlreadyRooted: true};
+  }
   return await this.changeUserPrivileges(true);
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -377,7 +377,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   let shouldRestoreUser = false;
   if (privileged) {
     try {
-      shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root')
+      shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root');
     } catch (err) {
       if (!err.message.includes('adbd cannot run as root')) {
         // Do not show the warning for real devices, where root is locked

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -376,7 +376,8 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } = opts;
   let shouldRestoreUser = false;
   if (privileged) {
-    await this.root();
+    const {wasAlreadyRooted} = await this.root();
+    shouldRestoreUser = !wasAlreadyRooted;
   }
   let didCommandFail = false;
   try {
@@ -845,20 +846,32 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
 };
 
 /**
+ * @typedef {Object} rootResult
+ * @property {boolean} isRooted True if the device is rooted now
+ * @property {boolean} wasAlreadyRooted True if the device was already rooted
+ */
+
+/**
  * Switch adb server to root mode.
  * @param {boolean} unroot - Should we unroot instead of root? (default false)
  * @return {boolean} True if the device is rooted.
  */
 systemCallMethods.root = async function root (unroot = false) {
   let cmd = unroot ? 'unroot' : 'root';
+  let wasAlreadyRooted = false;
   try {
     let {stdout} = await exec(this.executable.path, [cmd]);
 
     // on real devices in some situations we get an error in the stdout
-    if (stdout && stdout.indexOf('adbd cannot run as root') !== -1) {
-      throw new Error(stdout.trim());
+    if (stdout) {
+      if (stdout.includes('adbd cannot run as root')) {
+        throw new Error(stdout.trim());
+      }
+      if (stdout.includes('already running as root')) {
+        wasAlreadyRooted = true;
+      }
     }
-    return true;
+    return {isRooted: !unroot, wasAlreadyRooted};
   } catch (err) {
     const {stderr = ''} = err;
     log.warn(`Unable to ${cmd} adb daemon. Original error: '${stderr}'. Continuing.`);
@@ -868,7 +881,7 @@ systemCallMethods.root = async function root (unroot = false) {
       await this.restartAdb();
     }
 
-    return false;
+    return {isRooted: unroot};
   }
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -377,9 +377,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   let shouldRestoreUser = false;
   if (privileged) {
     try {
-      shouldRestoreUser = await retryInterval(10, 1000, async () =>
-        !(await this.adbExec(['root'], opts)).includes('already running as root')
-      );
+      shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root')
     } catch (err) {
       if (!err.message.includes('adbd cannot run as root')) {
         // Do not show the warning for real devices, where root is locked
@@ -400,7 +398,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } finally {
     if (privileged && shouldRestoreUser && (!keepPrivileged || didCommandFail)) {
       try {
-        retryInterval(10, 1000, async () => await this.adbExec(['unroot'], opts));
+        await this.adbExec(['unroot'], opts);
       } catch (err) {
         log.warn(`Cannot run adbd as non-root. Original error: ${err.message}`);
       }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -388,14 +388,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
     }
   } finally {
     if (privileged && shouldRestoreUser && (!keepPrivileged || didCommandFail)) {
-      try {
-        await this.unroot();
-      } catch (err) {
-        log.warn(`Cannot run adbd as non-root. Original error: ${err.message}`);
-
-        // adb 'unroot' can cause device to go offline, restart if so
-        await this.restartAdbIfDevicesOffline();
-      }
+      await this.unroot();
     }
   }
 };
@@ -871,7 +864,8 @@ systemCallMethods.root = async function root (unroot = false) {
     log.warn(`Unable to ${cmd} adb daemon. Original error: '${stderr}'. Continuing.`);
     // adb 'root' can cause device to go offline, restart if so
     if (stderr.toLowerCase().includes('closed')) {
-      await this.restartAdbIfDevicesOffline();
+      log.warn(`${cmd} caused device to go offline. Restarting adb.`);
+      await this.restartAdb();
     }
 
     return false;

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -376,7 +376,8 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
   } = opts;
   let shouldRestoreUser = false;
   if (privileged) {
-    try {
+    await this.root();
+    /*try {
       shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root');
     } catch (err) {
       if (!err.message.includes('adbd cannot run as root')) {
@@ -385,7 +386,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
       }
       // adb 'root' can cause device to go offline, restart if so
       await this.restartAdbIfDevicesOffline();
-    }
+    }*/
   }
   let didCommandFail = false;
   try {
@@ -873,13 +874,14 @@ systemCallMethods.restartAdbIfDevicesOffline = async function restartAdbIfDevice
 
 /**
  * Switch adb server to root mode.
- *
+ * @param {boolean} unroot - Should we unroot instead of root? (default false)
  * @return {boolean} True of the switch was successful or false
  *                   if the switch failed.
  */
-systemCallMethods.root = async function root () {
+systemCallMethods.root = async function root (unroot = false) {
+  let cmd = unroot ? 'unroot' : 'root';
   try {
-    let {stdout} = await exec(this.executable.path, ['root']);
+    let {stdout} = await exec(this.executable.path, [cmd]);
 
     // on real devices in some situations we get an error in the stdout
     if (stdout && stdout.indexOf('adbd cannot run as root') !== -1) {
@@ -887,7 +889,8 @@ systemCallMethods.root = async function root () {
     }
     return true;
   } catch (err) {
-    log.warn(`Unable to root adb daemon: '${err.message}'. Continuing.`);
+    console.log('!!!!!!!!!!!!!!', err, JSON.stringify(err));
+    log.warn(`Unable to ${cmd} adb daemon: '${err.message}'. Continuing.`);
     // adb 'root' can cause device to go offline, restart if so
     await this.restartAdbIfDevicesOffline();
 
@@ -902,15 +905,7 @@ systemCallMethods.root = async function root () {
  *                   if the switch failed.
  */
 systemCallMethods.unroot = async function unroot () {
-  try {
-    await exec(this.executable.path, ['unroot']);
-    return true;
-  } catch (err) {
-    log.warn(`Unable to unroot adb daemon: '${err.message}'. Continuing`);
-    // adb 'unroot' can cause device to go offline, restart if so
-    await this.restartAdbIfDevicesOffline();
-    return false;
-  }
+  await this.root(true);
 };
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -375,7 +375,6 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
     keepPrivileged,
   } = opts;
   let shouldRestoreUser = false;
-  let isRoot = await this.isRoot();
   if (privileged) {
     try {
       shouldRestoreUser = !(await this.adbExec(['root'], opts)).includes('already running as root');

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -382,6 +382,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
       if (!err.message.includes('adbd cannot run as root')) {
         // Do not show the warning for real devices, where root is locked
         log.warn(`Cannot run adbd as root. Original error: ${err.message}`);
+        await this.restartAdbIfDevicesOffline();
       }
     }
   }
@@ -399,6 +400,7 @@ systemCallMethods.shell = async function shell (cmd, opts = {}) {
         await this.adbExec(['unroot'], opts);
       } catch (err) {
         log.warn(`Cannot run adbd as non-root. Original error: ${err.message}`);
+        await this.restartAdbIfDevicesOffline();
       }
     }
   }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -836,20 +836,16 @@ systemCallMethods.waitForDevice = async function waitForDevice (appDeviceReadyTi
  * @throws {Error} If the device failed to reboot and number of retries is exceeded.
  */
 systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_RETRIES) {
+  let wasAlreadyRooted;
   try {
     // Get root access so we can run the next shell commands which require root access
-    const {wasAlreadyRooted} = await this.root();
+    wasAlreadyRooted = (await this.root()).wasAlreadyRooted;
 
     // Stop and re-start the device
     await this.shell(['stop']);
     await B.delay(2000); // let the emu finish stopping;
-    await this.setDeviceProperty('sys.boot_completed', 0, false);
+    await this.setDeviceProperty('sys.boot_completed', 0, {privileged: false});
     await this.shell(['start']);
-
-    // Return root state to what it was before
-    if (!wasAlreadyRooted) {
-      await this.unroot();
-    }
   } catch (e) {
     const {message} = e;
 
@@ -859,6 +855,11 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
         `attempt to get root access on device failed with error: '${message}'`);
     }
     throw e;
+  } finally {
+    // Return root state to what it was before
+    if (!wasAlreadyRooted) {
+      await this.unroot();
+    }
   }
   const started = process.hrtime();
   await retryInterval(retries, 1000, async () => {
@@ -880,11 +881,11 @@ systemCallMethods.reboot = async function reboot (retries = DEFAULT_ADB_REBOOT_R
 
 /**
  * Switch adb server to root mode.
- * @param {boolean} unroot - Should we unroot instead of root? (default false)
+ * @param {boolean} isElevated - Should we elevate to to root or unroot? (default true)
  * @return {rootResult}
  */
-systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (unroot) {
-  const cmd = unroot ? 'unroot' : 'root';
+systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (isElevated) {
+  const cmd = isElevated ? 'root' : 'unroot';
   let wasAlreadyRooted = false;
   try {
     let {stdout} = await exec(this.executable.path, [cmd]);
@@ -892,7 +893,7 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (un
     // on real devices in some situations we get an error in the stdout
     if (stdout) {
       if (stdout.includes('adbd cannot run as root')) {
-        throw new Error(stdout.trim());
+        log.warn('Cannot run device as root');
       }
       // if the device was already rooted, return that in the result
       if (stdout.includes('already running as root')) {
@@ -921,7 +922,7 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (un
  * @return {rootResult}
  */
 systemCallMethods.root = async function root () {
-  return await this.changeUserPrivileges(false);
+  return await this.changeUserPrivileges(true);
 };
 
 /**
@@ -930,7 +931,7 @@ systemCallMethods.root = async function root () {
  * @return {rootResult}
  */
 systemCallMethods.unroot = async function unroot () {
-  return await this.changeUserPrivileges(true);
+  return await this.changeUserPrivileges(false);
 };
 
 /**

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -88,7 +88,7 @@ describe('adb commands', function () {
   });
   it('should get device language and country', async function () {
     if (parseInt(apiLevel, 10) >= 23) return this.skip(); // eslint-disable-line curly
-    if (process.env.TRAVIS || process.env.CI) return this.skip(); // eslint-disable-line curly
+    if (process.env.TRAVIS /*|| process.env.CI*/) return this.skip(); // eslint-disable-line curly
 
     ['en', 'fr'].should.contain(await adb.getDeviceSysLanguage());
     ['US', 'EN_US', 'EN', 'FR'].should.contain(await adb.getDeviceSysCountry());
@@ -255,7 +255,7 @@ describe('adb commands', function () {
 
   describe('bugreport', function () {
     it('should return the report as a raw string', async function () {
-      if (process.env.TRAVIS || process.env.CI) {
+      if (process.env.TRAVIS /*|| process.env.CI*/) {
         // skip the test on CI, since it takes a lot of time
         return this.skip;
       }

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -48,7 +48,7 @@ describe('adb commands', function () {
   });
   it('defaultIME should get default IME', async function () {
     const defaultIME = await adb.defaultIME();
-    if (defaultIME) {
+    if (defaultIME && defaultIME !== 'null') {
       defaultIMEs.should.include(defaultIME);
     }
   });

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -88,7 +88,7 @@ describe('adb commands', function () {
   });
   it('should get device language and country', async function () {
     if (parseInt(apiLevel, 10) >= 23) return this.skip(); // eslint-disable-line curly
-    if (process.env.TRAVIS /*|| process.env.CI*/) return this.skip(); // eslint-disable-line curly
+    if (process.env.TRAVIS) return this.skip(); // eslint-disable-line curly
 
     ['en', 'fr'].should.contain(await adb.getDeviceSysLanguage());
     ['US', 'EN_US', 'EN', 'FR'].should.contain(await adb.getDeviceSysCountry());
@@ -255,7 +255,7 @@ describe('adb commands', function () {
 
   describe('bugreport', function () {
     it('should return the report as a raw string', async function () {
-      if (process.env.TRAVIS /*|| process.env.CI*/) {
+      if (process.env.TRAVIS) {
         // skip the test on CI, since it takes a lot of time
         return this.skip;
       }

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -48,7 +48,7 @@ describe('adb commands', function () {
   });
   it('defaultIME should get default IME', async function () {
     const defaultIME = await adb.defaultIME();
-    if (defaultIME && defaultIME !== 'null') {
+    if (defaultIME) {
       defaultIMEs.should.include(defaultIME);
     }
   });

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -88,7 +88,7 @@ describe('adb commands', function () {
   });
   it('should get device language and country', async function () {
     if (parseInt(apiLevel, 10) >= 23) return this.skip(); // eslint-disable-line curly
-    if (process.env.TRAVIS) return this.skip(); // eslint-disable-line curly
+    if (process.env.TRAVIS || process.env.CI) return this.skip(); // eslint-disable-line curly
 
     ['en', 'fr'].should.contain(await adb.getDeviceSysLanguage());
     ['US', 'EN_US', 'EN', 'FR'].should.contain(await adb.getDeviceSysCountry());
@@ -259,6 +259,8 @@ describe('adb commands', function () {
         // skip the test on CI, since it takes a lot of time
         return this.skip;
       }
+      const BUG_REPORT_TIMEOUT = 2 * 60 * 1000; // 2 minutes
+      this.timeout(BUG_REPORT_TIMEOUT);
       (await adb.bugreport()).should.be.a('string');
     });
   });

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -53,7 +53,7 @@ describe('System calls', function () {
   it('waitForDevice should get all connected avds', async function () {
     await adb.waitForDevice(2);
   });
-  it.only('reboot should reboot the device', async function () {
+  it('reboot should reboot the device', async function () {
     if (process.env.TRAVIS) {
       // The test is very slow on CI
       return this.skip();

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -54,7 +54,7 @@ describe('System calls', function () {
     await adb.waitForDevice(2);
   });
   it('reboot should reboot the device', async function () {
-    if (process.env.TRAVIS /*|| process.env.CI*/) {
+    if (process.env.TRAVIS || process.env.CI) {
       // The test is very slow on CI
       return this.skip();
     }

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -10,7 +10,7 @@ const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
 
 chai.use(chaiAsPromised);
 
-describe.only('System calls', function () {
+describe('System calls', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let adb;
@@ -54,7 +54,7 @@ describe.only('System calls', function () {
     await adb.waitForDevice(2);
   });
   it('reboot should reboot the device', async function () {
-    if (process.env.TRAVIS /*|| process.env.CI*/) {
+    if (process.env.TRAVIS) {
       // The test is very slow on CI
       return this.skip();
     }

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -10,7 +10,7 @@ const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
 
 chai.use(chaiAsPromised);
 
-describe.only('System calls', function () {
+describe('System calls', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let adb;

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -53,7 +53,7 @@ describe('System calls', function () {
   it('waitForDevice should get all connected avds', async function () {
     await adb.waitForDevice(2);
   });
-  it('reboot should reboot the device', async function () {
+  it.only('reboot should reboot the device', async function () {
     if (process.env.TRAVIS) {
       // The test is very slow on CI
       return this.skip();
@@ -63,7 +63,7 @@ describe('System calls', function () {
       await adb.reboot();
       await adb.ping();
     } catch (e) {
-      e.message.should.include('requires root access');
+      e.message.should.include('must be root');
     }
   });
   it('fileExists should detect when files do and do not exist', async function () {

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -54,7 +54,7 @@ describe('System calls', function () {
     await adb.waitForDevice(2);
   });
   it('reboot should reboot the device', async function () {
-    if (process.env.TRAVIS || process.env.CI) {
+    if (process.env.TRAVIS /*|| process.env.CI*/) {
       // The test is very slow on CI
       return this.skip();
     }

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -59,8 +59,12 @@ describe('System calls', function () {
       return this.skip();
     }
     this.timeout(MOCHA_LONG_TIMEOUT);
-    await adb.reboot();
-    await adb.ping();
+    try {
+      await adb.reboot();
+      await adb.ping();
+    } catch (e) {
+      e.message.should.include('requires root access');
+    }
   });
   it('fileExists should detect when files do and do not exist', async function () {
     (await adb.fileExists('/foo/bar/baz.zip')).should.be.false;

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -10,7 +10,7 @@ const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
 
 chai.use(chaiAsPromised);
 
-describe('System calls', function () {
+describe.only('System calls', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let adb;

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -154,10 +154,10 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       it('should call setprop with correct args', async function () {
         mocks.adb.expects('shell')
           .withExactArgs(['setprop', 'persist.sys.locale', locale], {
-            privileged: false
+            privileged: true
           })
           .returns('');
-        await adb.setDeviceProperty('persist.sys.locale', locale, {privileged: false});
+        await adb.setDeviceProperty('persist.sys.locale', locale);
       });
     });
     describe('availableIMEs', function () {

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -154,10 +154,10 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       it('should call setprop with correct args', async function () {
         mocks.adb.expects('shell')
           .withExactArgs(['setprop', 'persist.sys.locale', locale], {
-            privileged: true
+            privileged: false
           })
           .returns('');
-        await adb.setDeviceProperty('persist.sys.locale', locale);
+        await adb.setDeviceProperty('persist.sys.locale', locale, {privileged: false});
       });
     });
     describe('availableIMEs', function () {

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -200,6 +200,7 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
     await adb.reboot().should.eventually.not.be.rejected;
   });
   it('reboot should error with helpful message if cause of error is no root access', async function () {
+    mocks.adb.expects('isRoot').once().returns(false);
     mocks.adb.expects('root').once().returns({wasAlreadyRooted: false});
     mocks.adb.expects('shell')
       .once().throws(new Error('something something ==must be root== something something'));
@@ -275,6 +276,7 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       await adb.root().should.eventually.eql({isSuccessful: false, wasAlreadyRooted: false});
     });
     it('should call "unroot" on shell if call .unroot', async function () {
+      mocks.adb.expects('isRoot').once().returns(false);
       mocks.teen_process.expects('exec')
         .once()
         .withExactArgs(adb.executable.path, ['unroot'])
@@ -294,10 +296,16 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       mocks.teen_process.expects('exec').never();
       await adb.root().should.eventually.eql({isSuccessful: true, wasAlreadyRooted: true});
     });
+    it('should not call unroot if isRoot returns false', async function () {
+      mocks.adb.expects('isRoot').once().returns(false);
+      mocks.teen_process.expects('exec').never();
+      await adb.unroot().should.eventually.eql({isSuccessful: true, wasAlreadyRooted: false});
+    });
     it('should return unsuccessful if "adbd cannot run as root" in stdout', async function () {
+      mocks.adb.expects('isRoot').once().returns(false);
       mocks.teen_process.expects('exec').once()
         .returns({stdout: 'something something adbd cannot run as root something smoething'});
-      await adb.changeUserPrivileges().should.eventually.eql({isSuccessful: false, wasAlreadyRooted: false});
+      await adb.root().should.eventually.eql({isSuccessful: false, wasAlreadyRooted: false});
     });
   });
 }));

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -294,5 +294,10 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       mocks.teen_process.expects('exec').never();
       await adb.root().should.eventually.eql({isSuccessful: true, wasAlreadyRooted: true});
     });
+    it('should return unsuccessful if "adbd cannot run as root" in stdout', async function () {
+      mocks.adb.expects('isRoot').once().returns(true);
+      mocks.teen_process.expects('exec').once().returns('something something adbd cannot run as root something smoething');
+      await adb.root().should.eventually.eql({isSuccessful: true, wasAlreadyRooted: true});
+    });
   });
 }));

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -235,14 +235,4 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       .returns([]);
     chai.expect(await adb.getRunningAVD(avdName)).to.be.null;
   });
-  it('restartAdbIfDevicesOffline should call restartAdb if no connected devices', async function () {
-    mocks.adb.expects('getConnectedDevices').once().withExactArgs().returns([]);
-    mocks.adb.expects('restartAdb').once();
-    await adb.restartAdbIfDevicesOffline();
-  });
-  it('restartAdbIfDevicesOffline should not call restartAdb if connected devices', async function () {
-    mocks.adb.expects('getConnectedDevices').once().withExactArgs().returns(['singleton device']);
-    mocks.adb.expects('restartAdb').never();
-    await adb.restartAdbIfDevicesOffline();
-  });
 }));

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -295,9 +295,9 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       await adb.root().should.eventually.eql({isSuccessful: true, wasAlreadyRooted: true});
     });
     it('should return unsuccessful if "adbd cannot run as root" in stdout', async function () {
-      mocks.adb.expects('isRoot').once().returns(true);
-      mocks.teen_process.expects('exec').once().returns('something something adbd cannot run as root something smoething');
-      await adb.root().should.eventually.eql({isSuccessful: true, wasAlreadyRooted: true});
+      mocks.teen_process.expects('exec').once()
+        .returns({stdout: 'something something adbd cannot run as root something smoething'});
+      await adb.changeUserPrivileges().should.eventually.eql({isSuccessful: false, wasAlreadyRooted: false});
     });
   });
 }));

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -235,4 +235,14 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       .returns([]);
     chai.expect(await adb.getRunningAVD(avdName)).to.be.null;
   });
+  it('restartAdbIfDevicesOffline should call restartAdb if no connected devices', async function () {
+    mocks.adb.expects('getConnectedDevices').once().withExactArgs().returns([]);
+    mocks.adb.expects('restartAdb').once();
+    await adb.restartAdbIfDevicesOffline();
+  });
+  it('restartAdbIfDevicesOffline should not call restartAdb if connected devices', async function () {
+    mocks.adb.expects('getConnectedDevices').once().withExactArgs().returns(['singleton device']);
+    mocks.adb.expects('restartAdb').never();
+    await adb.restartAdbIfDevicesOffline();
+  });
 }));


### PR DESCRIPTION
This addresses two problems: `adb root/unroot` 1. works intermittently, 2. sometimes cases the device to go offline.

The fix is:
1. retries `root/unroot` instead of calling it just once
2. after a root/unroot occurs, check if there's no connected devices and if there aren't any, restart adb (uses a new method called `restartAdbIfDevicesOffline ()`

This PR also:
1. Uses mocha multireporters so that the logs show tests being called
2. Fixes an IME test that wasn't working