### PR TITLE
Clean up Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,20 @@ licenses:
   - 'google-gdk-license-.+'
 env:
   global:
+    # used in tests
+    - ANDROID_AVD=test
     - _FORCE_LOGS=1
     - DEVICE=android
+
+    # used in Travis config
     - MOCHA_TIMEOUT=900000
     - RECURSIVE=
     - START_EMU=1
-    - ANDROID_API=21
     - EMU_NAME=test
-    - ANDROID_EMU_ABI=x86_64
-    - ANDROID_EMU_TAG=default
-    - ANDROID_AVD=test
+    - EMU_ABI=x86_64
+    - EMU_TAG=default
+    - SDK_VERSION=28.0.3
+    - API_VERSION=28
     - PLATFORM_VERSION=5.0.2
     - CC=gcc-6 CXX=g++-6
     - QEMU_AUDIO_DRV=none
@@ -36,8 +40,8 @@ env:
     # API24@armeabi-v7a is the newest available default image
     # which does not require hardware acceleration:
     # https://github.com/travis-ci/travis-ci/issues/1419
-    - TEST=functional RECURSIVE=--recursive ANDROID_API=24 PLATFORM_VERSION=7.0 ANDROID_EMU_TARGET=android-24
-    - TEST=functional RECURSIVE=--recursive ANDROID_EMU_TARGET=android-21
+    - TEST=functional RECURSIVE=--recursive PLATFORM_VERSION=7.0 EMU_TARGET=android-24
+    - TEST=functional RECURSIVE=--recursive EMU_TARGET=android-21
     - TEST=unit START_EMU=0
 before_install:
   - echo $ANDROID_HOME
@@ -51,22 +55,22 @@ before_install:
       for apiVersion in 18 19; do
         sdkmanager --uninstall "platforms;android-${apiVersion}" > /dev/null
       done
-      echo y | sdkmanager "build-tools;28.0.3" >/dev/null
+      echo y | sdkmanager "build-tools;${SDK_VERSION}" >/dev/null
       echo y | sdkmanager --update > /dev/null
-      echo y | sdkmanager "platforms;${ANDROID_EMU_TARGET}" > /dev/null
-      echo y | sdkmanager "platforms;android-28" >/dev/null
+      echo y | sdkmanager "platforms;${EMU_TARGET}" > /dev/null
+      echo y | sdkmanager "platforms;android-${API_VERSION}" >/dev/null
       echo y | sdkmanager "extras;android;m2repository" > /dev/null
-      echo y | sdkmanager --channel=4 "emulator" >/dev/null
-      export ANDROID_EMU_IMAGE="system-images;${ANDROID_EMU_TARGET};${ANDROID_EMU_TAG};${ANDROID_EMU_ABI}"
+      echo y | sdkmanager --channel=3 "emulator" >/dev/null
+      export EMU_IMAGE="system-images;${EMU_TARGET};${EMU_TAG};${EMU_ABI}"
       for retry in 1 2 3; do
-        echo yes | sdkmanager "${ANDROID_EMU_IMAGE}" > /dev/null && break
-        echo "sdkmanager was not able to download the ${ANDROID_EMU_IMAGE} image (retry ${retry})"
+        echo yes | sdkmanager "${EMU_IMAGE}" > /dev/null && break
+        echo "sdkmanager was not able to download the ${EMU_IMAGE} image (retry ${retry})"
         sleep 5
       done
       sdkmanager --list
       export TOOLS=${ANDROID_HOME}/tools
       export PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
-      echo no | avdmanager create avd -k "${ANDROID_EMU_IMAGE}" -n "${EMU_NAME}" -f --abi "${ANDROID_EMU_ABI}" --tag "${ANDROID_EMU_TAG}" || exit 1
+      echo no | avdmanager create avd -k "${EMU_IMAGE}" -n "${EMU_NAME}" -f --abi "${EMU_ABI}" --tag "${EMU_TAG}" || exit 1
       emulator -avd "${EMU_NAME}" -no-accel -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048 &
     fi
 install:


### PR DESCRIPTION
Get rid of hard-coded versions of things, and remove superfluous `ANDROID_` from environment variable names.