### PR TITLE
feat: ignore setting hidden api policies error

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -408,7 +408,7 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
     try {
       await this.setSetting('global', k, v);
     } catch (e) {
-      log.info(`Failed to set '${k}'. Original error: ${e.message}`);
+      log.info(`Failed to set value, '${v}', as key, '${k}'. Original error: ${e.message}`);
     }
   };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -404,10 +404,8 @@ methods.toggleGPSLocationProvider = async function toggleGPSLocationProvider (en
  *        or to a restricted greylist for your target API level.
  */
 methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
-  const cmds = HIDDEN_API_POLICY_KEYS.map((key) => `settings put global ${key} ${value}`);
-
   try {
-    await this.shell(cmds.join(';'));
+    await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings put global ${k} ${value}`).join(';'));
   } catch (e) {
     log.info(`Failed to set hidden policy keys '${HIDDEN_API_POLICY_KEYS}' to '${value}'. Original error: ${e.message}`);
   }
@@ -418,10 +416,8 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  */
 methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy () {
-  const cmds = HIDDEN_API_POLICY_KEYS.map((key) => `settings delete global ${key}`);
-
   try {
-    await this.shell(cmds.join(';'));
+    await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings delete global ${k}`).join(';'));
   } catch (e) {
     log.info(`Failed to delete keys'${HIDDEN_API_POLICY_KEYS}'. Original error: ${e.message}`);
   }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -404,12 +404,10 @@ methods.toggleGPSLocationProvider = async function toggleGPSLocationProvider (en
  *        or to a restricted greylist for your target API level.
  */
 methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
-  const cmd = HIDDEN_API_POLICY_KEYS.reduce((acc, key) => {
-    return `${acc}settings put global ${key} ${value};`;
-  }, '');
+  const cmds = HIDDEN_API_POLICY_KEYS.map((key) => `settings put global ${key} ${value}`);
 
   try {
-    await this.shell(cmd);
+    await this.shell(cmds.join(';'));
   } catch (e) {
     log.info(`Failed to set hidden policy keys '${HIDDEN_API_POLICY_KEYS}' to '${value}'. Original error: ${e.message}`);
   }
@@ -420,12 +418,10 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  */
 methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy () {
-  const cmd = HIDDEN_API_POLICY_KEYS.reduce((acc, key) => {
-    return `${acc}settings delete global ${key};`;
-  }, '');
+  const cmds = HIDDEN_API_POLICY_KEYS.map((key) => `settings delete global ${key}`);
 
   try {
-    await this.shell(cmd);
+    await this.shell(cmds.join(';'));
   } catch (e) {
     log.info(`Failed to delete keys'${HIDDEN_API_POLICY_KEYS}'. Original error: ${e.message}`);
   }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -407,7 +407,7 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
   try {
     await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings put global ${k} ${value}`).join(';'));
   } catch (e) {
-    log.info(`Failed to set hidden policy keys '${HIDDEN_API_POLICY_KEYS}' to '${value}'. Original error: ${e.message}`);
+    log.info(`Failed to set setting keys '${HIDDEN_API_POLICY_KEYS}' to '${value}'. Original error: ${e.message}`);
   }
 };
 
@@ -419,7 +419,7 @@ methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy () 
   try {
     await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings delete global ${k}`).join(';'));
   } catch (e) {
-    log.info(`Failed to delete keys'${HIDDEN_API_POLICY_KEYS}'. Original error: ${e.message}`);
+    log.info(`Failed to delete keys '${HIDDEN_API_POLICY_KEYS}'. Original error: ${e.message}`);
   }
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -21,7 +21,7 @@ const IGNORED_PERM_ERRORS = [
   /Unknown permission/i,
 ];
 const MAX_PGREP_PATTERN_LEN = 15;
-const HIDDEN_API_POLICIES = [
+const HIDDEN_API_POLICY_KEYS = [
   'hidden_api_policy_pre_p_apps',
   'hidden_api_policy_p_apps',
   'hidden_api_policy'
@@ -404,15 +404,15 @@ methods.toggleGPSLocationProvider = async function toggleGPSLocationProvider (en
  *        or to a restricted greylist for your target API level.
  */
 methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
-  const _setSetting = async (k, v) => {
-    try {
-      await this.setSetting('global', k, v);
-    } catch (e) {
-      log.info(`Failed to set value, '${v}', as key, '${k}'. Original error: ${e.message}`);
-    }
-  };
+  const cmd = HIDDEN_API_POLICY_KEYS.reduce((acc, key) => {
+    return `${acc}settings put global ${key} ${value};`;
+  }, '');
 
-  for (const k of HIDDEN_API_POLICIES) { await _setSetting(k, value); }
+  try {
+    await this.shell(cmd);
+  } catch (e) {
+    log.info(`Failed to set hidden policy keys '${HIDDEN_API_POLICY_KEYS}' to '${value}'. Original error: ${e.message}`);
+  }
 };
 
 /**
@@ -420,15 +420,15 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  */
 methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy () {
-  const _delSetting = async (k) => {
-    try {
-      await this.shell(['settings', 'delete', 'global', k]);
-    } catch (e) {
-      log.info(`Failed to delete '${k}' to make it default. Original error: ${e.message}`);
-    }
-  };
+  const cmd = HIDDEN_API_POLICY_KEYS.reduce((acc, key) => {
+    return `${acc}settings delete global ${key};`;
+  }, '');
 
-  for (const k of HIDDEN_API_POLICIES) { await _delSetting(k); }
+  try {
+    await this.shell(cmd);
+  } catch (e) {
+    log.info(`Failed to delete keys'${HIDDEN_API_POLICY_KEYS}'. Original error: ${e.message}`);
+  }
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -21,7 +21,11 @@ const IGNORED_PERM_ERRORS = [
   /Unknown permission/i,
 ];
 const MAX_PGREP_PATTERN_LEN = 15;
-
+const HIDDEN_API_POLICIES = [
+  'hidden_api_policy_pre_p_apps',
+  'hidden_api_policy_p_apps',
+  'hidden_api_policy'
+];
 
 let methods = {};
 
@@ -400,9 +404,15 @@ methods.toggleGPSLocationProvider = async function toggleGPSLocationProvider (en
  *        or to a restricted greylist for your target API level.
  */
 methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
-  await this.setSetting('global', 'hidden_api_policy_pre_p_apps', value);
-  await this.setSetting('global', 'hidden_api_policy_p_apps', value);
-  await this.setSetting('global', 'hidden_api_policy', value);
+  const _setSetting = async (k, v) => {
+    try {
+      await this.setSetting('global', k, v);
+    } catch (e) {
+      log.info(`Failed to set '${k}'. Original error: ${e.message}`);
+    }
+  };
+
+  for (const k of HIDDEN_API_POLICIES) { await _setSetting(k, value); }
 };
 
 /**
@@ -410,9 +420,15 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  */
 methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy () {
-  await this.shell(['settings', 'delete', 'global', 'hidden_api_policy_pre_p_apps']);
-  await this.shell(['settings', 'delete', 'global', 'hidden_api_policy_p_apps']);
-  await this.shell(['settings', 'delete', 'global', 'hidden_api_policy']);
+  const _delSetting = async (k) => {
+    try {
+      await this.shell(['settings', 'delete', 'global', k]);
+    } catch (e) {
+      log.info(`Failed to delete '${k}' to make it default. Original error: ${e.message}`);
+    }
+  };
+
+  for (const k of HIDDEN_API_POLICIES) { await _delSetting(k); }
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -403,7 +403,7 @@ methods.toggleGPSLocationProvider = async function toggleGPSLocationProvider (en
  *     2: Disallow usage of non-SDK interfaces that belong to either the black list
  *        or to a restricted greylist for your target API level.
  *
- * @param {boolean} ignoreError  Whether to ignore an exception in 'adb shell settings put global' command
+ * @param {boolean} ignoreError [false] Whether to ignore an exception in 'adb shell settings put global' command
  * @throws {error} If there was an error and ignoreError was true while executing 'adb shell settings put global'
  *                 command on the device under test.
  */
@@ -422,7 +422,7 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value, ignoreErr
  * Reset access to non-SDK APIs to its default setting.
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  *
- * @param {boolean} ignoreError  Whether to ignore an exception in 'adb shell settings delete global' command
+ * @param {boolean} ignoreError [false] Whether to ignore an exception in 'adb shell settings delete global' command
  * @throws {error} If there was an error and ignoreError was true while executing 'adb shell settings delete global'
  *                 command on the device under test.
  */

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -402,11 +402,18 @@ methods.toggleGPSLocationProvider = async function toggleGPSLocationProvider (en
  *        Using this setting also allows you to test your app using the StrictMode API.
  *     2: Disallow usage of non-SDK interfaces that belong to either the black list
  *        or to a restricted greylist for your target API level.
+ *
+ * @param {boolean} ignoreError  Whether to ignore an exception in 'adb shell settings put global' command
+ * @throws {error} If there was an error and ignoreError was true while executing 'adb shell settings put global'
+ *                 command on the device under test.
  */
-methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
+methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value, ignoreError = false) {
   try {
     await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings put global ${k} ${value}`).join(';'));
   } catch (e) {
+    if (!ignoreError) {
+      throw e;
+    }
     log.info(`Failed to set setting keys '${HIDDEN_API_POLICY_KEYS}' to '${value}'. Original error: ${e.message}`);
   }
 };
@@ -414,11 +421,18 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value) {
 /**
  * Reset access to non-SDK APIs to its default setting.
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
+ *
+ * @param {boolean} ignoreError  Whether to ignore an exception in 'adb shell settings delete global' command
+ * @throws {error} If there was an error and ignoreError was true while executing 'adb shell settings delete global'
+ *                 command on the device under test.
  */
-methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy () {
+methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy (ignoreError = false) {
   try {
     await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings delete global ${k}`).join(';'));
   } catch (e) {
+    if (!ignoreError) {
+      throw e;
+    }
     log.info(`Failed to delete keys '${HIDDEN_API_POLICY_KEYS}'. Original error: ${e.message}`);
   }
 };

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -1249,4 +1249,22 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       await adb.getTimeZone().should.eventually.be.rejected;
     });
   });
+  describe('setHiddenApiPolicy', function () {
+    it('should call setSetting method with correct args for set hidden api policy', async function () {
+      mocks.adb.expects('shell').once().withExactArgs(
+        'settings put global hidden_api_policy_pre_p_apps 1;' +
+        'settings put global hidden_api_policy_p_apps 1;' +
+        'settings put global hidden_api_policy 1');
+      await adb.setHiddenApiPolicy(1);
+    });
+  });
+  describe('setDefaultHiddenApiPolicy', function () {
+    it('should call setSetting method with correct args for set hidden api policy', async function () {
+      mocks.adb.expects('shell').once().withExactArgs(
+        'settings delete global hidden_api_policy_pre_p_apps;' +
+        'settings delete global hidden_api_policy_p_apps;' +
+        'settings delete global hidden_api_policy');
+      await adb.setDefaultHiddenApiPolicy();
+    });
+  });
 }));


### PR DESCRIPTION
closes https://github.com/appium/appium-desktop/issues/1265

It looks some manufactures set limitations for hidden api policies.
We can ignore them when it fails because of such customisation with printing the error as info.