### PR TITLE
[wip] Fixes to support Q

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -78,28 +78,26 @@ methods.initBundletool = async function initBundletool () {
  *                  Android Lollipop. The result of this method is cached, so all the further
  * calls return the same value as the first one.
  */
-methods.getApiLevel = async function getApiLevel () {
-  if (!_.isInteger(this._apiLevel)) {
-    try {
-      const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
-      let apiLevel = parseInt(strOutput.trim(), 10);
+methods.getApiLevel = _.memoize(async function getApiLevel () {
+  try {
+    const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
+    let apiLevel = parseInt(strOutput.trim(), 10);
 
-      // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
-      if (apiLevel === 28 && (await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
-        log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
-        apiLevel = 29;
-      }
-      this._apiLevel = apiLevel;
-      log.debug(`Device API level: ${this._apiLevel}`);
-      if (isNaN(this._apiLevel)) {
-        throw new Error(`The actual output '${strOutput}' cannot be converted to an integer`);
-      }
-    } catch (e) {
-      throw new Error(`Error getting device API level. Original error: ${e.message}`);
+    // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
+    // TODO: When Q is out of beta we can take this out
+    if (apiLevel === 28 && (await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
+      log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
+      apiLevel = 29;
     }
+    log.debug(`Device API level: ${apiLevel}`);
+    if (isNaN(apiLevel)) {
+      throw new Error(`The actual output '${strOutput}' cannot be converted to an integer`);
+    }
+    return apiLevel;
+  } catch (e) {
+    throw new Error(`Error getting device API level. Original error: ${e.message}`);
   }
-  return this._apiLevel;
-};
+});
 
 /**
  * Retrieve the platform version of the device under test.
@@ -110,7 +108,13 @@ methods.getApiLevel = async function getApiLevel () {
 methods.getPlatformVersion = async function getPlatformVersion () {
   log.info('Getting device platform version');
   try {
-    return await this.getDeviceProperty('ro.build.version.release');
+    const platformVersion = await this.getDeviceProperty('ro.build.version.release');
+    // TODO: Temporary workaround for Android Q beta reporting 'Q' instead of 10
+    // Can remove this once Android Q comes out of beta and starts reporting at as 10
+    if (platformVersion === 'Q') {
+      return 10;
+    }
+    return platformVersion;
   } catch (e) {
     throw new Error(`Error getting device platform version. Original error: ${e.message}`);
   }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -78,26 +78,29 @@ methods.initBundletool = async function initBundletool () {
  *                  Android Lollipop. The result of this method is cached, so all the further
  * calls return the same value as the first one.
  */
-methods.getApiLevel = _.memoize(async function getApiLevel () {
-  try {
-    const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
-    let apiLevel = parseInt(strOutput.trim(), 10);
+methods.getApiLevel = async function getApiLevel () {
+  if (!_.isInteger(this._apiLevel)) {
+    try {
+      const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
+      let apiLevel = parseInt(strOutput.trim(), 10);
 
-    // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
-    // TODO: When Q is out of beta we can take this out
-    if (apiLevel === 28 && (await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
-      log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
-      apiLevel = 29;
+      // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
+      // TODO: When Q is out of beta we can take this out
+      if (apiLevel === 28 && (await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
+        log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
+        apiLevel = 29;
+      }
+      log.debug(`Device API level: ${apiLevel}`);
+      if (isNaN(apiLevel)) {
+        throw new Error(`The actual output '${strOutput}' cannot be converted to an integer`);
+      }
+      this._apiLevel = apiLevel;
+    } catch (e) {
+      throw new Error(`Error getting device API level. Original error: ${e.message}`);
     }
-    log.debug(`Device API level: ${apiLevel}`);
-    if (isNaN(apiLevel)) {
-      throw new Error(`The actual output '${strOutput}' cannot be converted to an integer`);
-    }
-    return apiLevel;
-  } catch (e) {
-    throw new Error(`Error getting device API level. Original error: ${e.message}`);
   }
-});
+  return this._apiLevel;
+};
 
 /**
  * Retrieve the platform version of the device under test.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint-config-appium": "^4.0.1",
     "gulp": "^4.0.0",
+    "io.appium.settings": "^2.14.0",
     "mocha": "^6.0.0",
     "mocha-junit-reporter": "^1.21.0",
     "mocha-multi-reporters": "^1.1.7",

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -32,6 +32,10 @@ describe('adb commands', function () {
   const androidInstallTimeout = 90000;
   before(async function () {
     adb = await ADB.createADB({ adbExecTimeout: 60000 });
+    await adb.install(path.resolve('node_modules', 'io.appium.settings', 'apks', 'settings_apk-debug.apk'));
+  });
+  after(async function () {
+    await adb.uninstallApk(path.resolve('node_modules', 'io.appium.settings', 'apks', 'settings_apk-debug.apk'));
   });
   it('getApiLevel should get correct api level', async function () {
     (await adb.getApiLevel()).should.equal(apiLevel);
@@ -79,7 +83,7 @@ describe('adb commands', function () {
     (await adb.getPIDsByName(pkg)).should.have.length(0);
   });
   it('killProcessByPID should kill process', async function () {
-    await adb.install(contactManagerPath, {timeout: androidInstallTimeout});
+    await adb.install(contactManagerPath, {timeout: androidInstallTimeout, grantPermissions: true});
     await adb.startApp({pkg, activity});
     let pids = await adb.getPIDsByName(pkg);
     pids.should.have.length.above(0);

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -37,7 +37,7 @@ describe('apk utils', function () {
   });
   it('should be able to install/remove app and detect its status', async function () {
     (await adb.isAppInstalled('foo')).should.be.false;
-    await adb.install(contactManagerPath);
+    await adb.install(contactManagerPath, {grantPermissions: true});
     (await adb.isAppInstalled('com.example.android.contactmanager')).should.be.true;
     (await adb.uninstallApk('com.example.android.contactmanager')).should.be.true;
     (await adb.isAppInstalled('com.example.android.contactmanager')).should.be.false;
@@ -54,7 +54,7 @@ describe('apk utils', function () {
       await adb.goToHome();
       let res = await adb.getFocusedPackageAndActivity();
       res.appPackage.should.not.equal('com.android.contacts');
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true});
       await adb.startUri('content://contacts/people', 'com.android.contacts');
       await retryInterval(10, 500, async () => {
         res = await adb.dumpWindows();
@@ -69,7 +69,7 @@ describe('apk utils', function () {
   });
   describe('startApp', function () {
     it('should be able to start', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true}, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'ContactManager',
@@ -79,7 +79,7 @@ describe('apk utils', function () {
 
     });
     it('should throw error for wrong activity', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true}, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'ContactManage',
@@ -87,7 +87,7 @@ describe('apk utils', function () {
       }).should.eventually.be.rejectedWith('Activity');
     });
     it('should throw error for wrong wait activity', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true}, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'ContactManager',
@@ -96,7 +96,7 @@ describe('apk utils', function () {
       }).should.eventually.be.rejectedWith('foo');
     });
     it('should start activity with wait activity', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true}, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'ContactManager',
@@ -106,7 +106,7 @@ describe('apk utils', function () {
       await assertPackageAndActivity();
     });
     it('should start activity when wait activity is a wildcard', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'ContactManager',
@@ -116,7 +116,7 @@ describe('apk utils', function () {
       await assertPackageAndActivity();
     });
     it('should start activity when wait activity contains a wildcard', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'ContactManager',
@@ -126,7 +126,7 @@ describe('apk utils', function () {
       await assertPackageAndActivity();
     });
     it('should throw error for wrong activity when wait activity contains a wildcard', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'SuperManager',
@@ -135,7 +135,7 @@ describe('apk utils', function () {
       }).should.eventually.be.rejectedWith('Activity');
     });
     it('should throw error for wrong wait activity which contains wildcard', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         activity: 'ContactManager',
@@ -144,7 +144,7 @@ describe('apk utils', function () {
       }).should.eventually.be.rejectedWith('SuperManager');
     });
     it('should start activity with comma separated wait packages list', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         waitPkg: 'com.android.settings, com.example.android.contactmanager',
@@ -155,7 +155,7 @@ describe('apk utils', function () {
       await assertPackageAndActivity();
     });
     it('should throw error for wrong activity when packages provided as comma separated list', async function () {
-      await adb.install(contactManagerPath);
+      await adb.install(contactManagerPath, {grantPermissions: true});
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
         waitPkg: 'com.android.settings, com.example.somethingelse',
@@ -166,7 +166,7 @@ describe('apk utils', function () {
     });
   });
   it('should start activity when start activity is an inner class', async function () {
-    await adb.install(contactManagerPath);
+    await adb.install(contactManagerPath, {grantPermissions: true});
     await adb.startApp({
       pkg: 'com.android.settings',
       activity: '.Settings$NotificationAppListActivity',
@@ -180,7 +180,7 @@ describe('apk utils', function () {
     // The test sometimes fails due to Emulator slowness on Travis
     this.retries(2);
 
-    await adb.install(contactManagerPath);
+    await adb.install(contactManagerPath, {grantPermissions: true});
     await adb.startApp({
       pkg: 'com.example.android.contactmanager',
       activity: 'ContactManager',

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -12,6 +12,7 @@ const API_LEVEL_MAP = {
   8.0: '26',
   8.1: '27',
   9: '28',
+  10: '29',
 };
 
 const avdName = process.env.ANDROID_AVD || 'NEXUS_S_18_X86';

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -32,6 +32,8 @@ describe('System calls', function () {
     (await adb.isDeviceConnected()).should.be.true;
   });
   it('shell should execute command in adb shell ', async function () {
+    // TODO: This fails in Q beta due to emulator not reporting correct apiLevel (28 when it should be 29)
+    // If this problem stops, remove this comment
     (await adb.shell(['getprop', 'ro.build.version.sdk'])).should.equal(`${apiLevel}`);
   });
   it('getConnectedEmulators should get all connected emulators', async function () {


### PR DESCRIPTION
The biggest problem is the permission requesting APK that comes up before an app opens. Right now I set `grantPermissions` to true in the tests to prevent this.

For the drivers (Espresso, UiAutomator2, etc...) we'll either need to grant permissions by default and deprecate `autoGrantPermissions`; or we'll have to find some alternative way of getting through the permissions screen.

* Temporary workaround to return platform version as 10 if platformVersion == 'Q'
* Unrelated to Q.... memoize getApiLevel
* Install io.appium.settings before tests to make test work
* Add 10 to the API_LEVEL_MAP