### PR TITLE
feat: Add a helper to get process name for the given PID

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1073,7 +1073,7 @@ methods.getNameByPid = async function getNameByPid (pid) {
   const titleMatch = PS_TITLE_PATTERN.exec(stdout);
   if (!titleMatch) {
     log.debug(stdout);
-    throw new Error(`Could not get the package name for PID '${pid}' from the processes list`);
+    throw new Error(`Could not get the process name for PID '${pid}'`);
   }
   const allTitles = titleMatch[1].trim().split(/\s+/);
   const pidIndex = allTitles.indexOf(PID_COLUMN_TITLE);
@@ -1091,7 +1091,7 @@ methods.getNameByPid = async function getNameByPid (pid) {
     }
   }
   log.debug(stdout);
-  throw new Error(`Could not get the package name for PID '${pid}' from the processes list`);
+  throw new Error(`Could not get the process name for PID '${pid}'`);
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1076,13 +1076,17 @@ methods.getNameByPid = async function getNameByPid (pid) {
     throw new Error(`Could not get the package name for PID '${pid}' from the processes list`);
   }
   const allTitles = titleMatch[1].trim().split(/\s+/);
-  // NAME is usually the last column
+  const pidIndex = allTitles.indexOf(PID_COLUMN_TITLE);
+  // it might not be stable to take NAME by index, because depending on the
+  // actual SDK the ps output might not contain an abbreviation for the S flag:
+  // USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
+  // USER     PID   PPID  VSIZE  RSS     WCHAN    PC   S    NAME
   const nameOffset = allTitles.indexOf(PROCESS_NAME_COLUMN_TITLE) - allTitles.length;
   const pidRegex = new RegExp(`^(.*\\b${pid}\\b.*)$`, 'gm');
   let matchedLine;
   while ((matchedLine = pidRegex.exec(stdout))) {
     const items = matchedLine[1].trim().split(/\s+/);
-    if (items[items.length + nameOffset]) {
+    if (parseInt(items[pidIndex], 10) === pid && items[items.length + nameOffset]) {
       return items[items.length + nameOffset];
     }
   }

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -26,6 +26,10 @@ const HIDDEN_API_POLICY_KEYS = [
   'hidden_api_policy_p_apps',
   'hidden_api_policy'
 ];
+const PID_COLUMN_TITLE = 'PID';
+const PROCESS_NAME_COLUMN_TITLE = 'NAME';
+const PS_TITLE_PATTERN = new RegExp(`^(.*\\b${PID_COLUMN_TITLE}\\b.*\\b${PROCESS_NAME_COLUMN_TITLE}\\b.*)$`, 'm');
+
 
 let methods = {};
 
@@ -1052,6 +1056,41 @@ methods.removeLogcatListener = function removeLogcatListener (listener) {
 };
 
 /**
+ * Returns process name for the given process identifier
+ *
+ * @param {string|number} pid - The valid process identifier
+ * @throws {Error} If the given PID is either invalid or is not present
+ * in the active processes list
+ * @returns {string} The process name
+ */
+methods.getNameByPid = async function getNameByPid (pid) {
+  if (isNaN(pid)) {
+    throw new Error(`The PID value must be a valid number. '${pid}' is given instead`);
+  }
+  pid = parseInt(pid, 10);
+
+  const stdout = await this.shell(['ps']);
+  const titleMatch = PS_TITLE_PATTERN.exec(stdout);
+  if (!titleMatch) {
+    log.debug(stdout);
+    throw new Error(`Could not get the package name for PID '${pid}' from the processes list`);
+  }
+  const allTitles = titleMatch[1].trim().split(/\s+/);
+  // NAME is usually the last column
+  const nameOffset = allTitles.indexOf(PROCESS_NAME_COLUMN_TITLE) - allTitles.length;
+  const pidRegex = new RegExp(`^(.*\\b${pid}\\b.*)$`, 'gm');
+  let matchedLine;
+  while ((matchedLine = pidRegex.exec(stdout))) {
+    const items = matchedLine[1].trim().split(/\s+/);
+    if (items[items.length + nameOffset]) {
+      return items[items.length + nameOffset];
+    }
+  }
+  log.debug(stdout);
+  throw new Error(`Could not get the package name for PID '${pid}' from the processes list`);
+};
+
+/**
  * Get the list of process ids for the particular process on the device under test.
  *
  * @param {string} name - The part of process name.
@@ -1099,22 +1138,22 @@ methods.getPIDsByName = async function getPIDsByName (name) {
   }
 
   log.debug('Using ps-based PID detection');
-  const pidColumnTitle = 'PID';
-  const processNameColumnTitle = 'NAME';
   const stdout = await this.shell(['ps']);
-  const titleMatch = new RegExp(`^(.*\\b${pidColumnTitle}\\b.*\\b${processNameColumnTitle}\\b.*)$`, 'm').exec(stdout);
+  const titleMatch = PS_TITLE_PATTERN.exec(stdout);
   if (!titleMatch) {
-    throw new Error(`Could not extract PID of '${name}' from ps output: ${stdout}`);
+    log.debug(stdout);
+    throw new Error(`Could not extract PID of '${name}' from ps output`);
   }
   const allTitles = titleMatch[1].trim().split(/\s+/);
-  const pidIndex = allTitles.indexOf(pidColumnTitle);
+  const pidIndex = allTitles.indexOf(PID_COLUMN_TITLE);
   const pids = [];
   const processNameRegex = new RegExp(`^(.*\\b\\d+\\b.*\\b${_.escapeRegExp(name)}\\b.*)$`, 'gm');
   let matchedLine;
   while ((matchedLine = processNameRegex.exec(stdout))) {
     const items = matchedLine[1].trim().split(/\s+/);
     if (pidIndex >= allTitles.length || isNaN(items[pidIndex])) {
-      throw new Error(`Could not extract PID of '${name}' from '${matchedLine[1].trim()}'. ps output: ${stdout}`);
+      log.debug(stdout);
+      throw new Error(`Could not extract PID of '${name}' from '${matchedLine[1].trim()}'`);
     }
     pids.push(parseInt(items[pidIndex], 10));
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "adbkit-apkreader": "^3.1.2",
-    "appium-support": "^2.37.0",
+    "appium-support": "^2.42.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.4.7",

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -622,6 +622,46 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         await adb.getLogcatLogs();
       });
     });
+    describe('getNameByPid', function () {
+      it('should get package name from valid ps output', async function () {
+        mocks.adb.expects('shell')
+          .once().withExactArgs(['ps'])
+          .returns(`
+          USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
+          radio     929   69    1228184 40844 ffffffff b6db0920 S com.android.phone
+          radio     930   69    1228184 40844 ffffffff b6db0920 S com.android.phone
+          u0_a7     951   69    1256464 72208 ffffffff b6db0920 S com.android.launcher
+          u0_a30    1119  69    1220004 33596 ffffffff b6db0920 S com.android.inputmethod.latin
+          u0_a12    1156  69    1246756 58588 ffffffff b6db0920 S com.android.systemui
+          root      1347  2     0      0     c002f068 00000000 S kworker/0:1
+          u0_a1     1349  69    1206724 26164 ffffffff b6db0920 S com.android.providers.calendar
+          u0_a17    1431  69    1217460 26616 ffffffff b6db0920 S com.android.calendar
+          u0_a21    1454  69    1203712 26244 ffffffff b6db0920 S com.android.deskclock
+          u0_a27    1490  69    1206480 24748 ffffffff b6db0920 S com.android.exchange
+          u0_a4     1574  69    1205460 22984 ffffffff b6db0920 S com.android.dialer
+          u0_a2     1590  69    1207456 29340 ffffffff b6db0920 S android.process.acore
+          u0_a11    1608  69    1199320 22448 ffffffff b6db0920 S com.android.sharedstoragebackup
+          u0_a15    1627  69    1206440 30480 ffffffff b6db0920 S com.android.browser
+          u0_a5     1646  69    1202716 27004 ffffffff b6db0920 S android.process.media
+          root      1676  2     0      0     c00d0d8c 00000000 S flush-31:1
+          root      1680  2     0      0     c00d0d8c 00000000 S flush-31:2
+          root      1681  60    10672  996   00000000 b6f33508 R ps
+          `);
+        (await adb.getNameByPid('1627')).should.eql('com.android.browser');
+      });
+      it('should fail if no PID could be found in the name', async function () {
+        await adb.getNameByPid('bla').should.eventually.be.rejectedWith(/valid number/);
+      });
+      it('should fail if no PID could be found in ps output', async function () {
+        mocks.adb.expects('shell')
+          .once().withExactArgs(['ps'])
+          .returns(`
+          USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
+          u0_a12    1156  69    1246756 58588 ffffffff b6db0920 S com.android.systemui
+          `);
+        await adb.getNameByPid(115).should.eventually.be.rejectedWith(/package name/);
+      });
+    });
     describe('getPIDsByName', function () {
       beforeEach(function () {
         mocks.adb.expects('getApiLevel').once().returns(23);

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -659,7 +659,7 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
           USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
           u0_a12    1156  69    1246756 58588 ffffffff b6db0920 S com.android.systemui
           `);
-        await adb.getNameByPid(115).should.eventually.be.rejectedWith(/package name/);
+        await adb.getNameByPid(115).should.eventually.be.rejectedWith(/process name/);
       });
     });
     describe('getPIDsByName', function () {


### PR DESCRIPTION
This helper is needed for android-driver, which has the corresponding TODO marker: https://github.com/appium/appium-android-driver/blob/63f7e87110e6e89c70886dc9092802fcd64f5735/lib/webview-helpers.js#L159