### PR TITLE
feat: add cmdline-tools path in binary search

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -75,9 +75,9 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
   const binaryLocs = [
     'platform-tools',
     'emulator',
+    `cmdline-tools${path.sep}latest${path.sep}bin`,
     'tools',
-    `tools${path.sep}bin`,
-    `cmdline-tools${path.sep}latest${path.sep}bin`
+    `tools${path.sep}bin`
   ].map((x) => path.resolve(this.sdkRoot, x, fullBinaryName));
   // get subpaths for currently installed build tool directories
   let buildToolsDirs = await getBuildToolsDirs(this.sdkRoot);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -78,7 +78,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
     ['cmdline-tools', 'latest', 'bin'],
     'tools',
     ['tools', 'bin']
-  ].map((x) => path.resolve(this.sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName))
+  ].map((x) => path.resolve(this.sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
   // get subpaths for currently installed build tool directories
   let buildToolsDirs = await getBuildToolsDirs(this.sdkRoot);
   if (this.buildToolsVersion) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -72,8 +72,13 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
   }
 
   const fullBinaryName = this.getBinaryNameForOS(binaryName);
-  const binaryLocs = ['platform-tools', 'emulator', 'tools', `tools${path.sep}bin`]
-    .map((x) => path.resolve(this.sdkRoot, x, fullBinaryName));
+  const binaryLocs = [
+    'platform-tools',
+    'emulator',
+    'tools',
+    `tools${path.sep}bin`,
+    `cmdline-tools${path.sep}latest${path.sep}bin`
+  ].map((x) => path.resolve(this.sdkRoot, x, fullBinaryName));
   // get subpaths for currently installed build tool directories
   let buildToolsDirs = await getBuildToolsDirs(this.sdkRoot);
   if (this.buildToolsVersion) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -75,10 +75,10 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
   const binaryLocs = [
     'platform-tools',
     'emulator',
-    `cmdline-tools${path.sep}latest${path.sep}bin`,
+    ['cmdline-tools', 'latest', 'bin'],
     'tools',
-    `tools${path.sep}bin`
-  ].map((x) => path.resolve(this.sdkRoot, x, fullBinaryName));
+    ['tools', 'bin']
+  ].map((x) => path.resolve(this.sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName))
   // get subpaths for currently installed build tool directories
   let buildToolsDirs = await getBuildToolsDirs(this.sdkRoot);
   if (this.buildToolsVersion) {


### PR DESCRIPTION
Noticed below commands were in `cmdline-tools` path for newer packages.

```
apkanalyzer
avdmanager
lint
screenshot2
sdkmanager
```

![image](https://user-images.githubusercontent.com/5511591/82724041-18d5f700-9d0e-11ea-8b32-edabefbd465f.png)

`latest` is the default one. (I mean other versions can select when 'show packages' is on. For now, it is only 1.0 though)