### PR TITLE
feat: Introduce signature verification options

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -263,13 +263,21 @@ apkSigningMethods.zipAlignApk = async function zipAlignApk (apk) {
 };
 
 /**
+ * @typedef {Object} CertCheckOptions
+ * @property {boolean} requireDefaultCert [true] Whether to require that the destination APK
+ * is signed with the default Appium certificate or any valid certificate. This option
+ * only has effect if `useKeystore` property is unset.
+ */
+
+/**
  * Check if the app is already signed with the default Appium certificate.
  *
  * @param {string} appPath - The full path to the local .apk(s) file.
  * @param {string} pgk - The name of application package.
+ * @param {CertCheckOptions} opts - Certificate checking options
  * @return {boolean} True if given application is already signed.
  */
-apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg) {
+apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts = {}) {
   log.debug(`Checking app cert for ${appPath}`);
   if (!await fs.exists(appPath)) {
     log.debug(`'${appPath}' does not exist`);
@@ -284,33 +292,40 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg) {
     appPath = await this.extractBaseApk(appPath);
   }
 
+  const {
+    requireDefaultCert = true,
+  } = opts;
   try {
     await getApksignerForOs(this);
     const output = await this.executeApksigner(['verify', '--print-certs', appPath]);
-    if (!_.includes(output, DEFAULT_CERT_DIGEST)) {
-      log.debug(`'${appPath}' is signed with non-default certificate`);
-      return false;
+    if (_.includes(output, DEFAULT_CERT_DIGEST)) {
+      log.debug(`'${appPath}' is signed with the default certificate`);
+    } else {
+      log.debug(`'${appPath}' is signed with a non-default certificate`);
     }
-    log.debug(`'${appPath}' is already signed.`);
-    return true;
+    return !requireDefaultCert || (requireDefaultCert && _.includes(output, DEFAULT_CERT_DIGEST));
   } catch (err) {
     // check if there is no signature
-    if (err.stderr && err.stderr.includes(APKSIGNER_VERIFY_FAIL)) {
-      log.debug(`'${appPath}' is not signed with debug cert`);
+    if (_.includes(err.stderr, APKSIGNER_VERIFY_FAIL)) {
+      log.debug(`'${appPath}' is not signed`);
       return false;
     }
     log.warn(`Cannot use apksigner tool for signature verification. ` +
       `Original error: ${err.message}`);
   }
 
-  // default to verify.jar
+  log.debug(`Defaulting to verify.jar`);
   try {
-    log.debug(`Defaulting to verify.jar`);
     await exec(getJavaForOs(), ['-jar', path.resolve(this.helperJarPath, 'verify.jar'), appPath]);
-    log.debug(`'${appPath}' is already signed.`);
+    log.debug(`'${appPath}' is signed with the default certificate`);
     return true;
   } catch (err) {
-    log.debug(`'${appPath}' is not signed with debug cert${err.stderr ? `: ${err.stderr}` : ''}`);
+    if (!requireDefaultCert && _.includes(_.toLower(err.stderr), 'invalid cert')) {
+      log.debug(`'${appPath}' is signed with a non-default certificate`);
+      return true;
+    }
+    log.debug(`'${appPath}' is not signed with the default certificate`);
+    log.debug(err.stderr ? err.stderr : err.message);
     return false;
   }
 };

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -303,7 +303,7 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
     } else {
       log.debug(`'${appPath}' is signed with a non-default certificate`);
     }
-    return !requireDefaultCert || (requireDefaultCert && _.includes(output, DEFAULT_CERT_DIGEST));
+    return !requireDefaultCert || _.includes(output, DEFAULT_CERT_DIGEST);
   } catch (err) {
     // check if there is no signature
     if (_.includes(err.stderr, APKSIGNER_VERIFY_FAIL)) {


### PR DESCRIPTION
UIA2 requires the application under test to be signed by any valid signature, not just the default one we use in Appium. this feature plus some improvements in UIA2 driver will allow to save session init time for already signed apps. 