### PR TITLE
refactor: Add a possibility to customize emulator env on startup

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -783,6 +783,37 @@ function parseJsonData (output, entityName) {
   }
 }
 
+/**
+ * Transforms the given language and country abbreviations
+ * to AVD arguments array
+ *
+ * @param {?string} language Language name, for example 'fr'
+ * @param {?string} country Country name, for example 'CA'
+ * @returns {Array<string>} The generated arguments. The
+ * resulting array might be empty if both arguments are empty
+ */
+function toAvdLocaleArgs (language, country) {
+  const result = [];
+  if (language && _.isString(language)) {
+    result.push('-prop', `persist.sys.language=${language.toLowerCase()}`);
+  }
+  if (country && _.isString(country)) {
+    result.push('-prop', `persist.sys.country=${country.toUpperCase()}`);
+  }
+  let locale;
+  if (_.isString(language) && _.isString(country) && language && country) {
+    locale = language.toLowerCase() + '-' + country.toUpperCase();
+  } else if (language && _.isString(language)) {
+    locale = language.toLowerCase();
+  } else if (country && _.isString(country)) {
+    locale = country;
+  }
+  if (locale) {
+    result.push('-prop', `persist.sys.locale=${locale}`);
+  }
+  return result;
+}
+
 export {
   getAndroidPlatformAndPath, unzipFile,
   getIMEListFromOutput, getJavaForOs, isShowingLockscreen, isCurrentFocusOnKeyguard,
@@ -791,5 +822,5 @@ export {
   getApkanalyzerForOs, getOpenSslForOs, extractMatchingPermissions, APKS_EXTENSION,
   APK_INSTALL_TIMEOUT, APKS_INSTALL_TIMEOUT, buildInstallArgs, APK_EXTENSION,
   DEFAULT_ADB_EXEC_TIMEOUT, parseManifest, parseAaptStrings, parseAapt2Strings,
-  formatConfigMarker, parseJsonData, unsignApk,
+  formatConfigMarker, parseJsonData, unsignApk, toAvdLocaleArgs,
 };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -3,10 +3,9 @@ import log from '../logger.js';
 import B from 'bluebird';
 import { system, fs, util, tempDir, timing } from 'appium-support';
 import {
-  getSdkToolsVersion,
-  getBuildToolsDirs,
-  getOpenSslForOs,
-  DEFAULT_ADB_EXEC_TIMEOUT } from '../helpers';
+  getSdkToolsVersion, getBuildToolsDirs, toAvdLocaleArgs,
+  getOpenSslForOs, DEFAULT_ADB_EXEC_TIMEOUT
+} from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
@@ -712,33 +711,12 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {
     avdName = avdName.substr(1);
   }
   await this.checkAvdExist(avdName);
+
   const launchArgs = ['-avd', avdName];
-
-  if (_.isString(language)) {
-    log.debug(`Setting Android Device Language to ${language}`);
-    launchArgs.push('-prop', `persist.sys.language=${language.toLowerCase()}`);
-  }
-  if (_.isString(country)) {
-    log.debug(`Setting Android Device Country to ${country}`);
-    launchArgs.push('-prop', `persist.sys.country=${country.toUpperCase()}`);
-  }
-  let locale;
-  if (_.isString(language) && _.isString(country)) {
-    locale = language.toLowerCase() + '-' + country.toUpperCase();
-  } else if (_.isString(language)) {
-    locale = language.toLowerCase();
-  } else if (_.isString(country)) {
-    locale = country;
-  }
-  if (_.isString(locale)) {
-    log.debug(`Setting Android Device Locale to ${locale}`);
-    launchArgs.push('-prop', `persist.sys.locale=${locale}`);
-  }
-
+  launchArgs.push(...(toAvdLocaleArgs(language, country)));
   if (!_.isEmpty(args)) {
     launchArgs.push(...(_.isArray(args) ? args : util.shellParse(`${args}`)));
   }
-
   log.debug(`Running '${emulatorBinaryPath}' with args: ${util.quote(launchArgs)}`);
   if (!_.isEmpty(env)) {
     log.debug(`Customized emulator environment: ${JSON.stringify(env)}`);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -676,26 +676,43 @@ systemCallMethods.killEmulator = async function killEmulator (avdName = null, ti
 };
 
 /**
- * Start an emulator with given parameters and wait until it is full started.
+ * @typedef {Object} AvdLaunchOptions
+ * @property {string|Array<string>} args Additional emulator command line arguments
+ * @property {Object} env Additional emulator environment variables
+ * @property {string} language Emulator system language
+ * @property {string} country Emulator system country
+ * @property {number} launchTimeout [60000] Emulator startup timeout in milliseconds
+ * @property {number} readyTimeout [60000] The maximum period of time to wait until Emulator
+ * is ready for usage in milliseconds
+ * @property {number} retryTimes [1] The maximum number of startup retries
+ */
+
+/**
+ * Start an emulator with given parameters and wait until it is fully started.
  *
  * @param {string} avdName - The name of an existing emulator.
- * @param {Array.<string>|string} avdArgs - Additional emulator command line argument.
- * @param {?string} language - Emulator system language.
- * @param {?country} country - Emulator system country.
- * @param {number} avdLaunchTimeout [60000] - Emulator startup timeout in milliseconds.
- * @param {number} retryTimes [1] - The maximum number of startup retries.
+ * @param {AvdLaunchOptions} opts
  * @throws {Error} If the emulator fails to start within the given timeout.
  */
-systemCallMethods.launchAVD = async function launchAVD (avdName, avdArgs, language, country,
-  avdLaunchTimeout = 60000, avdReadyTimeout = 60000, retryTimes = 1) {
+systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {
+  const {
+    args = [],
+    env = {},
+    language,
+    country,
+    launchTimeout = 60000,
+    readyTimeout = 60000,
+    retryTimes = 1,
+  } = opts;
   log.debug(`Launching Emulator with AVD ${avdName}, launchTimeout ` +
-            `${avdLaunchTimeout}ms and readyTimeout ${avdReadyTimeout}ms`);
-  let emulatorBinaryPath = await this.getSdkBinaryPath('emulator');
+            `${launchTimeout}ms and readyTimeout ${readyTimeout}ms`);
+  const emulatorBinaryPath = await this.getSdkBinaryPath('emulator');
   if (avdName[0] === '@') {
     avdName = avdName.substr(1);
   }
   await this.checkAvdExist(avdName);
-  let launchArgs = ['-avd', avdName];
+  const launchArgs = ['-avd', avdName];
+
   if (_.isString(language)) {
     log.debug(`Setting Android Device Language to ${language}`);
     launchArgs.push('-prop', `persist.sys.language=${language.toLowerCase()}`);
@@ -716,11 +733,18 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, avdArgs, langua
     log.debug(`Setting Android Device Locale to ${locale}`);
     launchArgs.push('-prop', `persist.sys.locale=${locale}`);
   }
-  if (!_.isEmpty(avdArgs)) {
-    launchArgs.push(...(_.isArray(avdArgs) ? avdArgs : avdArgs.split(' ')));
+
+  if (!_.isEmpty(args)) {
+    launchArgs.push(...(_.isArray(args) ? args : util.shellParse(`${args}`)));
   }
-  log.debug(`Running '${emulatorBinaryPath}' with args: ${JSON.stringify(launchArgs)}`);
-  let proc = new SubProcess(emulatorBinaryPath, launchArgs);
+
+  log.debug(`Running '${emulatorBinaryPath}' with args: ${util.quote(launchArgs)}`);
+  if (!_.isEmpty(env)) {
+    log.debug(`Customized emulator environment: ${JSON.stringify(env)}`);
+  }
+  const proc = new SubProcess(emulatorBinaryPath, launchArgs, {
+    env: Object.assign({}, process.env, env),
+  });
   await proc.start(0);
   proc.on('output', (stdout, stderr) => {
     for (let line of (stdout || stderr || '').split('\n').filter(Boolean)) {
@@ -730,8 +754,8 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, avdArgs, langua
   proc.on('die', (code, signal) => {
     log.warn(`Emulator avd ${avdName} exited with code ${code}${signal ? `, signal ${signal}` : ''}`);
   });
-  await retry(retryTimes, async () => await this.getRunningAVDWithRetry(avdName, avdLaunchTimeout));
-  await this.waitForEmulatorReady(avdReadyTimeout);
+  await retry(retryTimes, async () => await this.getRunningAVDWithRetry(avdName, launchTimeout));
+  await this.waitForEmulatorReady(readyTimeout);
   return proc;
 };
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -691,7 +691,8 @@ systemCallMethods.killEmulator = async function killEmulator (avdName = null, ti
  * Start an emulator with given parameters and wait until it is fully started.
  *
  * @param {string} avdName - The name of an existing emulator.
- * @param {AvdLaunchOptions} opts
+ * @param {?AvdLaunchOptions} opts
+ * @returns {SubProcess} Emulator subprocess instance
  * @throws {Error} If the emulator fails to start within the given timeout.
  */
 systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {


### PR DESCRIPTION
BREAKING CHANGE: Moved all non-mandatory options into the single opts argument