### PR TITLE
Update manifest helpers to use aapt2

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -51,6 +51,14 @@ methods.initAapt = async function initAapt () {
 };
 
 /**
+ * Get the full path to aapt2 tool and assign it to
+ * this.binaries.aapt2 property
+ */
+methods.initAapt = async function initAapt2 () {
+  await this.getSdkBinaryPath('aapt2');
+};
+
+/**
  * Get the full path to zipalign tool and assign it to
  * this.binaries.zipalign property
  */

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -54,7 +54,7 @@ methods.initAapt = async function initAapt () {
  * Get the full path to aapt2 tool and assign it to
  * this.binaries.aapt2 property
  */
-methods.initAapt = async function initAapt2 () {
+methods.initAapt2 = async function initAapt2 () {
   await this.getSdkBinaryPath('aapt2');
 };
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -3,7 +3,7 @@ import log from '../logger.js';
 import {
   getAndroidPlatformAndPath, unzipFile,
   getApkanalyzerForOs, APKS_EXTENSION, parseManifest } from '../helpers.js';
-import { fs, zip } from 'appium-support';
+import { fs, zip, tempDir } from 'appium-support';
 import _ from 'lodash';
 import path from 'path';
 import { quote } from 'shell-quote';
@@ -218,23 +218,45 @@ manifestMethods.compileManifest = async function compileManifest (manifest, mani
     throw new Error('Cannot compile the manifest. The required platform does not exist (API level >= 17)');
   }
   const resultPath = `${manifest}.apk`;
-  const args = [
-    'package',
-    '-M', manifest,
-    '--rename-manifest-package', manifestPackage,
-    '--rename-instrumentation-target-package', targetPackage,
-    '-I', path.resolve(platformPath, 'android.jar'),
-    '-F', resultPath,
-    '-f',
-  ];
-  try {
-    await this.initAapt();
-    log.debug(`Compiling the manifest: ${this.binaries.aapt} ${quote(args)}`);
-    await exec(this.binaries.aapt, args);
-    log.debug(`Compiled the manifest at '${resultPath}'`);
-  } catch (err) {
-    throw new Error(`Cannot compile the manifest. Original error: ${err.message}`);
+  const androidJarPath = path.resolve(platformPath, 'android.jar');
+  if (await fs.exists(resultPath)) {
+    await fs.rimraf(resultPath);
   }
+  try {
+    await this.initAapt2();
+    // https://developer.android.com/studio/command-line/aapt2
+    const args = [
+      'link',
+      '-o', resultPath,
+      '--manifest', manifest,
+      '--rename-manifest-package', manifestPackage,
+      '--rename-instrumentation-target-package', targetPackage,
+      '-I', androidJarPath,
+      '-v',
+    ];
+    log.debug(`Compiling the manifest using ${this.binaries.aapt2} ${quote(args)}`);
+    await exec(this.binaries.aapt2, args);
+  } catch (e) {
+    log.debug('Cannot compile the manifest using aapt2. Defaulting to aapt. ' +
+      `Original error: ${e.stderr || e.message}`);
+    await this.initAapt();
+    const args = [
+      'package',
+      '-M', manifest,
+      '--rename-manifest-package', manifestPackage,
+      '--rename-instrumentation-target-package', targetPackage,
+      '-I', androidJarPath,
+      '-F', resultPath,
+      '-f',
+    ];
+    log.debug(`Compiling the manifest using ${this.binaries.aapt} ${quote(args)}`);
+    try {
+      await exec(this.binaries.aapt, args);
+    } catch (e1) {
+      throw new Error(`Cannot compile the manifest. Original error: ${e1.stderr || e1.message}`);
+    }
+  }
+  log.debug(`Compiled the manifest at '${resultPath}'`);
 };
 
 /**
@@ -248,25 +270,46 @@ manifestMethods.compileManifest = async function compileManifest (manifest, mani
  *                          this manifest has to be insetred to. This package
  *                          will NOT be modified.
  * @param {string} dstApk - Full path to the resulting package.
- *                          The file will be overriden if it already exists.
+ *                          The file will be overridden if it already exists.
  */
 manifestMethods.insertManifest = async function insertManifest (manifest, srcApk, dstApk) {
-  log.debug(`Inserting manifest, src: ${srcApk} dst: ${dstApk}`);
-  await this.initAapt();
+  log.debug(`Inserting manifest '${manifest}', src: '${srcApk}', dst: '${dstApk}'`);
+  await zip.assertValidZip(srcApk);
   await unzipFile(`${manifest}.apk`);
-  await fs.copyFile(srcApk, dstApk);
-  log.debug('Testing new tmp apk');
-  await zip.assertValidZip(dstApk);
-  log.debug('Moving manifest');
+  const manifestName = path.basename(manifest);
   try {
+    await this.initAapt();
+    await fs.copyFile(srcApk, dstApk);
+    log.debug('Moving manifest');
+    try {
+      await exec(this.binaries.aapt, [
+        'remove', dstApk, manifestName
+      ]);
+    } catch (ign) {}
     await exec(this.binaries.aapt, [
-      'remove', dstApk, path.basename(manifest)
-    ]);
-  } catch (ign) {}
-  await exec(this.binaries.aapt, [
-    'add', dstApk, path.basename(manifest)
-  ], {cwd: path.dirname(manifest)});
-  log.debug('Inserted manifest.');
+      'add', dstApk, manifestName
+    ], {cwd: path.dirname(manifest)});
+  } catch (e) {
+    log.debug('Cannot insert manifest using aapt. Defaulting to zip. ' +
+      `Original error: ${e.message}`);
+    const tmpRoot = await tempDir.openDir();
+    try {
+      // Unfortunately NodeJS does not provide any reliable methods
+      // to replace files inside zip archives without loading the
+      // whole archive content into RAM
+      log.debug('Extracting the source apk');
+      await unzipFile(srcApk, tmpRoot);
+      log.debug('Moving manifest');
+      await fs.mv(manifest, path.join(tmpRoot, manifestName));
+      log.debug('Collecting the destination apk');
+      await zip.toArchive(dstApk, {
+        cwd: tmpRoot,
+      });
+    } finally {
+      await fs.rimraf(tmpRoot);
+    }
+  }
+  log.debug('Manifest insertion is completed');
 };
 
 /**
@@ -276,47 +319,35 @@ manifestMethods.insertManifest = async function insertManifest (manifest, srcApk
  * @return {boolean} True if the manifest requires Internet access permission.
  */
 manifestMethods.hasInternetPermissionFromManifest = async function hasInternetPermissionFromManifest (appPath) {
-  await this.initAapt();
+  const originalAppPath = appPath;
 
   if (appPath.endsWith(APKS_EXTENSION)) {
     appPath = await this.extractBaseApk(appPath);
   }
 
-  log.debug(`Checking if '${appPath}' requires internet access permission in the manifest`);
+  log.debug(`Checking if '${originalAppPath}' requires internet access permission in the manifest`);
+  const internetPermissionPattern = /\bandroid\.permission\.INTERNET\b/;
   try {
-    let {stdout} = await exec(this.binaries.aapt, ['dump', 'badging', appPath]);
-    return new RegExp(/uses-permission:.*'android.permission.INTERNET'/).test(stdout);
+    const apkanalyzerPath = await getApkanalyzerForOs(this);
+    const args = ['manifest', 'permissions', appPath];
+    log.debug(`Starting '${apkanalyzerPath}' with args ${JSON.stringify(args)}`);
+    const {stdout} = await exec(apkanalyzerPath, args, {
+      shell: true,
+      cwd: path.dirname(apkanalyzerPath),
+    });
+    return internetPermissionPattern.test(stdout);
   } catch (e) {
-    throw new Error(`Cannot check if '${appPath}' requires internet access permission. ` +
-                    `Original error: ${e.message}`);
-  }
-};
-
-/**
- * Prints out the manifest extracted from the apk
- *
- * @param {string} appPath - The full path to application package.
- * @param {?string} logLevel - The level at which to log. E.g., 'debug'
- */
-manifestMethods.printManifestFromApk = async function printManifestFromApk (appPath, logLevel = 'debug') {
-  await this.initAapt();
-
-  if (appPath.endsWith(APKS_EXTENSION)) {
-    appPath = await this.extractBaseApk(appPath);
-  }
-
-  log[logLevel](`Extracting the manifest from '${appPath}'`);
-  let out = false;
-  const {stdout} = await exec(this.binaries.aapt, ['l', '-a', appPath]);
-  for (const line of stdout.split('\n')) {
-    if (!out && line.includes('Android manifest:')) {
-      out = true;
-    }
-    if (out) {
-      log[logLevel](line);
+    log.debug('Cannot get apk permissions using apkanalyzer. Falling back to aapt. ' +
+      `Original error: ${e.stderr || e.message}`);
+    await this.initAapt();
+    try {
+      const {stdout} = await exec(this.binaries.aapt, ['dump', 'badging', appPath]);
+      return internetPermissionPattern.test(stdout);
+    } catch (e1) {
+      throw new Error(`Cannot check if '${originalAppPath}' requires internet access permission. ` +
+                      `Original error: ${e1.stderr || e1.message}`);
     }
   }
 };
-
 
 export default manifestMethods;

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -234,7 +234,7 @@ manifestMethods.compileManifest = async function compileManifest (manifest, mani
       '-I', androidJarPath,
       '-v',
     ];
-    log.debug(`Compiling the manifest using ${this.binaries.aapt2} ${quote(args)}`);
+    log.debug(`Compiling the manifest using '${quote([this.binaries.aapt2, ...args])}'`);
     await exec(this.binaries.aapt2, args);
   } catch (e) {
     log.debug('Cannot compile the manifest using aapt2. Defaulting to aapt. ' +
@@ -249,7 +249,7 @@ manifestMethods.compileManifest = async function compileManifest (manifest, mani
       '-F', resultPath,
       '-f',
     ];
-    log.debug(`Compiling the manifest using ${this.binaries.aapt} ${quote(args)}`);
+    log.debug(`Compiling the manifest using '${quote([this.binaries.aapt, ...args])}'`);
     try {
       await exec(this.binaries.aapt, args);
     } catch (e1) {

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -291,17 +291,17 @@ manifestMethods.insertManifest = async function insertManifest (manifest, srcApk
     ], {cwd: path.dirname(manifest)});
   } catch (e) {
     log.debug('Cannot insert manifest using aapt. Defaulting to zip. ' +
-      `Original error: ${e.message}`);
+      `Original error: ${e.stderr || e.message}`);
     const tmpRoot = await tempDir.openDir();
     try {
       // Unfortunately NodeJS does not provide any reliable methods
       // to replace files inside zip archives without loading the
       // whole archive content into RAM
-      log.debug('Extracting the source apk');
-      await unzipFile(srcApk, tmpRoot);
+      log.debug(`Extracting the source apk at '${srcApk}'`);
+      await zip.extractAllTo(srcApk, tmpRoot);
       log.debug('Moving manifest');
-      await fs.mv(manifest, path.join(tmpRoot, manifestName));
-      log.debug('Collecting the destination apk');
+      await fs.mv(manifest, path.resolve(tmpRoot, manifestName));
+      log.debug(`Collecting the destination apk at '${dstApk}'`);
       await zip.toArchive(dstApk, {
         cwd: tmpRoot,
       });
@@ -309,7 +309,7 @@ manifestMethods.insertManifest = async function insertManifest (manifest, srcApk
       await fs.rimraf(tmpRoot);
     }
   }
-  log.debug('Manifest insertion is completed');
+  log.debug(`Manifest insertion into '${dstApk}' is completed`);
 };
 
 /**

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -1005,7 +1005,7 @@ apkUtilsMethods.getApkInfo = async function getApkInfo (appPath) {
     };
   } catch (e) {
     log.info(`Cannot extract apk info using apkanalyzer. Falling back to aapt. ` +
-      `Original error: ${e.message}`);
+      `Original error: ${e.stderr || e.message}`);
     await this.initAapt();
     try {
       const {stdout} = await exec(this.binaries.aapt, ['d', 'badging', appPath]);
@@ -1018,7 +1018,7 @@ apkUtilsMethods.getApkInfo = async function getApkInfo (appPath) {
         };
       }
     } catch (err) {
-      log.warn(`Error "${err.message}" while getting badging info`);
+      log.warn(`Error "${err.stderr || err.message}" while getting badging info`);
     }
   }
   return {};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/appium/appium-adb",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-support": "^2.24.0",
+    "appium-support": "^2.31.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.4.7",


### PR DESCRIPTION
The only method which is left (still uses the deprecated aapt) is the resources extractor