### PR TITLE
Revert "fix: make sure device is reachable in createADB (#504)"

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -3,11 +3,8 @@ import os from 'os';
 import path from 'path';
 import methods from './tools/index.js';
 import { rootDir, DEFAULT_ADB_EXEC_TIMEOUT } from './helpers';
-import { retryInterval } from 'asyncbox';
-
 
 const DEFAULT_ADB_PORT = 5037;
-const ADB_INITIAL_RETRIES = 5;
 const JAR_PATH = path.resolve(rootDir, 'jars');
 const DEFAULT_OPTS = {
   sdkRoot: null,
@@ -68,8 +65,6 @@ class ADB {
 ADB.createADB = async function createADB (opts) {
   let adb = new ADB(opts);
   await adb.getAdbWithCorrectAdbPath();
-  // get the api level to make sure that the device is reachable
-  await retryInterval(ADB_INITIAL_RETRIES, 100, adb.getApiLevel.bind(adb));
   return adb;
 };
 


### PR DESCRIPTION
This reverts commit 0b029c4fd6132bcfb9b614f673eb8cb4653c6b74.

It turns out this patch will fail adb creation if multiple devices are connected to the same machine, because we sometimes should find out the actual udid of the device under test after adb instance is created by analyzing the `list` command output. Perhaps, it makes sense to move this patch into appium-android-driver's helpers, methods `createADB` and `getDeviceInfoFromCaps` after `setDeviceId` has been called.