### PR TITLE
chore: update to macOS 10.15

### DIFF
--- a/ci-jobs/ci.yml
+++ b/ci-jobs/ci.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: adbCI
     pool:
-      vmImage: macOS-10.13
+      vmImage: macOS-10.15
     variables:
       CI: true
       TERM: dumb

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -2,7 +2,7 @@
 parameters:
   script: echo "NO TEST SCRIPT WAS PROVIDED" && exit 1
   name: 'android_e2e_tests'
-  vmImage: 'macOS-10.13'
+  vmImage: 'macOS-10.15'
   MOCHA_FILE: 'sdk-$(ANDROID_SDK_VERSION)-test-results.xml'
   NODE_VERSION: 10.x
   PLATFORM_VERSION: 9.0
@@ -27,7 +27,7 @@ jobs:
     - script: adb logcat > logcat.txt &
       displayName: Capture Logcat
     - script: bash ci-jobs/scripts/start-emulator.sh
-      displayName: Create and run Emulator 
+      displayName: Create and run Emulator
     - script: npm run build
       displayName: Build
     - script: ${{ parameters.script }}
@@ -43,5 +43,3 @@ jobs:
       inputs:
         artifactName: ${{ parameters.name }}-logcat
         targetPath: logcat.txt
-
-  


### PR DESCRIPTION
Got `##[error]This job was temporarily blocked because it uses a Microsoft hosted agent (MacOS-10.13) that will be permanently removed on March 23rd, 2020.  See https://aka.ms/blocked-hosted-agent for more information.` error in https://github.com/appium/appium-adb/pull/507/checks?check_run_id=498080242