### PR TITLE
refactor: Switch apksigner to directly use the JAR implementation rather than the wrapper script

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -149,7 +149,7 @@ function getJavaHome () {
  * @throws {Error} If the tool is not present on the local file system.
  */
 async function getApksignerForOs (sysHelpers) {
-  return await sysHelpers.getBinaryFromSdkRoot('apksigner');
+  return await sysHelpers.getBinaryFromSdkRoot('apksigner.jar');
 }
 
 /**

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -112,8 +112,7 @@ apkSigningMethods.signWithCustomCert = async function signWithCustomCert (apk) {
       }
       const jarsigner = path.resolve(getJavaHome(), 'bin',
         `jarsigner${system.isWindows() ? '.exe' : ''}`);
-      const fullCmd = [
-        getJavaForOs(), '-jar', jarsigner,
+      const fullCmd = [jarsigner,
         '-sigalg', 'MD5withRSA',
         '-digestalg', 'SHA1',
         '-keystore', this.keystorePath,

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -28,7 +28,11 @@ let apkSigningMethods = {};
  */
 apkSigningMethods.executeApksigner = async function executeApksigner (args = []) {
   const apkSignerJar = await getApksignerForOs(this);
-  const fullCmd = [getJavaForOs(), '-Xmx1024M', '-jar', apkSignerJar, ...args];
+  const fullCmd = [
+    getJavaForOs(), '-Xmx1024M', '-Xss1m',
+    '-jar', apkSignerJar,
+    ...args
+  ];
   log.debug(`Starting apksigner: ${quote(fullCmd)}`);
   const {stdout, stderr} = await exec(fullCmd[0], fullCmd.slice(1));
   for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -67,14 +67,15 @@ apkSigningMethods.signWithDefaultCert = async function signWithDefaultCert (apk)
     await this.executeApksigner(args);
   } catch (err) {
     log.warn(`Cannot use apksigner tool for signing. Defaulting to sign.jar. ` +
-      `Original error: ${err.message}` + (err.stderr ? `; StdErr: ${err.stderr}` : ''));
+      `Original error: ${err.stderr || err.message}`);
     const signPath = path.resolve(this.helperJarPath, 'sign.jar');
     const fullCmd = [getJavaForOs(), '-jar', signPath, apk, '--override'];
     log.debug(`Starting sign.jar: ${quote(fullCmd)}`);
     try {
       await exec(fullCmd[0], fullCmd.slice(1));
     } catch (e) {
-      throw new Error(`Could not sign with default certificate. Original error ${e.message}`);
+      throw new Error(`Could not sign with default certificate. ` +
+        `Original error ${e.stderr || e.message}`);
     }
   }
 };
@@ -103,7 +104,7 @@ apkSigningMethods.signWithCustomCert = async function signWithCustomCert (apk) {
       apk]);
   } catch (err) {
     log.warn(`Cannot use apksigner tool for signing. Defaulting to jarsigner. ` +
-      `Original error: ${err.message}`);
+      `Original error: ${err.stderr || err.message}`);
     try {
       if (await unsignApk(apk)) {
         log.debug(`'${apk}' has been successfully unsigned`);
@@ -122,7 +123,8 @@ apkSigningMethods.signWithCustomCert = async function signWithCustomCert (apk) {
       log.debug(`Starting jarsigner: ${quote(fullCmd)}`);
       await exec(fullCmd[0], fullCmd.slice(1));
     } catch (e) {
-      throw new Error(`Could not sign with custom certificate. Original error: ${e.message}`);
+      throw new Error(`Could not sign with custom certificate. ` +
+        `Original error: ${e.stderr || e.message}`);
     }
   }
 };
@@ -208,7 +210,7 @@ apkSigningMethods.zipAlignApk = async function zipAlignApk (apk) {
     if (await fs.exists(alignedApk)) {
       await fs.unlink(alignedApk);
     }
-    throw new Error(`zipAlignApk failed. Original error: ${e.message}. Stdout: '${e.stdout}'; Stderr: '${e.stderr}'`);
+    throw new Error(`zipAlignApk failed. Original error: ${e.stderr || e.message}`);
   }
 };
 

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -32,7 +32,7 @@ apkSigningMethods.executeApksigner = async function executeApksigner (args = [])
   log.debug(`Starting apksigner: ${quote(fullCmd)}`);
   const {stdout, stderr} = await exec(fullCmd[0], fullCmd.slice(1));
   for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
-    if (_.trim(stream).length === 0) {
+    if (!_.trim(stream)) {
       continue;
     }
 

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -3,11 +3,12 @@ import _fs from 'fs';
 import { exec } from 'teen_process';
 import path from 'path';
 import log from '../logger.js';
-import { tempDir, system, mkdirp, fs, zip, util } from 'appium-support';
+import { tempDir, system, mkdirp, fs, zip } from 'appium-support';
 import {
   getJavaForOs, getApksignerForOs, getJavaHome,
   rootDir, APKS_EXTENSION, unsignApk,
 } from '../helpers.js';
+import { quote } from 'shell-quote';
 
 const DEFAULT_PRIVATE_KEY = path.resolve(rootDir, 'keys', 'testkey.pk8');
 const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
@@ -18,28 +19,6 @@ const APKSIGNER_VERIFY_FAIL = 'DOES NOT VERIFY';
 let apkSigningMethods = {};
 
 /**
- * Applies the patch, which workarounds'-Djava.ext.dirs is not supported. Use -classpath instead.'
- * error on Windows by creating a temporary patched copy of the original apksigner script.
- *
- * @param {string} originalPath - The original path to apksigner tool
- * @returns {string} The full path to the patched script or the same path if there is
- *                   no need to patch the original file.
- */
-async function patchApksigner (originalPath) {
-  const originalContent = await fs.readFile(originalPath, 'ascii');
-  const patchedContent = originalContent.replace('-Djava.ext.dirs="%frameworkdir%"',
-    '-cp "%frameworkdir%\\*"');
-  if (patchedContent === originalContent) {
-    return originalPath;
-  }
-  log.debug(`Patching '${originalPath}...`);
-  const patchedPath = await tempDir.path({prefix: 'apksigner', suffix: '.bat'});
-  await mkdirp(path.dirname(patchedPath));
-  await fs.writeFile(patchedPath, patchedContent, 'ascii');
-  return patchedPath;
-}
-
-/**
  * Execute apksigner utility with given arguments.
  *
  * @param {?Array<String>} args - The list of tool arguments.
@@ -48,54 +27,24 @@ async function patchApksigner (originalPath) {
  *                 or the return code is not equal to zero.
  */
 apkSigningMethods.executeApksigner = async function executeApksigner (args = []) {
-  const apkSigner = await getApksignerForOs(this);
-  const originalFolder = path.dirname(apkSigner);
-  const getApksignerOutput = async (apksignerPath) => {
-    let binaryPath = apksignerPath;
-    if (system.isWindows() && util.isSubPath(binaryPath, originalFolder)) {
-      // Workaround for https://github.com/nodejs/node-v0.x-archive/issues/25895
-      binaryPath = path.basename(binaryPath);
+  const apkSignerJar = await getApksignerForOs(this);
+  const fullCmd = [getJavaForOs(), '-Xmx1024M', '-jar', apkSignerJar, ...args];
+  log.debug(`Starting apksigner: ${quote(fullCmd)}`);
+  const {stdout, stderr} = await exec(fullCmd[0], fullCmd.slice(1));
+  for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
+    if (_.trim(stream).length === 0) {
+      continue;
     }
-    const {stdout, stderr} = await exec(binaryPath, args, {
-      cwd: originalFolder
-    });
-    for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
-      if (!stream) {
-        continue;
-      }
 
-      if (name === 'stdout') {
-        // Make the output less talkative
-        stream = stream.split('\n')
-          .filter((line) => !line.includes('WARNING:'))
-          .join('\n');
-      }
-      log.debug(`apksigner ${name}: ${stream}`);
+    if (name === 'stdout') {
+      // Make the output less talkative
+      stream = stream.split('\n')
+        .filter((line) => !line.includes('WARNING:'))
+        .join('\n');
     }
-    return stdout;
-  };
-  log.debug(`Starting '${apkSigner}' with args '${JSON.stringify(args)}'`);
-  try {
-    return await getApksignerOutput(apkSigner);
-  } catch (err) {
-    log.warn(`Got an error during apksigner execution: ${err.message}`);
-    for (const [name, stream] of [['stdout', err.stdout], ['stderr', err.stderr]]) {
-      if (stream) {
-        log.warn(`apksigner ${name}: ${stream}`);
-      }
-    }
-    if (system.isWindows()) {
-      const patchedApksigner = await patchApksigner(apkSigner);
-      if (patchedApksigner !== apkSigner) {
-        try {
-          return await getApksignerOutput(patchedApksigner);
-        } finally {
-          await fs.unlink(patchedApksigner);
-        }
-      }
-    }
-    throw err;
+    log.debug(`apksigner ${name}: ${stream}`);
   }
+  return stdout;
 };
 
 /**
@@ -119,11 +68,11 @@ apkSigningMethods.signWithDefaultCert = async function signWithDefaultCert (apk)
   } catch (err) {
     log.warn(`Cannot use apksigner tool for signing. Defaulting to sign.jar. ` +
       `Original error: ${err.message}` + (err.stderr ? `; StdErr: ${err.stderr}` : ''));
-    const java = getJavaForOs();
     const signPath = path.resolve(this.helperJarPath, 'sign.jar');
-    log.debug('Resigning apk.');
+    const fullCmd = [getJavaForOs(), '-jar', signPath, apk, '--override'];
+    log.debug(`Starting sign.jar: ${quote(fullCmd)}`);
     try {
-      await exec(java, ['-jar', signPath, apk, '--override']);
+      await exec(fullCmd[0], fullCmd.slice(1));
     } catch (e) {
       throw new Error(`Could not sign with default certificate. Original error ${e.message}`);
     }
@@ -146,13 +95,12 @@ apkSigningMethods.signWithCustomCert = async function signWithCustomCert (apk) {
   }
 
   try {
-    const args = ['sign',
+    await this.executeApksigner(['sign',
       '--ks', this.keystorePath,
       '--ks-key-alias', this.keyAlias,
       '--ks-pass', `pass:${this.keystorePassword}`,
       '--key-pass', `pass:${this.keyPassword}`,
-      apk];
-    await this.executeApksigner(args);
+      apk]);
   } catch (err) {
     log.warn(`Cannot use apksigner tool for signing. Defaulting to jarsigner. ` +
       `Original error: ${err.message}`);
@@ -162,15 +110,18 @@ apkSigningMethods.signWithCustomCert = async function signWithCustomCert (apk) {
       } else {
         log.debug(`'${apk}' does not need to be unsigned`);
       }
-      log.debug('Signing apk');
-      const jarsigner = path.resolve(getJavaHome(), 'bin', `jarsigner${system.isWindows() ? '.exe' : ''}`);
-      await exec(jarsigner, [
+      const jarsigner = path.resolve(getJavaHome(), 'bin',
+        `jarsigner${system.isWindows() ? '.exe' : ''}`);
+      const fullCmd = [
+        getJavaForOs(), '-jar', jarsigner,
         '-sigalg', 'MD5withRSA',
         '-digestalg', 'SHA1',
         '-keystore', this.keystorePath,
         '-storepass', this.keystorePassword,
         '-keypass', this.keyPassword,
-        apk, this.keyAlias]);
+        apk, this.keyAlias];
+      log.debug(`Starting jarsigner: ${quote(fullCmd)}`);
+      await exec(fullCmd[0], fullCmd.slice(1));
     } catch (e) {
       throw new Error(`Could not sign with custom certificate. Original error: ${e.message}`);
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -93,7 +93,12 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
       log.info(`Using build tools at '${buildToolsDirs}'`);
     }
   }
-  binaryLocs.push(...(buildToolsDirs.map((dir) => path.resolve(dir, fullBinaryName))));
+  binaryLocs.push(...(_.flatten(buildToolsDirs
+    .map((dir) => [
+      path.resolve(dir, fullBinaryName),
+      path.resolve(dir, 'lib', fullBinaryName),
+    ]))
+  ));
 
   let binaryLoc = null;
   for (const loc of binaryLocs) {

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -43,7 +43,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
         .once().withExactArgs(['sign',
           '--key', defaultKeyPath,
           '--cert', defaultCertPath, selendroidTestApp])
-        .returns({});
+        .returns('');
       await adb.signWithDefaultCert(selendroidTestApp);
     });
 
@@ -85,7 +85,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
           '--ks-pass', `pass:${password}`,
           '--key-pass', `pass:${password}`,
           selendroidTestApp
-        ]).returns({});
+        ]).returns('');
       await adb.signWithCustomCert(selendroidTestApp);
     });
 

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -40,7 +40,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.helpers.expects('getApksignerForOs')
         .returns(apksignerDummyPath);
       mocks.adb.expects('executeApksigner')
-        .once().withArgs(['sign',
+        .once().withExactArgs(['sign',
           '--key', defaultKeyPath,
           '--cert', defaultCertPath, selendroidTestApp])
         .returns({});
@@ -52,7 +52,7 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.helpers.expects('getApksignerForOs')
         .returns(apksignerDummyPath);
       mocks.adb.expects('executeApksigner')
-        .once().withArgs(['sign',
+        .once().withExactArgs(['sign',
           '--key', defaultKeyPath,
           '--cert', defaultCertPath, selendroidTestApp])
         .throws();

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -42,8 +42,9 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.adb.expects('executeApksigner')
         .once().withExactArgs(['sign',
           '--key', defaultKeyPath,
-          '--cert', defaultCertPath, selendroidTestApp])
-        .returns('');
+          '--cert', defaultCertPath,
+          selendroidTestApp
+        ]).returns('');
       await adb.signWithDefaultCert(selendroidTestApp);
     });
 
@@ -54,8 +55,9 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
       mocks.adb.expects('executeApksigner')
         .once().withExactArgs(['sign',
           '--key', defaultKeyPath,
-          '--cert', defaultCertPath, selendroidTestApp])
-        .throws();
+          '--cert', defaultCertPath,
+          selendroidTestApp
+        ]).throws();
       mocks.helpers.expects('getJavaForOs')
         .once().returns(javaDummyPath);
       mocks.teen_process.expects('exec')


### PR DESCRIPTION
This will allow to simplify our client code and get rid of some ugly workarounds. Also, the execution speed should improve a bit