### PR TITLE
fix: Update aapt2 commands

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -742,10 +742,11 @@ async function formatConfigMarker (configsGetter, desiredMarker, defaultMarker) 
   if (configMarker.toLowerCase().startsWith('en')
     && !configs.some((x) => x.trim() === configMarker)) {
     log.debug(`Resource configuration name '${configMarker}' is unknown. ` +
-      `Replacing it with '${defaultMarker || 'default'}'`);
+      `Replacing it with '${defaultMarker}'`);
     configMarker = defaultMarker;
+  } else {
+    log.debug(`Selected configuration: '${configMarker}'`);
   }
-  log.debug(`Selected configuration: '${configMarker}'`);
   return configMarker;
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -736,14 +736,16 @@ async function formatConfigMarker (configsGetter, desiredMarker, defaultMarker) 
   if (configMarker.includes('-') && !configMarker.includes('-r')) {
     configMarker = configMarker.replace('-', '-r');
   }
-  if (configMarker.toLowerCase().startsWith('en')) {
-    // Assume the 'en' configuration is the default one
-    if (!(await configsGetter()).map((x) => x.trim()).includes(configMarker)) {
-      log.debug(`There is no '${configMarker}' configuration. ` +
-        `Replacing it with '${defaultMarker || 'default'}'`);
-      configMarker = defaultMarker;
-    }
+  const configs = await configsGetter();
+  // Assume the 'en' configuration is the default one
+  if (configMarker.toLowerCase().startsWith('en')
+    && !configs.some((x) => x.trim() === configMarker)) {
+    log.debug(`Resource configuration name '${configMarker}' is unknown. ` +
+      `Replacing it with '${defaultMarker || 'default'}'`);
+    configMarker = defaultMarker;
   }
+  log.debug(`Selected configuration name: '${configMarker}'`);
+  log.debug(`All configurations: ${JSON.stringify(configs)}`);
   return configMarker;
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -737,6 +737,7 @@ async function formatConfigMarker (configsGetter, desiredMarker, defaultMarker) 
     configMarker = configMarker.replace('-', '-r');
   }
   const configs = await configsGetter();
+  log.debug(`Resource configurations: ${JSON.stringify(configs)}`);
   // Assume the 'en' configuration is the default one
   if (configMarker.toLowerCase().startsWith('en')
     && !configs.some((x) => x.trim() === configMarker)) {
@@ -744,8 +745,7 @@ async function formatConfigMarker (configsGetter, desiredMarker, defaultMarker) 
       `Replacing it with '${defaultMarker || 'default'}'`);
     configMarker = defaultMarker;
   }
-  log.debug(`Selected configuration name: '${configMarker}'`);
-  log.debug(`All configurations: ${JSON.stringify(configs)}`);
+  log.debug(`Selected configuration: '${configMarker}'`);
   return configMarker;
 }
 

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -801,7 +801,7 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
       const {stdout} = await exec(this.binaries.aapt, [
         'd', 'configurations', appPath,
       ]);
-      return stdout.split(os.EOL).filter(Boolean);
+      return stdout.split(os.EOL);
     }, language, '(default)');
 
     const {stdout} = await exec(this.binaries.aapt, [
@@ -818,7 +818,7 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
       const {stdout} = await exec(this.binaries.aapt2, [
         'd', 'configurations', appPath,
       ]);
-      return stdout.split(os.EOL).filter(Boolean);
+      return stdout.split(os.EOL);
     }, language, '');
 
     try {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -801,7 +801,7 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
       const {stdout} = await exec(this.binaries.aapt, [
         'd', 'configurations', appPath,
       ]);
-      return stdout.split(os.EOL);
+      return _.uniq(stdout.split(os.EOL));
     }, language, '(default)');
 
     const {stdout} = await exec(this.binaries.aapt, [
@@ -818,7 +818,7 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
       const {stdout} = await exec(this.binaries.aapt2, [
         'd', 'configurations', appPath,
       ]);
-      return stdout.split(os.EOL);
+      return _.uniq(stdout.split(os.EOL));
     }, language, '');
 
     try {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -1,6 +1,6 @@
 import {
   buildStartCmd, APKS_EXTENSION, buildInstallArgs,
-  APK_INSTALL_TIMEOUT, DEFAULT_ADB_EXEC_TIMEOUT, getApkanalyzerForOs,
+  APK_INSTALL_TIMEOUT, DEFAULT_ADB_EXEC_TIMEOUT,
   parseManifest, parseAaptStrings, parseAapt2Strings, formatConfigMarker } from '../helpers.js';
 import { exec } from 'teen_process';
 import log from '../logger.js';
@@ -799,18 +799,13 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
 
     configMarker = await formatConfigMarker(async () => {
       const {stdout} = await exec(this.binaries.aapt, [
-        'd',
-        'configurations',
-        appPath,
+        'd', 'configurations', appPath,
       ]);
       return stdout.split(os.EOL);
     }, language, '(default)');
 
     const {stdout} = await exec(this.binaries.aapt, [
-      'd',
-      '--values',
-      'resources',
-      appPath,
+      'd', '--values', 'resources', appPath,
     ]);
     apkStrings = parseAaptStrings(stdout, configMarker);
   } catch (e) {
@@ -820,21 +815,15 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
     await this.initAapt2();
 
     configMarker = await formatConfigMarker(async () => {
-      const apkanalyzerPath = await getApkanalyzerForOs(this);
-      const {stdout} = await exec(apkanalyzerPath, [
-        'resources', 'configs',
-        '--type', 'string',
-        appPath,
-      ], {
-        shell: true,
-        cwd: path.dirname(apkanalyzerPath),
-      });
+      const {stdout} = await exec(this.binaries.aapt2, [
+        'd', 'configurations', appPath,
+      ]);
       return stdout.split(os.EOL);
     }, language, '');
 
     try {
       const {stdout} = await exec(this.binaries.aapt2, [
-        'dump', appPath,
+        'd', 'resources', appPath,
       ]);
       apkStrings = parseAapt2Strings(stdout, configMarker);
     } catch (e) {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -801,7 +801,7 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
       const {stdout} = await exec(this.binaries.aapt, [
         'd', 'configurations', appPath,
       ]);
-      return stdout.split(os.EOL);
+      return stdout.split(os.EOL).filter(Boolean);
     }, language, '(default)');
 
     const {stdout} = await exec(this.binaries.aapt, [
@@ -818,7 +818,7 @@ apkUtilsMethods.extractStringsFromApk = async function extractStringsFromApk (ap
       const {stdout} = await exec(this.binaries.aapt2, [
         'd', 'configurations', appPath,
       ]);
-      return stdout.split(os.EOL);
+      return stdout.split(os.EOL).filter(Boolean);
     }, language, '');
 
     try {


### PR DESCRIPTION
It looks like Google has updated aapt2 commands spec since we checked that for the last time: https://developer.android.com/studio/command-line/aapt2