### PR TITLE
feat: Return API Level 30 for Android R preview

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -87,11 +87,13 @@ methods.getApiLevel = async function getApiLevel () {
       let apiLevel = parseInt(strOutput.trim(), 10);
 
       // Workaround for preview/beta platform API level
-      const asciiq = 113; // 113 is the code point of 'q'
-      const apiLevelDiff = apiLevel - 28; // 28 is the first API Level getPlatformVersion() returns alphabet
-      if (apiLevelDiff >= 0 && (await this.getPlatformVersion()).toLowerCase() === String.fromCharCode(asciiq + apiLevelDiff)) {
-        log.debug(`Release version is ${String.fromCharCode(asciiq + apiLevelDiff).toUpperCase()} but found API Level ${apiLevel}. Setting API Level to ${apiLevel + 1}`);
-        apiLevel += 1;
+      const charCodeQ = 'q'.charCodeAt(0);
+      // 28 is the first API Level, where Android SDK started returning letters in response to getPlatformVersion
+      const apiLevelDiff = apiLevel - 28;
+      const codename = String.fromCharCode(charCodeQ + apiLevelDiff);
+      if (apiLevelDiff >= 0 && (await this.getPlatformVersion()).toLowerCase() === codename) {
+        log.debug(`Release version is ${codename.toUpperCase()} but found API Level ${apiLevel}. Setting API Level to ${apiLevel + 1}`);
+        apiLevel++;
       }
 
       this._apiLevel = apiLevel;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -87,12 +87,11 @@ methods.getApiLevel = async function getApiLevel () {
       let apiLevel = parseInt(strOutput.trim(), 10);
 
       // Workaround for preview/beta platform API level
-      if (apiLevel === 28 && (await this.getPlatformVersion()).toLowerCase() === 'q') {
-        log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
-        apiLevel = 29;
-      } else if (apiLevel === 29 && (await this.getPlatformVersion()).toLowerCase() === 'r') {
-        log.debug('Release version is R but found API Level 29. Setting API Level to 30');
-        apiLevel = 30;
+      const asciiq = 113; // 113 is the code point of 'q'
+      const apiLevelDiff = apiLevel - 28; // 28 is the first API Level getPlatformVersion() returns alphabet
+      if (apiLevelDiff >= 0 && (await this.getPlatformVersion()).toLowerCase() === String.fromCharCode(asciiq + apiLevelDiff)) {
+        log.debug(`Release version is ${String.fromCharCode(asciiq + apiLevelDiff).toUpperCase()} but found API Level ${apiLevel}. Setting API Level to ${apiLevel + 1}`);
+        apiLevel += 1;
       }
 
       this._apiLevel = apiLevel;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -86,11 +86,18 @@ methods.getApiLevel = async function getApiLevel () {
       const strOutput = await this.getDeviceProperty('ro.build.version.sdk');
       let apiLevel = parseInt(strOutput.trim(), 10);
 
-      // Temp workaround. Android Q beta emulators report SDK 28 when they should be 29
-      if (apiLevel === 28 && (await this.getDeviceProperty('ro.build.version.release')).toLowerCase() === 'q') {
-        log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
-        apiLevel = 29;
+      // Workaround for preview/beta platform API level
+      if (apiLevel === 28 || apiLevel === 29) {
+        const platform_version = (await this.getPlatformVersion()).toLowerCase();
+        if (apiLevel === 28 && platform_version === 'q') {
+          log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
+          apiLevel = 29;
+        } else if (apiLevel === 29 && platform_version === 'r') {
+          log.debug('Release version is R but found API Level 29. Setting API Level to 30');
+          apiLevel = 30;
+        }
       }
+
       this._apiLevel = apiLevel;
       log.debug(`Device API level: ${this._apiLevel}`);
       if (isNaN(this._apiLevel)) {

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -87,15 +87,12 @@ methods.getApiLevel = async function getApiLevel () {
       let apiLevel = parseInt(strOutput.trim(), 10);
 
       // Workaround for preview/beta platform API level
-      if (apiLevel === 28 || apiLevel === 29) {
-        const platform_version = (await this.getPlatformVersion()).toLowerCase();
-        if (apiLevel === 28 && platform_version === 'q') {
-          log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
-          apiLevel = 29;
-        } else if (apiLevel === 29 && platform_version === 'r') {
-          log.debug('Release version is R but found API Level 29. Setting API Level to 30');
-          apiLevel = 30;
-        }
+      if (apiLevel === 28 && (await this.getPlatformVersion()).toLowerCase() === 'q') {
+        log.debug('Release version is Q but found API Level 28. Setting API Level to 29');
+        apiLevel = 29;
+      } else if (apiLevel === 29 && (await this.getPlatformVersion()).toLowerCase() === 'r') {
+        log.debug('Release version is R but found API Level 29. Setting API Level to 30');
+        apiLevel = 30;
       }
 
       this._apiLevel = apiLevel;

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -55,6 +55,26 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
           .returns(`${apiLevel}`);
         (await adb.getApiLevel()).should.equal(apiLevel);
       });
+      it('should call shell with correct args with Q preview device', async function () {
+        adb._apiLevel = null;
+        mocks.adb.expects('getDeviceProperty')
+          .once().withExactArgs('ro.build.version.sdk')
+          .returns('28');
+        mocks.adb.expects('getDeviceProperty')
+          .once().withExactArgs('ro.build.version.release')
+          .returns('q');
+        (await adb.getApiLevel()).should.equal(29);
+      });
+      it('should call shell with correct args with R preview device', async function () {
+        adb._apiLevel = null;
+        mocks.adb.expects('getDeviceProperty')
+          .once().withExactArgs('ro.build.version.sdk')
+          .returns('29');
+        mocks.adb.expects('getDeviceProperty')
+          .once().withExactArgs('ro.build.version.release')
+          .returns('R');
+        (await adb.getApiLevel()).should.equal(30);
+      });
     });
     describe('getPlatformVersion', function () {
       it('should call shell with correct args', async function () {


### PR DESCRIPTION
`getPlatformVersion` returns 29 in Android R preview, although the version should be for Android Q.
In Android Q, the returned value became from 28 to 29 in middle or later beta. Thus, I predict R also will be 30, but for now, let's add a workaround the same as Android Q case for Android R preview.