### PR TITLE
feat: Do not apply caching if the device under test supports streamed installs

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1607,7 +1607,7 @@ methods.getTimeZone = async function getTimeZone () {
  * ```
  * @throws {Error} if there was an error while retrieving the list
  */
-methods.listFeatures = async function listFeaures () {
+methods.listFeatures = async function listFeatures () {
   try {
     return (await this.adbExec(['features']))
       .split(/\s+/)

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1588,4 +1588,58 @@ methods.getTimeZone = async function getTimeZone () {
   }
 };
 
+/**
+ * Retrives the list of features supported by the device under test
+ *
+ * @returns {Array<string>} the list of supported feature names or an empty list.
+ * An example adb command output:
+ * ```
+ * cmd
+ * ls_v2
+ * fixed_push_mkdir
+ * shell_v2
+ * abb
+ * stat_v2
+ * apex
+ * abb_exec
+ * remount_shell
+ * fixed_push_symlink_timestamp
+ * ```
+ * @throws {Error} if there was an error while retrieving the list
+ */
+methods.listFeatures = async function listFeaures () {
+  try {
+    return (await this.adbExec(['features']))
+      .split(/\s+/)
+      .map((x) => x.trim())
+      .filter(Boolean);
+  } catch (e) {
+    if (_.includes(e.stderr, 'unknown command')) {
+      return [];
+    }
+    throw e;
+  }
+};
+
+/**
+ * Checks the state of streamed install feature.
+ * This feature allows to speed up apk installation
+ * since it does not require the original apk to be pushed to
+ * the device under test first, which also saves space.
+ * Although, it is required that both the device under test
+ * and the adb server have the mentioned functionality.
+ * See https://github.com/aosp-mirror/platform_system_core/blob/master/adb/client/adb_install.cpp
+ * for more details
+ *
+ * @returns {boolean} `true` if the feature is supported by both adb and the
+ * device under test
+ */
+methods.isStreamedInstallSupported = async function isStreamedInstallSupported () {
+  const isSupportedOnDevice = await this.listFeatures().includes('cmd');
+  if (_.isUndefined(this._isStreamedInstallSupported)) {
+    this._isStreamedInstallSupported = (await this.adbExec(['help'])).includes('--streaming');
+  }
+  return isSupportedOnDevice && this._isStreamedInstallSupported;
+};
+
 export default methods;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1635,11 +1635,10 @@ methods.listFeatures = async function listFeaures () {
  * device under test
  */
 methods.isStreamedInstallSupported = async function isStreamedInstallSupported () {
-  const isSupportedOnDevice = await this.listFeatures().includes('cmd');
-  if (_.isUndefined(this._isStreamedInstallSupported)) {
-    this._isStreamedInstallSupported = (await this.adbExec(['help'])).includes('--streaming');
+  if (!_.isBoolean(this._isStreamedInstallSupportedOnServer)) {
+    this._isStreamedInstallSupportedOnServer = (await this.adbExec(['help'])).includes('--streaming');
   }
-  return isSupportedOnDevice && this._isStreamedInstallSupported;
+  return this._isStreamedInstallSupportedOnServer && await this.listFeatures().includes('cmd');
 };
 
 export default methods;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1608,8 +1608,10 @@ methods.getTimeZone = async function getTimeZone () {
  * @throws {Error} if there was an error while retrieving the list
  */
 methods.listFeatures = async function listFeatures () {
+  this._memoizedFeatures = this._memoizedFeatures
+    || _.memoize(async () => await this.adbExec(['features']), () => this.curDeviceId);
   try {
-    return (await this.adbExec(['features']))
+    return (await this._memoizedFeatures())
       .split(/\s+/)
       .map((x) => x.trim())
       .filter(Boolean);
@@ -1635,10 +1637,9 @@ methods.listFeatures = async function listFeatures () {
  * device under test
  */
 methods.isStreamedInstallSupported = async function isStreamedInstallSupported () {
-  if (!_.isBoolean(this._isStreamedInstallSupportedOnServer)) {
-    this._isStreamedInstallSupportedOnServer = (await this.adbExec(['help'])).includes('--streaming');
-  }
-  return this._isStreamedInstallSupportedOnServer && (await this.listFeatures()).includes('cmd');
+  const proto = Object.getPrototypeOf(this);
+  proto._helpOutput = proto._helpOutput || await this.adbExec(['help']);
+  return proto._helpOutput.includes('--streaming') && (await this.listFeatures()).includes('cmd');
 };
 
 export default methods;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1638,7 +1638,7 @@ methods.isStreamedInstallSupported = async function isStreamedInstallSupported (
   if (!_.isBoolean(this._isStreamedInstallSupportedOnServer)) {
     this._isStreamedInstallSupportedOnServer = (await this.adbExec(['help'])).includes('--streaming');
   }
-  return this._isStreamedInstallSupportedOnServer && await this.listFeatures().includes('cmd');
+  return this._isStreamedInstallSupportedOnServer && (await this.listFeatures()).includes('cmd');
 };
 
 export default methods;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1589,7 +1589,7 @@ methods.getTimeZone = async function getTimeZone () {
 };
 
 /**
- * Retrives the list of features supported by the device under test
+ * Retrieves the list of features supported by the device under test
  *
  * @returns {Array<string>} the list of supported feature names or an empty list.
  * An example adb command output:

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -522,7 +522,15 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
   ];
   let performAppInstall = async () => await this.adbExec(installCmd, installOpts);
   // this.remoteAppsCacheLimit <= 0 means no caching should be applied
-  if (this.remoteAppsCacheLimit > 0) {
+  let shouldCacheApp = this.remoteAppsCacheLimit > 0;
+  if (shouldCacheApp) {
+    shouldCacheApp = !(await this.isStreamedInstallSupported());
+    if (!shouldCacheApp) {
+      log.info(`The application at '${appPath}' will not be cached, because the device under test has ` +
+        `confirmed the support of streamed installs`);
+    }
+  }
+  if (shouldCacheApp) {
     const clearCache = async () => {
       log.info(`Clearing the cache at '${REMOTE_CACHE_ROOT}'`);
       await this.shell(['rm', '-rf', `${REMOTE_CACHE_ROOT}/*`]);

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -265,4 +265,16 @@ describe('adb commands', function () {
     });
   });
 
+  describe('features', function () {
+    it('should return the features as a list', async function () {
+      _.isArray(await adb.listFeatures()).should.be.true;
+    });
+  });
+
+  describe('isStreamedInstallSupported', function () {
+    it('should return boolean value', async function () {
+      _.isBoolean(await adb.isStreamedInstallSupported()).should.be.true;
+    });
+  });
+
 });

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -6,6 +6,7 @@ import { rootDir } from '../../lib/helpers.js';
 import { apiLevel, platformVersion, MOCHA_TIMEOUT } from './setup';
 import { fs, mkdirp } from 'appium-support';
 import temp from 'temp';
+import _ from 'lodash';
 
 
 chai.should();

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -384,6 +384,8 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
   });
   describe('install', function () {
     it('should call shell with correct arguments', async function () {
+      mocks.adb.expects('isStreamedInstallSupported')
+        .once().returns(false);
       mocks.adb.expects('getApiLevel')
         .once().returns(23);
       mocks.adb.expects('cacheApk')
@@ -399,7 +401,24 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .returns('');
       await adb.install('foo');
     });
+    it('should not cache apk if streamed install is supported', async function () {
+      mocks.adb.expects('isStreamedInstallSupported')
+        .once().returns(true);
+      mocks.adb.expects('getApiLevel')
+        .once().returns(23);
+      mocks.adb.expects('cacheApk')
+        .never();
+      mocks.adb.expects('adbExec')
+        .once().withExactArgs(['install', '-r', 'foo'], {
+          timeout: 60000,
+          timeoutCapName: 'androidInstallTimeout'
+        })
+        .returns('');
+      await adb.install('foo');
+    });
     it('should call shell with correct arguments when not replacing', async function () {
+      mocks.adb.expects('isStreamedInstallSupported')
+        .once().returns(false);
       mocks.adb.expects('getApiLevel')
         .once().returns(23);
       mocks.adb.expects('cacheApk')


### PR DESCRIPTION
Recently Google has added the support of streamed installs to adb. This type of installs does not require the apk file to be pushed to the device first, which allows to save time for the whole operation and to save space on SD card.