### PR TITLE
modify apk analyzer query to find launch activity

### DIFF
--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -136,6 +136,7 @@ async function extractApkInfoWithApkanalyzer (localApk, apkanalyzerPath) {
   // descendants
   const apkActivityAttribute = xpath.select1(
     "//application/*[starts-with(name(), 'activity') " +
+    "and (not(@*[local-name()='enabled']) or @*[local-name()='enabled' and .='true']) " +
     "and .//action[@*[local-name()='name' and .='android.intent.action.MAIN']] " +
     "and .//category[@*[local-name()='name' and .='android.intent.category.LAUNCHER']]]" +
     "/@*[local-name()='name']", doc);


### PR DESCRIPTION
Apkanalyzer parse can give wrong launch activity name when more than MAIN and LAUNCHER activities exist and they have 'enabled' attribute.

case:
`<activity-alias>
     ... 
    android:enabled='true'
    ...><MAIN> <LAUNCHER>
  />   
<activity-alias>
     ... 
    android:enabled='false'
    ...><MAIN> <LAUNCHER>
  />`
 
To avoid this case, parser must check enabled tag of activity. Firstly, i checked whether 'enabled' attribute exists or not. If not exist, it is ok to take as launchable activity. If exist, i checked the whether 'enabled' is set to true or not.