### PR TITLE
fix: Always fall back to ps-based PID detection on Android 5 and older versions

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1221,34 +1221,37 @@ methods.removeLogcatListener = function removeLogcatListener (listener) {
  */
 methods.getPIDsByName = async function getPIDsByName (name) {
   log.debug(`Getting IDs of all '${name}' processes`);
-  if (!_.isBoolean(this._isPgrepAvailable)) {
-    // pgrep is in priority, since pidof has been reported of having bugs on some platforms
-    const pgrepOutput = _.trim(await this.shell(['pgrep --help; echo $?']));
-    this._isPgrepAvailable = parseInt(_.last(pgrepOutput.split(/\s+/)), 10) === 0;
-    if (this._isPgrepAvailable) {
-      this._canPgrepUseFullCmdLineSearch = /^-f\b/m.test(pgrepOutput);
-    } else {
-      this._isPidofAvailable = parseInt(await this.shell(['pidof --help > /dev/null; echo $?']), 10) === 0;
-    }
-  }
-  if (this._isPgrepAvailable || this._isPidofAvailable) {
-    const shellCommand = this._isPgrepAvailable
-      ? (this._canPgrepUseFullCmdLineSearch
-        ? ['pgrep', '-f', _.escapeRegExp(name)]
-        : ['pgrep', `^${_.escapeRegExp(name.slice(-15))}$`])
-      : ['pidof', name];
-    try {
-      return (await this.shell(shellCommand))
-        .split(/\s+/)
-        .map((x) => parseInt(x, 10))
-        .filter((x) => _.isInteger(x));
-    } catch (e) {
-      // error code 1 is returned if the utility did not find any processes
-      // with the given name
-      if (e.code === 1) {
-        return [];
+  // https://github.com/appium/appium/issues/13567
+  if (await this.getApiLevel() >= 23) {
+    if (!_.isBoolean(this._isPgrepAvailable)) {
+      // pgrep is in priority, since pidof has been reported of having bugs on some platforms
+      const pgrepOutput = _.trim(await this.shell(['pgrep --help; echo $?']));
+      this._isPgrepAvailable = parseInt(_.last(pgrepOutput.split(/\s+/)), 10) === 0;
+      if (this._isPgrepAvailable) {
+        this._canPgrepUseFullCmdLineSearch = /^-f\b/m.test(pgrepOutput);
+      } else {
+        this._isPidofAvailable = parseInt(await this.shell(['pidof --help > /dev/null; echo $?']), 10) === 0;
       }
-      throw new Error(`Could not extract process ID of '${name}': ${e.message}`);
+    }
+    if (this._isPgrepAvailable || this._isPidofAvailable) {
+      const shellCommand = this._isPgrepAvailable
+        ? (this._canPgrepUseFullCmdLineSearch
+          ? ['pgrep', '-f', _.escapeRegExp(name)]
+          : ['pgrep', `^${_.escapeRegExp(name.slice(-15))}$`])
+        : ['pidof', name];
+      try {
+        return (await this.shell(shellCommand))
+          .split(/\s+/)
+          .map((x) => parseInt(x, 10))
+          .filter((x) => _.isInteger(x));
+      } catch (e) {
+        // error code 1 is returned if the utility did not find any processes
+        // with the given name
+        if (e.code === 1) {
+          return [];
+        }
+        throw new Error(`Could not extract process ID of '${name}': ${e.message}`);
+      }
     }
   }
 

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -593,6 +593,9 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       });
     });
     describe('getPIDsByName', function () {
+      beforeEach(function () {
+        mocks.adb.expects('getApiLevel').once().returns(23);
+      });
       afterEach(function () {
         adb._isPidofAvailable = undefined;
         adb._isPgrepAvailable = undefined;


### PR DESCRIPTION
According to https://github.com/appium/appium/issues/13567 the implementation of `pgrep` in Android 5 is buggy and should not be used.