### PR TITLE
feat: Add a possibility for emulator commands execution via telnet

### DIFF
--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -252,7 +252,7 @@ emuMethods.networkSpeed = async function networkSpeed (speed = 'full') {
 emuMethods.execEmuConsoleCommand = async function execTelnet (cmd, opts = {}) {
   const portMatch = /emulator-(\d+)/i.exec(this.curDeviceId);
   if (!portMatch) {
-    throw new Error(`Cannot parse the telnet port number from the device identifier '${this.curDeviceId}'. ` +
+    throw new Error(`Cannot parse the console port number from the device identifier '${this.curDeviceId}'. ` +
       `Is it an emulator?`);
   }
   const host = '127.0.0.1';
@@ -274,8 +274,8 @@ emuMethods.execEmuConsoleCommand = async function execTelnet (cmd, opts = {}) {
 
   return await new B((resolve, reject) => {
     const connTimeoutObj = setTimeout(
-      () => reject(new Error(`Cannot connect to the Emulator telnet interface at ${host}:${port} ` +
-        `after ${connTimeout}ms timeout`)), connTimeout);
+      () => reject(new Error(`Cannot connect to the Emulator console at ${host}:${port} ` +
+        `after ${connTimeout}ms`)), connTimeout);
     let execTimeoutObj;
     let initTimeoutObj;
     let isCommandSent = false;
@@ -283,14 +283,14 @@ emuMethods.execEmuConsoleCommand = async function execTelnet (cmd, opts = {}) {
 
     client.once('error', (e) => {
       clearTimeout(connTimeoutObj);
-      reject(new Error(`Cannot connect to the Emulator telnet interface at ${host}:${port}. ` +
+      reject(new Error(`Cannot connect to the Emulator console at ${host}:${port}. ` +
         `Original error: ${e.message}`));
     });
 
     client.once('connect', () => {
       clearTimeout(connTimeoutObj);
       initTimeoutObj = setTimeout(
-        () => reject(new Error(`Did not get the initial response from the Emulator telnet interface at ${host}:${port} ` +
+        () => reject(new Error(`Did not get the initial response from the Emulator console at ${host}:${port} ` +
           `after ${initTimeout}ms`)), initTimeout);
     });
 
@@ -302,12 +302,12 @@ emuMethods.execEmuConsoleCommand = async function execTelnet (cmd, opts = {}) {
         if (!isCommandSent) {
           clearTimeout(initTimeoutObj);
           serverResponse = [];
-          log.debug(`Executing Emulator Telnet command: ${cmd}`);
+          log.debug(`Executing Emulator console command: ${cmd}`);
           client.write(_.isArray(cmd) ? util.quote(cmd) : cmd);
           client.write(eol);
           isCommandSent = true;
           execTimeoutObj = setTimeout(
-            () => reject(new Error(`Did not get any response from the Emulator telnet interface at ${host}:${port} ` +
+            () => reject(new Error(`Did not get any response from the Emulator console at ${host}:${port} ` +
               `to '${cmd}' command after ${execTimeout}ms`)), execTimeout);
           return;
         }
@@ -321,7 +321,7 @@ emuMethods.execEmuConsoleCommand = async function execTelnet (cmd, opts = {}) {
         clearTimeout(execTimeoutObj);
         client.end();
         const outputArr = output.split(eol);
-        return reject(_.trim(outputArr[outputArr.length - 1]));
+        return reject(_.trim(_.last(outputArr)));
       }
     });
   });

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -1,6 +1,8 @@
 import log from '../logger.js';
 import _ from 'lodash';
-
+import net from 'net';
+import { util } from 'appium-support';
+import B from 'bluebird';
 
 const PHONE_NUMBER_PATTERN = /^[+]?[(]?[0-9]*[)]?[-\s.]?[0-9]*[-\s.]?[0-9]{2,}$/im;
 
@@ -224,6 +226,105 @@ emuMethods.networkSpeed = async function networkSpeed (speed = 'full') {
     throw new Error(`Invalid network speed param ${speed}. Supported values: ${_.values(emuMethods.NETWORK_SPEED)}`);
   }
   await this.adbExecEmu(['network', 'speed', speed]);
+};
+
+/**
+ * @typedef {Object} ExecTelnetOptions
+ * @property {number} execTimeout [60000] A timeout used to wait for a server
+ * reply to the given command
+ * @property {number} connTimeout [5000] Console connection timeout in milliseconds
+ * @property {number} initTimeout [5000] Telnet console initialization timeout
+ * in milliseconds (the time between connection happens and the command prompt
+ * is available)
+ */
+
+/**
+ * Executes a command through emulator telnet console interface and returns its output
+ *
+ * @param {Array<string>|string} cmd - The actual command to execute. See
+ * https://developer.android.com/studio/run/emulator-console for more details
+ * on available commands
+ * @param {ExecTelnetOptions} opts
+ * @returns {string} The command output
+ * @throws {Error} If there was an error while connecting to the Telnet console
+ * or if the given command returned non-OK response
+ */
+emuMethods.execEmuConsoleCommand = async function execTelnet (cmd, opts = {}) {
+  const portMatch = /emulator-(\d+)/i.exec(this.curDeviceId);
+  if (!portMatch) {
+    throw new Error(`Cannot parse the telnet port number from the device identifier '${this.curDeviceId}'. ` +
+      `Is it an emulator?`);
+  }
+  const host = '127.0.0.1';
+  const port = parseInt(portMatch[1], 10);
+  const {
+    execTimeout = 60000,
+    connTimeout = 5000,
+    initTimeout = 5000,
+  } = opts;
+  await this.resetTelnetAuthToken();
+
+  const okFlag = /^OK$/m;
+  const nokFlag = /^KO\b/m;
+  const eol = '\r\n';
+  const client = net.connect({
+    host,
+    port,
+  });
+
+  return await new B((resolve, reject) => {
+    const connTimeoutObj = setTimeout(
+      () => reject(new Error(`Cannot connect to the Emulator telnet interface at ${host}:${port} ` +
+        `after ${connTimeout}ms timeout`)), connTimeout);
+    let execTimeoutObj;
+    let initTimeoutObj;
+    let isCommandSent = false;
+    let serverResponse = [];
+
+    client.once('error', (e) => {
+      clearTimeout(connTimeoutObj);
+      reject(new Error(`Cannot connect to the Emulator telnet interface at ${host}:${port}. ` +
+        `Original error: ${e.message}`));
+    });
+
+    client.once('connect', () => {
+      clearTimeout(connTimeoutObj);
+      initTimeoutObj = setTimeout(
+        () => reject(new Error(`Did not get the initial response from the Emulator telnet interface at ${host}:${port} ` +
+          `after ${initTimeout}ms`)), initTimeout);
+    });
+
+    client.on('data', (chunk) => {
+      serverResponse.push(chunk);
+      const output = Buffer.concat(serverResponse).toString('utf8').trim();
+      if (okFlag.test(output)) {
+        // The initial incoming data chunk confirms the interface is ready for input
+        if (!isCommandSent) {
+          clearTimeout(initTimeoutObj);
+          serverResponse = [];
+          log.debug(`Executing Emulator Telnet command: ${cmd}`);
+          client.write(_.isArray(cmd) ? util.quote(cmd) : cmd);
+          client.write(eol);
+          isCommandSent = true;
+          execTimeoutObj = setTimeout(
+            () => reject(new Error(`Did not get any response from the Emulator telnet interface at ${host}:${port} ` +
+              `to '${cmd}' command after ${execTimeout}ms`)), execTimeout);
+          return;
+        }
+        clearTimeout(execTimeoutObj);
+        client.end();
+        const outputArr = output.split(eol);
+        // remove the redundant OK flag from the resulting command output
+        return resolve(outputArr.slice(0, outputArr.length - 1).join('\n').trim());
+      } else if (nokFlag.test(output)) {
+        clearTimeout(initTimeoutObj);
+        clearTimeout(execTimeoutObj);
+        client.end();
+        const outputArr = output.split(eol);
+        return reject(_.trim(outputArr[outputArr.length - 1]));
+      }
+    });
+  });
 };
 
 export default emuMethods;

--- a/test/functional/adb-emu-commands-e2e-specs.js
+++ b/test/functional/adb-emu-commands-e2e-specs.js
@@ -42,4 +42,16 @@ describe('adb emu commands', function () {
     app = await adb.getFocusedPackageAndActivity();
     app.appActivity.should.equal(secretActivity);
   });
+
+  describe('execEmuConsoleCommand', function () {
+    it('should print name', async function () {
+      const name = await adb.execEmuConsoleCommand(['avd', 'name']);
+      name.should.not.be.empty;
+    });
+
+    it('should fail if the command is unknown', async function () {
+      await adb.execEmuConsoleCommand(['avd', 'namer']).should.eventually
+        .be.rejected;
+    });
+  });
 });


### PR DESCRIPTION
Android Emulator console has a set of pretty handy features, like snapshotting, rotation, etc. There is no reason not to use them