### PR TITLE
feat: add allowOfflineDevices capability

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -29,6 +29,7 @@ const DEFAULT_OPTS = {
   adbExecTimeout: DEFAULT_ADB_EXEC_TIMEOUT,
   remoteAppsCacheLimit: 10,
   buildToolsVersion: null,
+  allowOfflineDevices: false,
 };
 
 class ADB {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -169,7 +169,10 @@ systemCallMethods.getConnectedDevices = async function getConnectedDevices () {
   }
   // slicing output we care about
   stdout = stdout.slice(startingIndex);
-  const excludedLines = [listHeader, 'adb server', '* daemon', 'offline'];
+  let excludedLines = [listHeader, 'adb server', '* daemon'];
+  if (!this.allowOfflineDevices) {
+    excludedLines.push('offline');
+  }
   const devices = stdout.split('\n')
     .map(_.trim)
     .filter((line) => line && !excludedLines.some((x) => line.includes(x)))
@@ -196,29 +199,24 @@ systemCallMethods.getConnectedDevices = async function getConnectedDevices () {
  * @throws {Error} If no connected devices can be detected within the given timeout.
  */
 systemCallMethods.getDevicesWithRetry = async function getDevicesWithRetry (timeoutMs = 20000) {
-  let start = Date.now();
+  const timer = new timing.Timer().start();
   log.debug('Trying to find a connected android device');
-  let getDevices = async () => {
-    if ((Date.now() - start) > timeoutMs) {
-      throw new Error('Could not find a connected Android device.');
+  const getDevices = async () => {
+    if (timer.getDuration().asMilliSeconds > timeoutMs) {
+      throw new Error(`Could not find a connected Android device in ${timer.getDuration().asMilliSeconds.toFixed(0)}ms.`);
     }
     try {
-      let devices = await this.getConnectedDevices();
-      if (devices.length < 1) {
-        log.debug('Could not find devices, restarting adb server...');
-        await this.restartAdb();
-        // cool down
-        await sleep(200);
-        return await getDevices();
+      const devices = await this.getConnectedDevices();
+      if (devices.length > 0) {
+        return devices;
       }
-      return devices;
-    } catch (e) {
-      log.debug('Could not find devices, restarting adb server...');
-      await this.restartAdb();
-      // cool down
-      await sleep(200);
-      return await getDevices();
-    }
+    } catch (ign) {}
+
+    log.debug('Could not find devices, restarting adb server...');
+    await this.restartAdb();
+    // cool down
+    await sleep(200);
+    return await getDevices();
   };
   return await getDevices();
 };
@@ -244,7 +242,7 @@ systemCallMethods.restartAdb = async function restartAdb () {
  * Kill adb server.
  */
 systemCallMethods.killServer = async function killServer () {
-  log.debug(`Killing adb server on port ${this.adbPort}`);
+  log.debug(`Killing adb server on port '${this.adbPort}'`);
   await this.adbExec(['kill-server'], {
     exclusive: true,
   });


### PR DESCRIPTION
Sometimes (as in the `appium-uiautomator2-driver` tests) the device is there but reported as `'offline'`, though fully interactive. It seems to be when another adb server is/was running on a different port.

I'm not sure of the implications for this, so defaulting to `false`.