### PR TITLE
Warn install failed due to INSTALL_FAILED_TEST_ONLY

### DIFF
--- a/ci-jobs/nightly.yml
+++ b/ci-jobs/nightly.yml
@@ -17,5 +17,5 @@ jobs:
     parameters:
       script: npx mocha --timeout 6000000 --reporter mocha-multi-reporters --reporter-options configFile=./ci-jobs/mocha-config.json --recursive build/test/functional/ -g @skip-ci -i --exit
       name: sdk22_e2e_tests
-      PLATFORM_VERSION: 7.1
+      PLATFORM_VERSION: 5.1
       ANDROID_SDK_VERSION: 22

--- a/ci-jobs/nightly.yml
+++ b/ci-jobs/nightly.yml
@@ -17,5 +17,5 @@ jobs:
     parameters:
       script: npx mocha --timeout 6000000 --reporter mocha-multi-reporters --reporter-options configFile=./ci-jobs/mocha-config.json --recursive build/test/functional/ -g @skip-ci -i --exit
       name: sdk22_e2e_tests
-      PLATFORM_VERSION: 5.1
+      PLATFORM_VERSION: 7.1
       ANDROID_SDK_VERSION: 22

--- a/ci-jobs/scripts/start-emulator.sh
+++ b/ci-jobs/scripts/start-emulator.sh
@@ -8,7 +8,7 @@ declare -r emulator="system-images;android-$ANDROID_SDK_VERSION;google_apis;x86"
 echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "$emulator"
 
 # Create emulator
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n $ANDROID_AVD -k "$emulator" --force
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n $ANDROID_AVD -k "$emulator" -c 1500M --force
 
 echo $ANDROID_HOME/emulator/emulator -list-avds
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -525,7 +525,9 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
     log.debug(`Install command stdout: ${truncatedOutput}`);
     if (/\[INSTALL[A-Z_]+FAILED[A-Z_]+\]/.test(output)) {
       if (this.isTestPackageOnlyError(output)) {
-        log.warn('Set `allowTestPackages` capability to true in order to allow test packages installation.');
+        const msg = `Set 'allowTestPackages' capability to true in order to allow test packages installation.`;
+        log.warn(msg);
+        throw new Error(`${output}\n${msg}`);
       }
       throw new Error(output);
     }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -524,8 +524,8 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;
     log.debug(`Install command stdout: ${truncatedOutput}`);
     if (/\[INSTALL[A-Z_]+FAILED[A-Z_]+\]/.test(output)) {
-      if (/\[INSTALL_FAILED_TEST_ONLY\]/.test(output)) {
-        log.error('Set `allowTestPackages` capability to true in order to allow test packages installation.');
+      if (this.isTestPackageOnlyError(output)) {
+        log.warn('Set `allowTestPackages` capability to true in order to allow test packages installation.');
       }
       throw new Error(output);
     }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -524,6 +524,9 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;
     log.debug(`Install command stdout: ${truncatedOutput}`);
     if (/\[INSTALL[A-Z_]+FAILED[A-Z_]+\]/.test(output)) {
+      if (/\[INSTALL_FAILED_TEST_ONLY\]/.test(output)) {
+        log.error('Set `allowTestPackages` capability to true in order to allow test packages installation.');
+      }
       throw new Error(output);
     }
   } catch (err) {

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -224,4 +224,8 @@ apksUtilsMethods.extractLanguageApk = async function extractLanguageApk (apks, l
   return await this.extractBaseApk(apks);
 };
 
+apksUtilsMethods.isTestPackageOnlyError = function (output) {
+  return /\[INSTALL_FAILED_TEST_ONLY\]/.test(output);
+};
+
 export default apksUtilsMethods;

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -21,9 +21,6 @@ let apiLevel = process.env.API_LEVEL ||
                API_LEVEL_MAP[parseFloat(platformVersion)];
 apiLevel = parseInt(apiLevel, 10);
 
-// eslint-disable-next-line no-console
-console.log('apiLevel vruno', apiLevel);
-
 const MOCHA_TIMEOUT = process.env.TRAVIS ? 240000 : 60000;
 const MOCHA_LONG_TIMEOUT = MOCHA_TIMEOUT * 10;
 

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -21,6 +21,9 @@ let apiLevel = process.env.API_LEVEL ||
                API_LEVEL_MAP[parseFloat(platformVersion)];
 apiLevel = parseInt(apiLevel, 10);
 
+// eslint-disable-next-line no-console
+console.log('apiLevel vruno', apiLevel);
+
 const MOCHA_TIMEOUT = process.env.TRAVIS ? 240000 : 60000;
 const MOCHA_LONG_TIMEOUT = MOCHA_TIMEOUT * 10;
 

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -250,11 +250,15 @@ describe('android-manifest', withMocks({adb, teen_process, helpers}, function (m
   describe('compileManifest', function () {
     it('should throw an error if no ANDROID_HOME set', async function () {
       let oldAndroidHome = process.env.ANDROID_HOME;
+      let oldAndroidSdkRoot = process.env.ANDROID_SDK_ROOT;
+
       delete process.env.ANDROID_HOME;
+      delete process.env.ANDROID_SDK_ROOT;
 
       await adb.compileManifest().should.eventually.be.rejectedWith(/environment/);
 
       process.env.ANDROID_HOME = oldAndroidHome;
+      process.env.ANDROID_SDK_ROOT = oldAndroidSdkRoot;
     });
   });
 }));

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -7,6 +7,7 @@ import { withMocks } from 'appium-test-support';
 import path from 'path';
 import _ from 'lodash';
 import { REMOTE_CACHE_ROOT } from '../../lib/tools/apk-utils';
+import apksUtilsMethods from '../../lib/tools/apks-utils';
 
 chai.use(chaiAsPromised);
 const should = chai.should(),
@@ -1104,6 +1105,15 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       mocks.adb.expects('shell').withArgs(['getprop', 'ro.build.version.sdk']).onCall(0);
       mocks.adb.expects('shell').withArgs(['dumpsys', 'window', 'displays']).onCall(1);
       await adb.dumpWindows();
+    });
+  });
+  describe('isTestPackageOnly', function () {
+    it('should return true on INSTALL_FAILED_TEST_ONLY meesage found in adb install output', function () {
+      apksUtilsMethods.isTestPackageOnlyError('[INSTALL_FAILED_TEST_ONLY]').should.equal(true);
+      apksUtilsMethods.isTestPackageOnlyError(' [INSTALL_FAILED_TEST_ONLY] ').should.equal(true);
+    });
+    it('should return false on INSTALL_FAILED_TEST_ONLY meesage not found in adb install output', function () {
+      apksUtilsMethods.isTestPackageOnlyError('[INSTALL_FAILED_OTHER]').should.equal(false);
     });
   });
 }));


### PR DESCRIPTION
The idea is too add more visibility to the testers when adb fails to this by explicitly saying 
`Set allowTestPackages capability to true in order to allow test packages installation.` in the logs. 

Work in progress, I want to add another unit test to check this. 