### PR TITLE
Prefer apkanalyzer for package information retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ console.log(await adb.getPIDsByName('com.android.phone'));
 - `endAndroidCoverage`
 - `instrument`
 - `androidCoverage`
-- `processFromManifest`
 - `packageAndLaunchActivityFromManifest`
 - `compileManifest`
 - `insertManifest`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -434,11 +434,9 @@ function buildInstallArgs (apiLevel, options = {}) {
  */
 function parseManifest (manifestXml) {
   const doc = new xmldom.DOMParser().parseFromString(manifestXml);
-  const result = {};
-  const apkPackageAttribute = doc.documentElement.getAttribute('package');
-  if (apkPackageAttribute) {
-    result.pkg = apkPackageAttribute;
-  }
+  const result = {
+    pkg: doc.documentElement.getAttribute('package'),
+  };
   // Look for activity or activity-alias with
   // action == android.intent.action.MAIN and
   // category == android.intent.category.LAUNCHER

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,8 @@ import log from './logger.js';
 import _ from 'lodash';
 import B from 'bluebird';
 import semver from 'semver';
-
+import xmldom from 'xmldom';
+import xpath from 'xpath';
 
 const rootDir = path.resolve(__dirname, process.env.NO_PRECOMPILE ? '..' : '../..');
 const APKS_EXTENSION = '.apks';
@@ -416,6 +417,52 @@ function buildInstallArgs (apiLevel, options = {}) {
   return result;
 }
 
+/**
+ * @typedef {Object} ManifestInfo
+ * @property {string} pkg - The application identifier
+ * @property {string} activity - The name of the main package activity
+ * @property {?number} versionCode - The version code number (might be `undefined`)
+ * @property {?string} versionName - The version name (might be `undefined`)
+ */
+
+/**
+ * Perform parsing of the manifest XML file to in order
+ * to extract some vital values from it
+ *
+ * @param {string} manifestXml The original manifest content as a string
+ * @returns {ManifestInfo}
+ */
+function parseManifest (manifestXml) {
+  const doc = new xmldom.DOMParser().parseFromString(manifestXml);
+  const result = {};
+  const apkPackageAttribute = doc.documentElement.getAttribute('package');
+  if (apkPackageAttribute) {
+    result.pkg = apkPackageAttribute;
+  }
+  // Look for activity or activity-alias with
+  // action == android.intent.action.MAIN and
+  // category == android.intent.category.LAUNCHER
+  // descendants
+  const apkActivityAttribute = xpath.select1(
+    "//application/*[starts-with(name(), 'activity') " +
+    "and (not(@*[local-name()='enabled']) or @*[local-name()='enabled' and .='true']) " +
+    "and .//action[@*[local-name()='name' and .='android.intent.action.MAIN']] " +
+    "and .//category[@*[local-name()='name' and .='android.intent.category.LAUNCHER']]]" +
+    "/@*[local-name()='name']", doc);
+  if (apkActivityAttribute) {
+    result.activity = apkActivityAttribute.value;
+  }
+  const versionCodeAttribute = xpath.select1("//manifest/@*[local-name()='versionCode']", doc);
+  if (versionCodeAttribute) {
+    result.versionCode = parseInt(versionCodeAttribute.value, 10);
+  }
+  const versionNameAttribute = xpath.select1("//manifest/@*[local-name()='versionName']", doc);
+  if (versionNameAttribute) {
+    result.versionName = versionNameAttribute.value;
+  }
+  return result;
+}
+
 export {
   getAndroidPlatformAndPath, unzipFile,
   getIMEListFromOutput, getJavaForOs, isShowingLockscreen, isCurrentFocusOnKeyguard,
@@ -423,5 +470,5 @@ export {
   rootDir, getSdkToolsVersion, getApksignerForOs, getBuildToolsDirs,
   getApkanalyzerForOs, getOpenSslForOs, extractMatchingPermissions, APKS_EXTENSION,
   APK_INSTALL_TIMEOUT, APKS_INSTALL_TIMEOUT, buildInstallArgs, APK_EXTENSION,
-  DEFAULT_ADB_EXEC_TIMEOUT,
+  DEFAULT_ADB_EXEC_TIMEOUT, parseManifest,
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -421,8 +421,8 @@ function buildInstallArgs (apiLevel, options = {}) {
  * @typedef {Object} ManifestInfo
  * @property {string} pkg - The application identifier
  * @property {string} activity - The name of the main package activity
- * @property {?number} versionCode - The version code number (might be `undefined`)
- * @property {?string} versionName - The version name (might be `undefined`)
+ * @property {?number} versionCode - The version code number (might be `NaN`)
+ * @property {?string} versionName - The version name (might be `null`)
  */
 
 /**
@@ -434,8 +434,11 @@ function buildInstallArgs (apiLevel, options = {}) {
  */
 function parseManifest (manifestXml) {
   const doc = new xmldom.DOMParser().parseFromString(manifestXml);
+  const documentElement = doc.documentElement;
   const result = {
-    pkg: doc.documentElement.getAttribute('package'),
+    pkg: documentElement.getAttribute('package'),
+    versionCode: parseInt(documentElement.getAttribute('android:versionCode'), 10),
+    versionName: documentElement.getAttribute('android:versionName'),
   };
   // Look for activity or activity-alias with
   // action == android.intent.action.MAIN and
@@ -449,14 +452,6 @@ function parseManifest (manifestXml) {
     "/@*[local-name()='name']", doc);
   if (apkActivityAttribute) {
     result.activity = apkActivityAttribute.value;
-  }
-  const versionCodeAttribute = xpath.select1("//manifest/@*[local-name()='versionCode']", doc);
-  if (versionCodeAttribute) {
-    result.versionCode = parseInt(versionCodeAttribute.value, 10);
-  }
-  const versionNameAttribute = xpath.select1("//manifest/@*[local-name()='versionName']", doc);
-  if (versionNameAttribute) {
-    result.versionName = versionNameAttribute.value;
   }
   return result;
 }

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -2,56 +2,13 @@ import { exec } from 'teen_process';
 import log from '../logger.js';
 import {
   getAndroidPlatformAndPath, unzipFile,
-  getApkanalyzerForOs, APKS_EXTENSION } from '../helpers.js';
+  getApkanalyzerForOs, APKS_EXTENSION, parseManifest } from '../helpers.js';
 import { fs, zip } from 'appium-support';
 import _ from 'lodash';
 import path from 'path';
-import xmldom from 'xmldom';
-import xpath from 'xpath';
 import { quote } from 'shell-quote';
 
 let manifestMethods = {};
-
-// android:process= may be defined in AndroidManifest.xml
-// http://developer.android.com/reference/android/R.attr.html#process
-// note that the process name when used with ps must be truncated to the last 15 chars
-// ps -c com.example.android.apis becomes ps -c le.android.apis
-manifestMethods.processFromManifest = async function processFromManifest (localApk) {
-  await this.initAapt();
-  log.info('Retrieving process from manifest');
-  let args = ['dump', 'xmltree', localApk, 'AndroidManifest.xml'];
-  let {stdout} = await exec(this.binaries.aapt, args);
-  let result = null;
-  let lines = stdout.split('\n');
-  let applicationRegex = new RegExp(/\s+E: application \(line=\d+\).*/);
-  let applicationFound = false;
-  let attributeRegex = new RegExp(/\s+A: .+/);
-  let processRegex = new RegExp(/\s+A: android:process\(0x01010011\)="([^"]+).*"/);
-  for (let line of lines) {
-    if (!applicationFound) {
-      if (applicationRegex.test(line)) {
-        applicationFound = true;
-      }
-    } else {
-      let notAttribute = !attributeRegex.test(line);
-      // process must be an attribute after application.
-      if (notAttribute) {
-        break;
-      }
-      let process = processRegex.exec(line);
-      // this is an application attribute process.
-      if (process && process.length > 1) {
-        result = process[1];
-        // must trim to last 15 for android's ps binary
-        if (result.length > 15) {
-          result = result.substr(result.length - 15);
-        }
-        break;
-      }
-    }
-  }
-  return result;
-};
 
 /**
  * @typedef {Object} APKInfo
@@ -120,31 +77,21 @@ async function extractApkInfoWithApkTools (localApk, aaptPath, jarPath, tmpRoot)
 async function extractApkInfoWithApkanalyzer (localApk, apkanalyzerPath) {
   const args = ['-h', 'manifest', 'print', localApk];
   log.debug(`Starting '${apkanalyzerPath}' with args ${JSON.stringify(args)}`);
-  const manifestXml = (await exec(apkanalyzerPath, args, {
+  const {stdout} = await exec(apkanalyzerPath, args, {
     shell: true,
     cwd: path.dirname(apkanalyzerPath)
-  })).stdout;
-  const doc = new xmldom.DOMParser().parseFromString(manifestXml);
-  const apkPackageAttribute = xpath.select1('//manifest/@package', doc);
-  if (!apkPackageAttribute) {
-    throw new Error(`Cannot parse package name from ${manifestXml}`);
+  });
+  const {pkg, activity} = parseManifest(stdout);
+  if (!pkg) {
+    throw new Error(`Cannot parse package name from ${stdout}`);
   }
-  const apkPackage = apkPackageAttribute.value;
-  // Look for activity or activity-alias with
-  // action == android.intent.action.MAIN and
-  // category == android.intent.category.LAUNCHER
-  // descendants
-  const apkActivityAttribute = xpath.select1(
-    "//application/*[starts-with(name(), 'activity') " +
-    "and (not(@*[local-name()='enabled']) or @*[local-name()='enabled' and .='true']) " +
-    "and .//action[@*[local-name()='name' and .='android.intent.action.MAIN']] " +
-    "and .//category[@*[local-name()='name' and .='android.intent.category.LAUNCHER']]]" +
-    "/@*[local-name()='name']", doc);
-  if (!apkActivityAttribute) {
-    throw new Error(`Cannot parse main activity name from ${manifestXml}`);
+  if (!activity) {
+    throw new Error(`Cannot parse main activity name from ${stdout}`);
   }
-  const apkActivity = apkActivityAttribute.value;
-  return {apkPackage, apkActivity};
+  return {
+    apkPackage: pkg,
+    apkActivity: activity,
+  };
 }
 
 /**
@@ -199,26 +146,41 @@ manifestMethods.packageAndLaunchActivityFromManifest = async function packageAnd
  *                 application package.
  */
 manifestMethods.targetSdkVersionFromManifest = async function targetSdkVersionFromManifest (appPath) {
-  await this.initAapt();
-
+  const originalAppPath = appPath;
   if (appPath.endsWith(APKS_EXTENSION)) {
     appPath = await this.extractBaseApk(appPath);
   }
 
-  log.info('Extracting package and launch activity from manifest');
-  let args = ['dump', 'badging', appPath];
-  let output;
+  log.info('Extracting target SDK version from the manifest');
   try {
-    let {stdout} = await exec(this.binaries.aapt, args);
-    output = stdout;
+    const apkanalyzerPath = await getApkanalyzerForOs(this);
+    const {stdout} = await exec(apkanalyzerPath, ['manifest', 'target-sdk', appPath], {
+      shell: true,
+      cwd: path.dirname(apkanalyzerPath),
+    });
+    if (isNaN(_.trim(stdout))) {
+      throw new Error(`Cannot parse the minimum SDK version from '${stdout}'`);
+    }
+    return parseInt(_.trim(stdout), 10);
   } catch (e) {
-    throw new Error(`fetching targetSdkVersion from local APK failed. Original error: ${e.message}`);
+    log.info(`Cannot extract targetSdkVersion using apkanalyzer. Falling back to aapt. ` +
+      `Original error: ${e.message}`);
+    await this.initAapt();
+    const args = ['dump', 'badging', appPath];
+    let output;
+    try {
+      const {stdout} = await exec(this.binaries.aapt, args);
+      output = stdout;
+    } catch (e) {
+      throw new Error(`Fetching targetSdkVersion from '${originalAppPath}' failed. ` +
+        `Original error: ${e.message}`);
+    }
+    const targetSdkVersion = new RegExp(/targetSdkVersion:'([^']+)'/g).exec(output);
+    if (!targetSdkVersion) {
+      throw new Error(`targetSdkVersion is not specified in the '${originalAppPath}' application`);
+    }
+    return parseInt(targetSdkVersion[1], 10);
   }
-  let targetSdkVersion = new RegExp(/targetSdkVersion:'([^']+)'/g).exec(output);
-  if (!targetSdkVersion) {
-    throw new Error(`targetSdkVersion is not specified in the application.`);
-  }
-  return parseInt(targetSdkVersion[1], 10);
 };
 
 /**

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -1,6 +1,7 @@
 import {
   buildStartCmd, APKS_EXTENSION, buildInstallArgs,
-  APK_INSTALL_TIMEOUT, DEFAULT_ADB_EXEC_TIMEOUT } from '../helpers.js';
+  APK_INSTALL_TIMEOUT, DEFAULT_ADB_EXEC_TIMEOUT, getApkanalyzerForOs,
+  parseManifest } from '../helpers.js';
 import { exec } from 'teen_process';
 import log from '../logger.js';
 import path from 'path';
@@ -988,19 +989,37 @@ apkUtilsMethods.getApkInfo = async function getApkInfo (appPath) {
     appPath = await this.extractBaseApk(appPath);
   }
 
-  await this.initAapt();
   try {
-    const {stdout} = await exec(this.binaries.aapt, ['d', 'badging', appPath]);
-    const matches = new RegExp(/package: name='([^']+)' versionCode='(\d+)' versionName='([^']+)'/).exec(stdout);
-    if (matches) {
-      return {
-        name: matches[1],
-        versionCode: parseInt(matches[2], 10),
-        versionName: matches[3]
-      };
+    const apkanalyzerPath = await getApkanalyzerForOs(this);
+    const args = ['manifest', 'print', appPath];
+    log.debug(`Starting '${apkanalyzerPath}' with args ${JSON.stringify(args)}`);
+    const {stdout} = await exec(apkanalyzerPath, args, {
+      shell: true,
+      cwd: path.dirname(apkanalyzerPath),
+    });
+    const {pkg, versionName, versionCode} = parseManifest(stdout);
+    return {
+      name: pkg,
+      versionCode,
+      versionName,
+    };
+  } catch (e) {
+    log.info(`Cannot extract apk info using apkanalyzer. Falling back to aapt. ` +
+      `Original error: ${e.message}`);
+    await this.initAapt();
+    try {
+      const {stdout} = await exec(this.binaries.aapt, ['d', 'badging', appPath]);
+      const matches = new RegExp(/package: name='([^']+)' versionCode='(\d+)' versionName='([^']+)'/).exec(stdout);
+      if (matches) {
+        return {
+          name: matches[1],
+          versionCode: parseInt(matches[2], 10),
+          versionName: matches[3]
+        };
+      }
+    } catch (err) {
+      log.warn(`Error "${err.message}" while getting badging info`);
     }
-  } catch (err) {
-    log.warn(`Error "${err.message}" while getting badging info`);
   }
   return {};
 };

--- a/test/adb-specs.js
+++ b/test/adb-specs.js
@@ -6,7 +6,6 @@ chai.use(chaiAsPromised);
 
 describe.skip('ADB To be implemented methods', function () {
 
-  // it('processFromManifest', async () => { });
   // it('packageAndLaunchActivityFromManifest', async () => { });
   // it('processExists', async () => { });
   // it('compileManifest', async () => { });

--- a/test/functional/android-manifest-e2e-specs.js
+++ b/test/functional/android-manifest-e2e-specs.js
@@ -62,7 +62,3 @@ describe('Android-manifest', function () {
     }
   });
 });
-
-describe.skip('Android-manifest To be implemented methods', function () {
-  it('should return correct processFromManifest', async function () { });
-});

--- a/test/unit/android-manifest-specs.js
+++ b/test/unit/android-manifest-specs.js
@@ -15,21 +15,6 @@ describe('android-manifest', withMocks({adb, teen_process, helpers}, function (m
     mocks.verify();
   });
 
-  describe('processFromManifest', function () {
-    it('should correctly parse process from manifest', async function () {
-      adb.binaries.aapt = 'dummy_aapt';
-      const localApk = 'dummyAPK',
-            dummyProcess = 'dummyProcess';
-      mocks.adb.expects('initAapt')
-        .once().withExactArgs()
-              .returns('');
-      mocks.teen_process.expects('exec')
-        .once().withExactArgs('dummy_aapt', ['dump', 'xmltree', localApk, 'AndroidManifest.xml'])
-        .returns({stdout: ` E: application (line=234)
-                          A: android:process(0x01010011)="${dummyProcess}"`});
-      (await adb.processFromManifest(localApk)).should.equal(dummyProcess);
-    });
-  });
   describe('packageAndLaunchActivityFromManifest', function () {
     it('should correctly parse package and activity from manifest with apkanalyzer tool', async function () {
       const apkanalyzerDummyPath = 'apkanalyzer';

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -1,5 +1,5 @@
 import { getAndroidPlatformAndPath,
-         buildStartCmd, isShowingLockscreen, getBuildToolsDirs } from '../../lib/helpers';
+         buildStartCmd, isShowingLockscreen, getBuildToolsDirs, parseManifest } from '../../lib/helpers';
 import { withMocks } from 'appium-test-support';
 import { fs } from 'appium-support';
 import path from 'path';
@@ -150,6 +150,176 @@ describe('helpers', withMocks({fs}, function (mocks) {
         '/some/path/2.3.1',
         '/some/path/1.2.3',
       ]);
+    });
+  });
+
+  describe('parseManifest', function () {
+    const manifestXml = `<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="697"
+    android:versionName="3.27.697"
+    package="com.example"
+    platformBuildVersionCode="697"
+    platformBuildVersionName="3.27.697">
+
+    <uses-sdk
+        android:minSdkVersion="17"
+        android:targetSdkVersion="27" />
+
+    <uses-permission
+        android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <uses-permission
+        android:name="android.permission.INTERNET" />
+
+    <uses-permission
+        android:name="android.permission.READ_CONTACTS" />
+
+    <uses-permission
+        android:name="android.permission.RECORD_AUDIO" />
+
+    <uses-permission
+        android:name="android.permission.VIBRATE" />
+
+    <uses-permission
+        android:name="android.permission.CAMERA" />
+
+    <uses-permission
+        android:name="android.permission.FLASHLIGHT" />
+
+    <uses-permission
+        android:name="android.permission.READ_PHONE_STATE" />
+
+    <uses-permission
+        android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+
+    <uses-permission
+        android:name="android.permission.BLUETOOTH" />
+
+    <uses-permission
+        android:name="android.permission.WAKE_LOCK" />
+
+    <uses-permission
+        android:name="com.google.android.c2dm.permission.RECEIVE" />
+
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <uses-permission
+        android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
+    <uses-feature
+        android:name="android.hardware.camera.front"
+        android:required="false" />
+
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
+
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <uses-feature
+        android:glEsVersion="0x20000"
+        android:required="true" />
+
+    <application
+        android:theme="@ref/0x7f100148"
+        android:label="Example"
+        android:icon="@ref/0x7f0800cd"
+        android:name="com.example.Application"
+        android:allowBackup="false"
+        android:vmSafeMode="false"
+        android:hardwareAccelerated="true"
+        android:supportsRtl="true">
+
+        <activity
+            android:theme="@ref/0x7f100148"
+            android:name="com.example.Application.MainActivity"
+            android:launchMode="2"
+            android:configChanges="0x4a0"
+            android:windowSoftInputMode="0x12"
+            android:hardwareAccelerated="true">
+
+            <intent-filter>
+
+                <data
+                    android:scheme="example"
+                    android:host="password-reset-successful" />
+
+                <action
+                    android:name="android.intent.action.VIEW" />
+
+                <category
+                    android:name="android.intent.category.DEFAULT" />
+
+                <category
+                    android:name="android.intent.category.BROWSABLE" />
+
+                <category
+                    android:name="android.intent.category.VIEW" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:theme="@ref/0x7f100148"
+            android:label="@ref/0x7f0f004c"
+            android:name="com.example.LaunchActivity"
+            android:launchMode="2"
+            android:noHistory="true">
+
+            <intent-filter>
+
+                <action
+                    android:name="android.intent.action.MAIN" />
+
+                <category
+                    android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:theme="@ref/0x7f10013d"
+            android:name="com.example.CallingActivity"
+            android:launchMode="2"
+            android:screenOrientation="1"
+            android:windowSoftInputMode="0x2"
+            android:hardwareAccelerated="true"
+            android:showOnLockScreen="true" />
+
+        <activity
+            android:theme="@ref/0x7f100141"
+            android:label="@ref/0x7f0f01bc"
+            android:name="com.example.PreferencesActivity"
+            android:launchMode="2"
+            android:hardwareAccelerated="true" />
+
+        <activity
+            android:theme="@ref/0x7f10014c"
+            android:name="com.example.PopupActivity"
+            android:taskAffinity="@string/0x25"
+            android:excludeFromRecents="true"
+            android:launchMode="1"
+            android:screenOrientation="-1"
+            android:windowSoftInputMode="0x4"
+            android:hardwareAccelerated="true" />
+    </application>
+</manifest>`;
+
+    it('should parse manifest', function () {
+      const {pkg, activity, versionCode, versionName} = parseManifest(manifestXml);
+      pkg.should.eql('com.example');
+      activity.should.eql('com.example.LaunchActivity');
+      versionCode.should.eql(697);
+      versionName.should.eql('3.27.697');
     });
   });
 }));


### PR DESCRIPTION
Google has completely deprecated aapt tool since SDK 28 and removed it from build tools, so we need to start shifting to aapt2/apkanalyzer usage.