### PR TITLE
fix: Update glob expressions

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -32,8 +32,9 @@ async function getAndroidPlatformAndPath () {
     throw new Error('Neither ANDROID_HOME nor ANDROID_SDK_ROOT environment variable was exported');
   }
 
-  let propsPaths = await fs.glob(path.resolve(sdkRoot, 'platforms', '*', 'build.prop'), {
-    absolute: true
+  const propsPaths = await fs.glob('*/build.prop', {
+    cwd: path.resolve(sdkRoot, 'platforms'),
+    absolute: true,
   });
   const platformsMapping = {};
   for (const propsPath of propsPaths) {
@@ -332,7 +333,10 @@ const getSdkToolsVersion = _.memoize(async function getSdkToolsVersion () {
  * modification date (the newest comes first) or an empty list if no macthes were found
  */
 const getBuildToolsDirs = _.memoize(async function getBuildToolsDirs (sdkRoot) {
-  let buildToolsDirs = await fs.glob(path.resolve(sdkRoot, 'build-tools', '*'), {absolute: true});
+  let buildToolsDirs = await fs.glob('*/', {
+    cwd: path.resolve(sdkRoot, 'build-tools'),
+    absolute: true,
+  });
   try {
     buildToolsDirs = buildToolsDirs
       .map((dir) => [path.basename(dir), dir])


### PR DESCRIPTION
The `glob` [documentation](https://www.npmjs.com/package/glob) says:

```
Windows

Please only use forward-slashes in glob expressions.

Though windows uses either / or \ as its path separator, only / characters are used by this glob implementation. You must use forward-slashes only in glob expressions. Back-slashes will always be interpreted as escape characters, not path separators.

Results from absolute patterns such as /foo/* are mounted onto the root setting using path.join. On windows, this will by default result in /foo/* matching C:\foo\bar.txt.
```