### PR TITLE
Allow starting an app with just intent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
     - PLATFORM_VERSION=5.0.2
     - CC=gcc-6 CXX=g++-6
     - QEMU_AUDIO_DRV=none
+    - NODE_VERSION=10
   matrix:
     # API24@armeabi-v7a is the newest available default image
     # which does not require hardware acceleration:
@@ -46,20 +47,15 @@ env:
 before_install:
   - echo $ANDROID_HOME
   - |
-    if [ ${START_EMU} = "1" ]; then
+    if [[ "${START_EMU}" == "1" ]]; then
       echo 'count=0' > /home/travis/.android/repositories.cfg
-      echo y | android update sdk --no-ui -t tools
-      echo y | sdkmanager "platform-tools" >/dev/null
-      echo y | sdkmanager tools > /dev/null
-      # Free up some space
-      for apiVersion in 18 19; do
-        sdkmanager --uninstall "platforms;android-${apiVersion}" > /dev/null
-      done
-      echo y | sdkmanager "build-tools;${SDK_VERSION}" >/dev/null
+      export TOOLS=${ANDROID_HOME}/tools
+      curl -o "${HOME}/sdk.zip" https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+      rm -rf "${TOOLS}"
+      unzip -o "${HOME}/sdk.zip" -d "$ANDROID_HOME" > /dev/null
+      rm -f "${HOME}/sdk.zip"
       echo y | sdkmanager --update > /dev/null
-      echo y | sdkmanager "platforms;${EMU_TARGET}" > /dev/null
-      echo y | sdkmanager "platforms;android-${API_VERSION}" >/dev/null
-      echo y | sdkmanager "extras;android;m2repository" > /dev/null
+      echo y | sdkmanager "platform-tools" "build-tools;${SDK_VERSION}" "platforms;${EMU_TARGET}" "platforms;android-${API_VERSION}" "extras;android;m2repository" > /dev/null
       echo y | sdkmanager --channel=3 "emulator" >/dev/null
       export EMU_IMAGE="system-images;${EMU_TARGET};${EMU_TAG};${EMU_ABI}"
       for retry in 1 2 3; do
@@ -68,40 +64,21 @@ before_install:
         sleep 5
       done
       sdkmanager --list
-      export TOOLS=${ANDROID_HOME}/tools
       export PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
       echo no | avdmanager create avd -k "${EMU_IMAGE}" -n "${EMU_NAME}" -f --abi "${EMU_ABI}" --tag "${EMU_TAG}" || exit 1
-      emulator -avd "${EMU_NAME}" -no-accel -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048 &
+      emulator -avd "${EMU_NAME}" -gpu swiftshader_indirect -no-accel -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048 &
     fi
 install:
   # node stuff
-  - nvm install 10.15
+  - nvm install $NODE_VERSION
 
   # npm stuff
   - npm install
+  - npm install appium-test-support
 before_script:
   - |
-    if [ ${START_EMU} = "1" ]; then
-      # Fail fast if emulator process cannot start
-      pgrep -nf avd || exit 1
-      # make sure the emulator is ready
-      adb wait-for-device get-serialno
-      secondsStarted=`date +%s`
-      TIMEOUT=360
-      while [[ $(( `date +%s` - $secondsStarted )) -lt $TIMEOUT ]]; do
-        processList=`adb shell ps`
-        if [[ "$processList" =~ "com.android.systemui" ]]; then
-          echo "System UI process is running. Checking IME services availability"
-          adb shell ime list && break
-        fi
-        sleep 5
-        secondsElapsed=$(( `date +%s` - $secondsStarted ))
-        secondsLeft=$(( $TIMEOUT - $secondsElapsed ))
-        echo "Waiting until emulator finishes services startup; ${secondsElapsed}s elapsed; ${secondsLeft}s left"
-      done
-      bootDuration=$(( `date +%s` - $secondsStarted ))
-      echo "Emulator booting took ${bootDuration}s"
-      adb shell input keyevent 82
+    if [[ "${START_EMU}" == "1" ]]; then
+      $(npm bin)/android-emu-travis-post
     fi
 script:
   - npm run lint && npm run mocha -- -t $MOCHA_TIMEOUT -R spec $RECURSIVE build/test/$TEST -i -g @skip-ci

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -193,7 +193,9 @@ function buildStartCmd (startAppOptions, apiLevel) {
   if (waitForLaunch) {
     cmd.push('-W');
   }
-  cmd.push('-n', `${pkg}/${activity}`);
+  if (activity && pkg) {
+    cmd.push('-n', `${pkg}/${activity}`);
+  }
   if (stopApp && apiLevel >= 15) {
     cmd.push('-S');
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -78,8 +78,11 @@ apkUtilsMethods.startUri = async function startUri (uri, pkg) {
 
 /**
  * @typedef {Object} StartAppOptions
- * @property {!string} activity - The name of the main application activity
  * @property {!string} pkg - The name of the application package
+ * @property {?string} activity - The name of the main application activity.
+ * This or action is required in order to be able to launch an app.
+ * @property {?string} action - The name of the intent action that will launch the required app.
+ * This or activity is required in order to be able to launch an app.
  * @property {?boolean} retry [true] - If this property is set to `true`
  * and the activity name does not start with '.' then the method
  * will try to add the missing dot and start the activity once more
@@ -107,11 +110,8 @@ apkUtilsMethods.startUri = async function startUri (uri, pkg) {
  * @throws {Error} If there is an error while executing the activity
  */
 apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
-  const hasAppAndPkg = startAppOptions.activity && startAppOptions.pkg;
-  const hasIntent = startAppOptions.action;
-
-  if (!hasAppAndPkg && !hasIntent) {
-    throw new Error('activity and pkg, or intent, are required to start an application');
+  if (!startAppOptions.pkg || !(startAppOptions.activity || startAppOptions.action)) {
+    throw new Error('pkg, and activity or intent action, are required to start an application');
   }
 
   startAppOptions = _.clone(startAppOptions);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -131,6 +131,7 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
 
   const apiLevel = await this.getApiLevel();
   const cmd = buildStartCmd(startAppOptions, apiLevel);
+  const intentName = `${startAppOptions.action}${startAppOptions.optionalIntentArguments ? ' ' + startAppOptions.optionalIntentArguments : ''}`;
   try {
     const shellOpts = {};
     if (_.isInteger(startAppOptions.waitDuration) && startAppOptions.waitDuration > 20000) {
@@ -148,10 +149,6 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
       throw new Error(`Activity name '${startAppOptions.activity}' used to start the app doesn't ` +
                       `exist or cannot be launched! Make sure it exists and is a launchable activity`);
     } else if (stdout.includes('Error: Intent does not match any activities') || stdout.includes('Error: Activity not started, unable to resolve Intent')) {
-      let intentName = startAppOptions.action;
-      if (startAppOptions.optionalIntentArguments) {
-        intentName += ` ${startAppOptions.optionalIntentArguments}`;
-      }
       throw new Error(`Activity for intent '${intentName}' used to start the app doesn't ` +
                       `exist or cannot be launched! Make sure it exists and is a launchable activity`);
     } else if (stdout.includes('java.lang.SecurityException')) {
@@ -164,7 +161,7 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
     }
     return stdout;
   } catch (e) {
-    const appDescriptor = startAppOptions.pkg || `${startAppOptions.action} ${startAppOptions.optionalIntentArguments}`;
+    const appDescriptor = startAppOptions.pkg || intentName;
     throw new Error(`Cannot start the '${appDescriptor}' application. ` +
       `Visit ${ACTIVITIES_TROUBLESHOOTING_LINK} for troubleshooting. ` +
       `Original error: ${e.message}`);

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -108,7 +108,7 @@ apkUtilsMethods.startUri = async function startUri (uri, pkg) {
  */
 apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
   const hasAppAndPkg = startAppOptions.activity && startAppOptions.pkg;
-  const hasIntent = startAppOptions.optionalIntentArguments && startAppOptions.action;
+  const hasIntent = startAppOptions.action;
 
   if (!hasAppAndPkg && !hasIntent) {
     throw new Error('activity and pkg, or intent, are required to start an application');
@@ -146,6 +146,9 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
         return await this.startApp(startAppOptions);
       }
       throw new Error(`Activity name '${startAppOptions.activity}' used to start the app doesn't ` +
+                      `exist or cannot be launched! Make sure it exists and is a launchable activity`);
+    } else if (stdout.includes('Error: Intent does not match any activities')) {
+      throw new Error(`Activity for intent '${startAppOptions.action} ${startAppOptions.optionalIntentArguments}' used to start the app doesn't ` +
                       `exist or cannot be launched! Make sure it exists and is a launchable activity`);
     } else if (stdout.includes('java.lang.SecurityException')) {
       // if the app is disabled on a real device it will throw a security exception

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -157,7 +157,8 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
     }
     return stdout;
   } catch (e) {
-    throw new Error(`Cannot start the '${startAppOptions.pkg}' application. ` +
+    const appDescriptor = startAppOptions.pkg || `${startAppOptions.action} ${startAppOptions.optionalIntentArguments}`;
+    throw new Error(`Cannot start the '${appDescriptor}' application. ` +
       `Visit ${ACTIVITIES_TROUBLESHOOTING_LINK} for troubleshooting. ` +
       `Original error: ${e.message}`);
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -147,8 +147,12 @@ apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
       }
       throw new Error(`Activity name '${startAppOptions.activity}' used to start the app doesn't ` +
                       `exist or cannot be launched! Make sure it exists and is a launchable activity`);
-    } else if (stdout.includes('Error: Intent does not match any activities')) {
-      throw new Error(`Activity for intent '${startAppOptions.action} ${startAppOptions.optionalIntentArguments}' used to start the app doesn't ` +
+    } else if (stdout.includes('Error: Intent does not match any activities') || stdout.includes('Error: Activity not started, unable to resolve Intent')) {
+      let intentName = startAppOptions.action;
+      if (startAppOptions.optionalIntentArguments) {
+        intentName += ` ${startAppOptions.optionalIntentArguments}`;
+      }
+      throw new Error(`Activity for intent '${intentName}' used to start the app doesn't ` +
                       `exist or cannot be launched! Make sure it exists and is a launchable activity`);
     } else if (stdout.includes('java.lang.SecurityException')) {
       // if the app is disabled on a real device it will throw a security exception

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -107,12 +107,17 @@ apkUtilsMethods.startUri = async function startUri (uri, pkg) {
  * @throws {Error} If there is an error while executing the activity
  */
 apkUtilsMethods.startApp = async function startApp (startAppOptions = {}) {
-  if (!startAppOptions.activity || !startAppOptions.pkg) {
-    throw new Error('activity and pkg are required to start an application');
+  const hasAppAndPkg = startAppOptions.activity && startAppOptions.pkg;
+  const hasIntent = startAppOptions.optionalIntentArguments && startAppOptions.action;
+
+  if (!hasAppAndPkg && !hasIntent) {
+    throw new Error('activity and pkg, or intent, are required to start an application');
   }
 
   startAppOptions = _.clone(startAppOptions);
-  startAppOptions.activity = startAppOptions.activity.replace('$', '\\$');
+  if (startAppOptions.activity) {
+    startAppOptions.activity = startAppOptions.activity.replace('$', '\\$');
+  }
   // initializing defaults
   _.defaults(startAppOptions, {
     waitPkg: startAppOptions.pkg,

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -83,7 +83,8 @@ describe('apk utils', function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
         action: 'android.intent.action.WEB_SEARCH',
-        waitDuration: START_APP_WAIT_DURATION,
+        pkg: 'com.google.android.googlequicksearchbox',
+        waitDuration: MOCHA_LONG_TIMEOUT,
         stopApp: false
       });
       let {appPackage} = await adb.getFocusedPackageAndActivity();
@@ -95,7 +96,7 @@ describe('apk utils', function () {
       await adb.startApp({
         action: 'android.intent.action.DEFAULT',
         optionalIntentArguments: '-d tel:555-5555',
-        waitDuration: START_APP_WAIT_DURATION,
+        waitDuration: MOCHA_LONG_TIMEOUT,
         stopApp: false
       }).should.eventually.be.rejectedWith(/Cannot start the .* application/);
     });

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -29,7 +29,7 @@ describe('apk utils', function () {
 
   before(async function () {
     adb = await ADB.createADB({
-      adbExecTimeout: (process.env.TRAVIS || process.env.CI) ? MOCHA_LONG_TIMEOUT : 40000,
+      adbExecTimeout: (process.env.TRAVIS || process.env.CI) ? 60000 : 40000,
     });
   });
   it('should be able to check status of third party app', async function () {

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -95,6 +95,7 @@ describe('apk utils', function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
         action: 'android.intent.action.DEFAULT',
+        pkg: 'com.google.android.telephony',
         optionalIntentArguments: '-d tel:555-5555',
         waitDuration: MOCHA_LONG_TIMEOUT,
         stopApp: false

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -4,7 +4,7 @@ import ADB from '../..';
 import path from 'path';
 import { rootDir } from '../../lib/helpers.js';
 import { retryInterval } from 'asyncbox';
-import { MOCHA_TIMEOUT, apiLevel } from './setup';
+import { MOCHA_TIMEOUT, MOCHA_LONG_TIMEOUT, apiLevel } from './setup';
 
 const START_APP_WAIT_DURATION = 60000;
 const START_APP_WAIT_DURATION_FAIL = 10000;
@@ -79,6 +79,7 @@ describe('apk utils', function () {
 
     });
     it('should be able to start with an intent and no activity', async function () {
+      this.timeout(MOCHA_LONG_TIMEOUT);
       await adb.install(contactManagerPath);
       await adb.startApp({
         action: 'android.intent.action.WEB_SEARCH',
@@ -89,6 +90,7 @@ describe('apk utils', function () {
       appPackage.should.equal('com.google.android.googlequicksearchbox');
     });
     it('should throw an error for unknown activity for intent', async function () {
+      this.timeout(MOCHA_LONG_TIMEOUT);
       await adb.install(contactManagerPath);
       await adb.startApp({
         action: 'android.intent.action.DEFAULT',

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -81,13 +81,12 @@ describe('apk utils', function () {
     it('should be able to start with an intent and no activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
-        action: 'android.intent.action.DIAL',
-        optionalIntentArguments: '-d tel:555-5555',
+        action: 'android.intent.action.WEB_SEARCH',
         waitDuration: START_APP_WAIT_DURATION
       });
       let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
-      appPackage.should.equal('com.android.dialer');
-      appActivity.should.equal('.main.impl.MainActivity');
+      appPackage.should.equal('com.google.android.googlequicksearchbox');
+      appActivity.should.equal('com.google.android.apps.gsa.searchnow.SearchNowActivity');
     });
     it('should throw an error for unknown activity for intent', async function () {
       await adb.install(contactManagerPath);

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -78,19 +78,25 @@ describe('apk utils', function () {
       await assertPackageAndActivity();
 
     });
-
     it('should be able to start with an intent and no activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
-        action: 'android.intent.action.VIEW',
-        optionalIntentArguments: '-d content://com.android.contacts/contacts',
-        waitDuration: START_APP_WAIT_DURATION,
+        action: 'android.intent.action.DIAL',
+        optionalIntentArguments: '-d tel:555-5555',
+        waitDuration: START_APP_WAIT_DURATION
       });
       let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
-      appPackage.should.equal('com.android.contacts');
-      appActivity.should.equal('.activities.PeopleActivity');
+      appPackage.should.equal('com.android.dialer');
+      appActivity.should.equal('.main.impl.MainActivity');
     });
-
+    it('should throw an error for unknown activity for intent', async function () {
+      await adb.install(contactManagerPath);
+      await adb.startApp({
+        action: 'android.intent.action.DEFAULT',
+        optionalIntentArguments: '-d tel:555-5555',
+        waitDuration: START_APP_WAIT_DURATION
+      }).should.eventually.be.rejectedWith(/Cannot start the .* application/);
+    });
     it('should throw error for wrong activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -82,18 +82,19 @@ describe('apk utils', function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
         action: 'android.intent.action.WEB_SEARCH',
-        waitDuration: START_APP_WAIT_DURATION
+        waitDuration: START_APP_WAIT_DURATION,
+        stopApp: false
       });
-      let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
+      let {appPackage} = await adb.getFocusedPackageAndActivity();
       appPackage.should.equal('com.google.android.googlequicksearchbox');
-      appActivity.should.equal('com.google.android.apps.gsa.searchnow.SearchNowActivity');
     });
     it('should throw an error for unknown activity for intent', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
         action: 'android.intent.action.DEFAULT',
         optionalIntentArguments: '-d tel:555-5555',
-        waitDuration: START_APP_WAIT_DURATION
+        waitDuration: START_APP_WAIT_DURATION,
+        stopApp: false
       }).should.eventually.be.rejectedWith(/Cannot start the .* application/);
     });
     it('should throw error for wrong activity', async function () {

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -68,7 +68,7 @@ describe('apk utils', function () {
     });
   });
   describe('startApp', function () {
-    it('should be able to start', async function () {
+    it('should be able to start with normal package and activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
         pkg: 'com.example.android.contactmanager',
@@ -78,6 +78,21 @@ describe('apk utils', function () {
       await assertPackageAndActivity();
 
     });
+
+    it('should be able to start with an intent and no activity', async function () {
+      await adb.install(contactManagerPath);
+      await adb.startApp({
+        pkg: 'com.example.android.contactmanager',
+        category: 'android.intent.category.DEFAULT',
+        action: 'android.intent.action.VIEW',
+        optionalIntentArguments: '-d content://com.android.contacts/contacts',
+        waitDuration: START_APP_WAIT_DURATION,
+      });
+      let {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
+      appPackage.should.equal('com.android.contacts');
+      appActivity.should.equal('.activities.PeopleActivity');
+    });
+
     it('should throw error for wrong activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -29,7 +29,7 @@ describe('apk utils', function () {
 
   before(async function () {
     adb = await ADB.createADB({
-      adbExecTimeout: (process.env.TRAVIS || process.env.CI) ? 60000 : 40000,
+      adbExecTimeout: (process.env.TRAVIS || process.env.CI) ? MOCHA_LONG_TIMEOUT : 40000,
     });
   });
   it('should be able to check status of third party app', async function () {

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -82,7 +82,6 @@ describe('apk utils', function () {
     it('should be able to start with an intent and no activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
-        pkg: 'com.android.contacts',
         action: 'android.intent.action.VIEW',
         optionalIntentArguments: '-d content://com.android.contacts/contacts',
         waitDuration: START_APP_WAIT_DURATION,

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -82,8 +82,7 @@ describe('apk utils', function () {
     it('should be able to start with an intent and no activity', async function () {
       await adb.install(contactManagerPath);
       await adb.startApp({
-        pkg: 'com.example.android.contactmanager',
-        category: 'android.intent.category.DEFAULT',
+        pkg: 'com.android.contacts',
         action: 'android.intent.action.VIEW',
         optionalIntentArguments: '-d content://com.android.contacts/contacts',
         waitDuration: START_APP_WAIT_DURATION,

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -84,7 +84,8 @@ describe('apk utils', function () {
       await adb.startApp({
         action: 'android.intent.action.WEB_SEARCH',
         pkg: 'com.google.android.googlequicksearchbox',
-        waitDuration: MOCHA_LONG_TIMEOUT,
+        optionalIntentArguments: '-e query foo',
+        waitDuration: START_APP_WAIT_DURATION,
         stopApp: false
       });
       let {appPackage} = await adb.getFocusedPackageAndActivity();
@@ -97,7 +98,7 @@ describe('apk utils', function () {
         action: 'android.intent.action.DEFAULT',
         pkg: 'com.google.android.telephony',
         optionalIntentArguments: '-d tel:555-5555',
-        waitDuration: MOCHA_LONG_TIMEOUT,
+        waitDuration: START_APP_WAIT_DURATION,
         stopApp: false
       }).should.eventually.be.rejectedWith(/Cannot start the .* application/);
     });

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -89,7 +89,12 @@ describe('apk utils', function () {
         stopApp: false
       });
       let {appPackage} = await adb.getFocusedPackageAndActivity();
-      appPackage.should.equal('com.google.android.googlequicksearchbox');
+      const expectedPkgPossibilities = [
+        'com.android.browser',
+        'org.chromium.webview_shell',
+        'com.google.android.googlequicksearchbox'
+      ];
+      expectedPkgPossibilities.should.include(appPackage);
     });
     it('should throw an error for unknown activity for intent', async function () {
       this.timeout(MOCHA_LONG_TIMEOUT);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -464,6 +464,23 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .returns('');
       (await adb.startApp(startAppOptions));
     });
+    it('should call getApiLevel and shell with correct arguments when activity is intent', async function () {
+      const startAppOptionsWithIntent = {
+        pkg: 'pkg',
+        action: 'android.intent.action.VIEW',
+        category: 'android.intent.category.DEFAULT',
+        optionalIntentArguments: '-d scheme://127.0.0.1'
+      };
+      const cmdWithIntent = ['am', 'start', '-W', '-S', '-a', 'android.intent.action.VIEW', '-c', 'android.intent.category.DEFAULT', '-d', 'scheme://127.0.0.1'];
+
+      mocks.adb.expects('getApiLevel')
+        .once().withExactArgs()
+        .returns(17);
+      mocks.adb.expects('shell')
+        .once().withArgs(cmdWithIntent)
+        .returns('');
+      (await adb.startApp(startAppOptionsWithIntent));
+    });
     it('should call getApiLevel and shell with correct arguments when activity is inner class', async function () {
       const startAppOptionsWithInnerClass = { pkg: 'pkg', activity: 'act$InnerAct'},
             cmdWithInnerClass = ['am', 'start', '-W', '-n', 'pkg/act\\$InnerAct', '-S'];

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -481,6 +481,27 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .returns('');
       (await adb.startApp(startAppOptionsWithIntent));
     });
+    it('should throw error when action provided, but pkg not provided', async function () {
+      const startAppOptionsWithoutPkg = {
+        action: 'android.intent.action.VIEW'
+      };
+      await adb.startApp(startAppOptionsWithoutPkg).should.eventually.be.rejectedWith(
+        `pkg, and activity or intent action, are required to start an application`);
+    });
+    it('should throw error when activity provided, but pkg not provided', async function () {
+      const startAppOptionsWithoutPkg = {
+        activity: '.MainActivity'
+      };
+      await adb.startApp(startAppOptionsWithoutPkg).should.eventually.be.rejectedWith(
+        `pkg, and activity or intent action, are required to start an application`);
+    });
+    it('should throw error when neither action nor activity provided', async function () {
+      const startAppOptionsWithoutActivityOrAction = {
+        pkg: 'pkg'
+      };
+      await adb.startApp(startAppOptionsWithoutActivityOrAction).should.eventually.be.rejectedWith(
+        `pkg, and activity or intent action, are required to start an application`);
+    });
     it('should call getApiLevel and shell with correct arguments when activity is inner class', async function () {
       const startAppOptionsWithInnerClass = { pkg: 'pkg', activity: 'act$InnerAct'},
             cmdWithInnerClass = ['am', 'start', '-W', '-n', 'pkg/act\\$InnerAct', '-S'];


### PR DESCRIPTION
Hi there,

I raised [an issue](https://github.com/appium/appium/issues/13628) around starting apps with just intents and I think currently it's not possible to launch an android app with just an intent in the desired capabilities; this PR should allow you to do that. I know it's possible to do it with a `mobile:deeplink` command at the moment, but if I want to run this against multiple configs where some can be launched directly with a pkg/activity, then I have to special case the code, and it would be great to keep that encapsulated in the desired capabilities.

I've just used what was already there, but changed the validation to allow you to call `startApp` with `intentAction` and `optionalIntentArgs` even when there isn't an activity provided. 

This works for me (though you do have to explicitly set the category for it to work), and allows me to launch my expo app with just the intent (previously `adb` would use the package and the intent ends up getting ignored as far as I can tell). 

I did want to flag that I'm not sure the error messaging when the app doesn't start correctly is right;  I'm happy to fix that if you could provide a little bit of guidance on how to change it, assuming the rest seems OK.