### PR TITLE
chore: Use quote helper imported from appium-support

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -12,7 +12,6 @@ import Logcat from '../logcat';
 import { sleep, waitForCondition } from 'asyncbox';
 import { SubProcess } from 'teen_process';
 import B from 'bluebird';
-import { quote } from 'shell-quote';
 
 const MAX_SHELL_BUFFER_LENGTH = 1000;
 const NOT_CHANGEABLE_PERM_ERROR = /not a changeable permission type/i;
@@ -1618,7 +1617,7 @@ methods.screenrecord = function screenrecord (destination, options = {}) {
     'shell',
     ...cmd
   ];
-  log.debug(`Building screenrecord process with the command line: adb ${quote(fullCmd)}`);
+  log.debug(`Building screenrecord process with the command line: adb ${util.quote(fullCmd)}`);
   return new SubProcess(this.executable.path, fullCmd);
 };
 

--- a/lib/tools/android-manifest.js
+++ b/lib/tools/android-manifest.js
@@ -3,10 +3,9 @@ import log from '../logger.js';
 import {
   getAndroidPlatformAndPath, unzipFile,
   APKS_EXTENSION, parseManifest } from '../helpers.js';
-import { fs, zip, tempDir } from 'appium-support';
+import { fs, zip, tempDir, util } from 'appium-support';
 import _ from 'lodash';
 import path from 'path';
-import { quote } from 'shell-quote';
 import ApkReader from 'adbkit-apkreader';
 
 let manifestMethods = {};
@@ -143,7 +142,7 @@ manifestMethods.compileManifest = async function compileManifest (manifest, mani
       '-I', androidJarPath,
       '-v',
     ];
-    log.debug(`Compiling the manifest using '${quote([this.binaries.aapt2, ...args])}'`);
+    log.debug(`Compiling the manifest using '${util.quote([this.binaries.aapt2, ...args])}'`);
     await exec(this.binaries.aapt2, args);
   } catch (e) {
     log.debug('Cannot compile the manifest using aapt2. Defaulting to aapt. ' +
@@ -158,7 +157,7 @@ manifestMethods.compileManifest = async function compileManifest (manifest, mani
       '-F', resultPath,
       '-f',
     ];
-    log.debug(`Compiling the manifest using '${quote([this.binaries.aapt, ...args])}'`);
+    log.debug(`Compiling the manifest using '${util.quote([this.binaries.aapt, ...args])}'`);
     try {
       await exec(this.binaries.aapt, args);
     } catch (e1) {

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -3,12 +3,11 @@ import _fs from 'fs';
 import { exec } from 'teen_process';
 import path from 'path';
 import log from '../logger.js';
-import { tempDir, system, mkdirp, fs, zip } from 'appium-support';
+import { tempDir, system, mkdirp, fs, zip, util } from 'appium-support';
 import {
   getJavaForOs, getApksignerForOs, getJavaHome,
   rootDir, APKS_EXTENSION, unsignApk,
 } from '../helpers.js';
-import { quote } from 'shell-quote';
 
 const DEFAULT_PRIVATE_KEY = path.resolve(rootDir, 'keys', 'testkey.pk8');
 const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
@@ -33,7 +32,7 @@ apkSigningMethods.executeApksigner = async function executeApksigner (args = [])
     '-jar', apkSignerJar,
     ...args
   ];
-  log.debug(`Starting apksigner: ${quote(fullCmd)}`);
+  log.debug(`Starting apksigner: ${util.quote(fullCmd)}`);
   const {stdout, stderr} = await exec(fullCmd[0], fullCmd.slice(1));
   for (let [name, stream] of [['stdout', stdout], ['stderr', stderr]]) {
     if (!_.trim(stream)) {
@@ -74,7 +73,7 @@ apkSigningMethods.signWithDefaultCert = async function signWithDefaultCert (apk)
       `Original error: ${err.stderr || err.message}`);
     const signPath = path.resolve(this.helperJarPath, 'sign.jar');
     const fullCmd = [await getJavaForOs(), '-jar', signPath, apk, '--override'];
-    log.debug(`Starting sign.jar: ${quote(fullCmd)}`);
+    log.debug(`Starting sign.jar: ${util.quote(fullCmd)}`);
     try {
       await exec(fullCmd[0], fullCmd.slice(1));
     } catch (e) {
@@ -124,7 +123,7 @@ apkSigningMethods.signWithCustomCert = async function signWithCustomCert (apk) {
         '-storepass', this.keystorePassword,
         '-keypass', this.keyPassword,
         apk, this.keyAlias];
-      log.debug(`Starting jarsigner: ${quote(fullCmd)}`);
+      log.debug(`Starting jarsigner: ${util.quote(fullCmd)}`);
       await exec(fullCmd[0], fullCmd.slice(1));
     } catch (e) {
       throw new Error(`Could not sign with custom certificate. ` +

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -10,7 +10,6 @@ import {
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
-import { quote } from 'shell-quote';
 
 
 let systemCallMethods = {};
@@ -320,7 +319,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
   const execFunc = async () => {
     try {
       const args = [...this.executable.defaultArgs, ...cmd];
-      log.debug(`Running '${this.executable.path} ${quote(args)}'`);
+      log.debug(`Running '${this.executable.path} ${util.quote(args)}'`);
       let {stdout} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "lodash": "^4.0.0",
     "lru-cache": "^5.0.0",
     "semver": "^7.0.0",
-    "shell-quote": "^1.6.1",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.11.0",
     "utf7": "^1.0.2"


### PR DESCRIPTION
There is no need to explicitly import `shell-quote`, since it's already being exposed by appium-support module