### PR TITLE
fix: Ignore 'Unknown permission' error for batch permission changes

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1,6 +1,8 @@
 import log from '../logger.js';
-import { getIMEListFromOutput, isShowingLockscreen, isCurrentFocusOnKeyguard,
-         getSurfaceOrientation, isScreenOnFully, extractMatchingPermissions } from '../helpers.js';
+import {
+  getIMEListFromOutput, isShowingLockscreen, isCurrentFocusOnKeyguard,
+  getSurfaceOrientation, isScreenOnFully, extractMatchingPermissions
+} from '../helpers.js';
 import path from 'path';
 import _ from 'lodash';
 import { fs, util } from 'appium-support';
@@ -29,7 +31,11 @@ const CLIPBOARD_RECEIVER = `${SETTINGS_HELPER_ID}/.receivers.ClipboardReceiver`;
 const CLIPBOARD_RETRIEVAL_ACTION = `${SETTINGS_HELPER_ID}.clipboard.get`;
 const APPIUM_IME = `${SETTINGS_HELPER_ID}/.AppiumIME`;
 const MAX_SHELL_BUFFER_LENGTH = 1000;
-const NOT_CHANGEABLE_PERM_ERROR = 'not a changeable permission type';
+const NOT_CHANGEABLE_PERM_ERROR = /not a changeable permission type/i;
+const IGNORED_PERM_ERRORS = [
+  NOT_CHANGEABLE_PERM_ERROR,
+  /Unknown permission/i,
+];
 
 
 let methods = {};
@@ -273,7 +279,7 @@ methods.grantPermissions = async function grantPermissions (pkg, permissions) {
     } catch (e) {
       // this is to give the method a chance to assign all the requested permissions
       // before to quit in case we'd like to ignore the error on the higher level
-      if (!e.message.includes(NOT_CHANGEABLE_PERM_ERROR)) {
+      if (!IGNORED_PERM_ERRORS.some((msgRegex) => msgRegex.test(e.stderr || e.message))) {
         lastError = e;
       }
     }
@@ -293,9 +299,9 @@ methods.grantPermissions = async function grantPermissions (pkg, permissions) {
 methods.grantPermission = async function grantPermission (pkg, permission) {
   try {
     await this.shell(['pm', 'grant', pkg, permission]);
-  } catch (error) {
-    if (!error.message.includes(NOT_CHANGEABLE_PERM_ERROR)) {
-      throw error;
+  } catch (e) {
+    if (!NOT_CHANGEABLE_PERM_ERROR.test(e.stderr || e.message)) {
+      throw e;
     }
   }
 };
@@ -310,9 +316,9 @@ methods.grantPermission = async function grantPermission (pkg, permission) {
 methods.revokePermission = async function revokePermission (pkg, permission) {
   try {
     await this.shell(['pm', 'revoke', pkg, permission]);
-  } catch (error) {
-    if (!error.message.includes(NOT_CHANGEABLE_PERM_ERROR)) {
-      throw error;
+  } catch (e) {
+    if (!NOT_CHANGEABLE_PERM_ERROR.test(e.stderr || e.message)) {
+      throw e;
     }
   }
 };


### PR DESCRIPTION
Addresses https://discuss.appium.io/t/unable-to-launch-an-already-installed-app-through-appium/28853

This error happens if application manifest contains permissions constants, which are only available for newer Android versions while being tested on older APIs