### PR TITLE
chore: Bump the cached application time stamp if needed

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -420,8 +420,13 @@ apkUtilsMethods.cacheApk = async function cacheApk (apkPath, options = {}) {
   log.debug(`The count of applications in the cache: ${remoteCachedFiles.length}`);
   const toHash = (remotePath) => path.posix.parse(remotePath).name;
   // Push the apk to the remote cache if needed
-  if (remoteCachedFiles.find((x) => toHash(x) === appHash)) {
+  if (remoteCachedFiles.some((x) => toHash(x) === appHash)) {
     log.info(`The application at '${apkPath}' is already cached to '${remotePath}'`);
+    try {
+      // Update the application timestamp in order to bump its position
+      // in the sorted ls output
+      await this.shell(['touch', '-am', remotePath]);
+    } catch (ign) {}
   } else {
     log.info(`Caching the application at '${apkPath}' to '${remotePath}'`);
     const started = process.hrtime();

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -422,11 +422,10 @@ apkUtilsMethods.cacheApk = async function cacheApk (apkPath, options = {}) {
   // Push the apk to the remote cache if needed
   if (remoteCachedFiles.some((x) => toHash(x) === appHash)) {
     log.info(`The application at '${apkPath}' is already cached to '${remotePath}'`);
-    try {
-      // Update the application timestamp in order to bump its position
-      // in the sorted ls output
-      await this.shell(['touch', '-am', remotePath]);
-    } catch (ign) {}
+    // Update the application timestamp asynchronously in order to bump its position
+    // in the sorted ls output
+    this.shell(['touch', '-am', remotePath])
+      .catch(() => {});
   } else {
     log.info(`Caching the application at '${apkPath}' to '${remotePath}'`);
     const started = process.hrtime();

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -5,6 +5,7 @@ import { fs } from 'appium-support';
 import ADB from '../..';
 import { withMocks } from 'appium-test-support';
 import _ from 'lodash';
+import B from 'bluebird';
 import { REMOTE_CACHE_ROOT } from '../../lib/tools/apk-utils';
 import apksUtilsMethods from '../../lib/tools/apks-utils';
 
@@ -339,6 +340,10 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
           .map((x) => `${x}.apk`)
           .join('\r\n')
         );
+      mocks.adb.expects('shell')
+        .once()
+        .withExactArgs(['touch', '-am', '/data/local/tmp/appium_cache/1.apk'])
+        .returns(B.resolve());
       mocks.fs.expects('hash')
         .withExactArgs(apkPath)
         .returns('1');


### PR DESCRIPTION
It makes sense to update the timestamp of the cached file if the file has been reused, so it does not get deleted because its position in the sorted ls output would be too close to the bottom