### PR TITLE
fix: return the clipboard content as base64-encoded string

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1794,8 +1794,8 @@ methods.getTimeZone = async function getTimeZone () {
  * This method only works if Appium Settings v. 2.15+ is installed
  * on the device under test
  *
- * @returns {string} The actual content of the main clipboard
- * or an empty string if the clipboard is empty
+ * @returns {string} The actual content of the main clipboard as
+ * base64-encoded string or an empty string if the clipboard is empty
  * @throws {Error} If there was a problem while getting the
  * clipboard contant
  */
@@ -1821,7 +1821,7 @@ methods.getClipboard = async function getClipboard () {
   if (!match) {
     throw new Error(`Cannot parse the actual cliboard content from the command output: ${output}`);
   }
-  return Buffer.from(_.trim(match[1]), 'base64').toString('utf8');
+  return _.trim(match[1]);
 };
 
 export default methods;


### PR DESCRIPTION
Fixes https://github.com/appium/appium-adb/pull/473#discussion_r347388767