### PR TITLE
fix: make sure device is reachable in createADB

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -3,8 +3,11 @@ import os from 'os';
 import path from 'path';
 import methods from './tools/index.js';
 import { rootDir, DEFAULT_ADB_EXEC_TIMEOUT } from './helpers';
+import { retryInterval } from 'asyncbox';
+
 
 const DEFAULT_ADB_PORT = 5037;
+const ADB_INITIAL_RETRIES = 5;
 const JAR_PATH = path.resolve(rootDir, 'jars');
 const DEFAULT_OPTS = {
   sdkRoot: null,
@@ -65,6 +68,8 @@ class ADB {
 ADB.createADB = async function createADB (opts) {
   let adb = new ADB(opts);
   await adb.getAdbWithCorrectAdbPath();
+  // get the api level to make sure that the device is reachable
+  await retryInterval(ADB_INITIAL_RETRIES, 100, adb.getApiLevel.bind(adb));
   return adb;
 };
 


### PR DESCRIPTION
Since `getApiLevel` is memoized once successful, this does not have performance impacts. Within the drivers we always get the API level directly after getting the ADB instance, so that will just be pre-populated.

This will necessitate some refactoring of https://github.com/appium/appium-uiautomator2-driver/pull/369