### PR TITLE
Fix the exclusive exec behaviour

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -11,10 +11,7 @@ import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
 import { quote } from 'shell-quote';
-import AsyncLock from 'async-lock';
 
-
-const ADB_EXEC_GUARD = new AsyncLock();
 
 let systemCallMethods = {};
 
@@ -285,6 +282,8 @@ systemCallMethods.adbExecEmu = async function adbExecEmu (cmd) {
   await this.adbExec(['emu', ...cmd]);
 };
 
+let isExecLocked = false;
+
 /**
  * Execute the given adb command.
  *
@@ -310,19 +309,12 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
   opts.timeoutCapName = opts.timeoutCapName || 'adbExecTimeout'; // For error message
 
   cmd = _.isArray(cmd) ? cmd : [cmd];
-
   let adbRetried = false;
   const execFunc = async () => {
     try {
-      const args = this.executable.defaultArgs.concat(cmd);
+      const args = [...this.executable.defaultArgs, ...cmd];
       log.debug(`Running '${this.executable.path} ${quote(args)}'`);
-      let stdout;
-      if (opts.exclusive) {
-        ({stdout} = await ADB_EXEC_GUARD.acquire('adbExec',
-          async () => await exec(this.executable.path, args, opts)));
-      } else {
-        ({stdout} = await exec(this.executable.path, args, opts));
-      }
+      let {stdout} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out
       stdout = stdout.replace(LINKER_WARNING_REGEXP, '').trim();
@@ -359,7 +351,24 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
     }
   };
 
-  return await execFunc();
+  if (isExecLocked) {
+    log.debug('Waiting until the other exclusive ADB command is completed');
+    await waitForCondition(() => !isExecLocked, {
+      waitMs: Number.MAX_SAFE_INTEGER,
+      intervalMs: 10,
+    });
+    log.debug('Continuing with the current ADB command');
+  }
+  if (opts.exclusive) {
+    isExecLocked = true;
+  }
+  try {
+    return await execFunc();
+  } finally {
+    if (opts.exclusive) {
+      isExecLocked = false;
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
The previous implementation was not properly handling the case where the other parallel exec command(s) is not exclusive.