### PR TITLE
feat: Expose get android binary path

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 import * as adb from './lib/adb';
 
 
-const { ADB, DEFAULT_ADB_PORT } = adb;
+const { ADB, DEFAULT_ADB_PORT, getAndroidBinaryPath } = adb;
 
 export default ADB;
-export { DEFAULT_ADB_PORT, ADB };
+export { DEFAULT_ADB_PORT, ADB, getAndroidBinaryPath };

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import os from 'os';
 import path from 'path';
-import methods from './tools/index.js';
+import methods, { getAndroidBinaryPath } from './tools/index.js';
 import {
   rootDir, DEFAULT_ADB_EXEC_TIMEOUT, requireSdkRoot, getSdkRootFromEnv
 } from './helpers';
@@ -73,4 +73,4 @@ for (const [fnName, fn] of _.toPairs(methods)) {
 }
 
 export default ADB;
-export { ADB, DEFAULT_ADB_PORT };
+export { ADB, DEFAULT_ADB_PORT, getAndroidBinaryPath };

--- a/lib/tools/index.js
+++ b/lib/tools/index.js
@@ -1,6 +1,6 @@
 import methods from './adb-commands.js';
 import manifestMethods from './android-manifest.js';
-import systemCallMethods from './system-calls.js';
+import systemCallMethods, { getAndroidBinaryPath } from './system-calls.js';
 import apkSigningMethods from './apk-signing.js';
 import apkUtilsMethods from './apk-utils.js';
 import apksUtilsMethods from './apks-utils.js';
@@ -19,3 +19,4 @@ Object.assign(
 );
 
 export default methods;
+export { getAndroidBinaryPath };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -4,7 +4,7 @@ import B from 'bluebird';
 import { system, fs, util, tempDir, timing } from 'appium-support';
 import {
   getSdkToolsVersion, getBuildToolsDirs, toAvdLocaleArgs,
-  getOpenSslForOs, DEFAULT_ADB_EXEC_TIMEOUT
+  getOpenSslForOs, DEFAULT_ADB_EXEC_TIMEOUT, getSdkRootFromEnv
 } from '../helpers';
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval, waitForCondition } from 'asyncbox';
@@ -40,6 +40,18 @@ systemCallMethods.getSdkBinaryPath = async function getSdkBinaryPath (binaryName
  *                  for example, 'android.bat' on Windows.
  */
 systemCallMethods.getBinaryNameForOS = _.memoize(function getBinaryNameForOS (binaryName) {
+  return getBinaryName(binaryName);
+});
+
+/**
+ * Retrieve full binary name for the current operating system.
+ *
+ * @param {string} binaryName - simple binary name, for example 'android'.
+ * @return {string} Formatted binary name depending on the current platform,
+ *                  for example, 'android.bat' on Windows.
+ */
+
+function getBinaryName (binaryName) {
   if (!system.isWindows()) {
     return binaryName;
   }
@@ -51,7 +63,15 @@ systemCallMethods.getBinaryNameForOS = _.memoize(function getBinaryNameForOS (bi
     return `${binaryName}.exe`;
   }
   return binaryName;
-});
+}
+
+const ANDROID_BINARIES_CANDIDATES = [
+  'platform-tools',
+  'emulator',
+  ['cmdline-tools', 'latest', 'bin'],
+  'tools',
+  ['tools', 'bin']
+];
 
 /**
  * Retrieve full path to the given binary and caches it into `binaries`
@@ -70,15 +90,11 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
   if (this.binaries[binaryName]) {
     return this.binaries[binaryName];
   }
-
   const fullBinaryName = this.getBinaryNameForOS(binaryName);
-  const binaryLocs = [
-    'platform-tools',
-    'emulator',
-    ['cmdline-tools', 'latest', 'bin'],
-    'tools',
-    ['tools', 'bin']
-  ].map((x) => path.resolve(this.sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
+
+  const binaryLocs = ANDROID_BINARIES_CANDIDATES.map((x) =>
+    path.resolve(this.sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
+
   // get subpaths for currently installed build tool directories
   let buildToolsDirs = await getBuildToolsDirs(this.sdkRoot);
   if (this.buildToolsVersion) {
@@ -113,6 +129,41 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
   this.binaries[binaryName] = binaryLoc;
   return binaryLoc;
 };
+
+/**
+ * Retrieve full path to the given binary.
+ * This method does not have cache.
+ *
+ * @param {string} binaryName - Simple name of a binary file.
+ * @return {string} Full path to the given binary. The method tries
+ *                  to enumerate all the known locations where the binary
+ *                  might be located and stops the search as soon as the first
+ *                  match is found on the local file system.
+ * @throws {Error} If the binary with given name is not present at any
+ *                 of known locations or Android SDK is not installed on the
+ *                 local file system.
+ */
+async function getAndroidBinaryPath (binaryName) {
+  const fullBinaryName = getBinaryName(binaryName);
+  const sdkRoot = getSdkRootFromEnv();
+
+  const binaryLocs = ANDROID_BINARIES_CANDIDATES.map((x) => path.resolve(sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
+  // get subpaths for currently installed build tool directories
+
+  let binaryLoc = null;
+  for (const loc of binaryLocs) {
+    if (await fs.exists(loc)) {
+      binaryLoc = loc;
+      break;
+    }
+  }
+  if (_.isNull(binaryLoc)) {
+    throw new Error(`Could not find '${fullBinaryName}' in ${JSON.stringify(binaryLocs)}. ` +
+      `Do you have Android Build Tools at '${this.sdkRoot}'?`);
+  }
+
+  return binaryLoc;
+}
 
 /**
  * Retrieve full path to a binary file using the standard system lookup tool.
@@ -1155,4 +1206,4 @@ systemCallMethods.isMitmCertificateInstalled = async function isMitmCertificateI
 };
 
 export default systemCallMethods;
-export { DEFAULT_ADB_EXEC_TIMEOUT };
+export { DEFAULT_ADB_EXEC_TIMEOUT, getAndroidBinaryPath };

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -58,7 +58,6 @@ systemCallMethods.getBinaryNameForOS = _.memoize(function getBinaryNameForOSMemo
  * @return {string} Formatted binary name depending on the current platform,
  *                  for example, 'android.bat' on Windows.
  */
-
 function getBinaryNameForOS (binaryName) {
   if (!system.isWindows()) {
     return binaryName;

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -143,11 +143,13 @@ function getAndroidBinariesLocations (sdkRoot, fullBinaryName) {
  * This method does not have cache.
  *
  * @param {string} binaryName - Simple name of a binary file.
- * @return {?string} Full path to the given binary. The method tries
- *                   to enumerate all the known locations where the binary
- *                   might be located and stops the search as soon as the first
- *                   match is found on the local file system.
- *                   It returns null if no matched path.
+ * @return {string} Full path to the given binary. The method tries
+ *                  to enumerate all the known locations where the binary
+ *                  might be located and stops the search as soon as the first
+ *                  match is found on the local file system.
+ * @throws {Error} If the binary with given name is not present at any
+ *                 of known locations or Android SDK is not installed on the
+ *                 local file system.
  */
 async function getAndroidBinaryPath (binaryName) {
   const fullBinaryName = getBinaryNameForOS(binaryName);
@@ -162,6 +164,11 @@ async function getAndroidBinaryPath (binaryName) {
       break;
     }
   }
+  if (_.isNull(binaryLoc)) {
+    throw new Error(`Could not find '${fullBinaryName}' in ${JSON.stringify(binaryLocs)}. ` +
+      `Do you have Android Build Tools at '${sdkRoot}'?`);
+  }
+
   return binaryLoc;
 }
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -22,6 +22,14 @@ const DEVICE_CONNECTING_ERROR_REGEXP = new RegExp('error: device still connectin
 
 const CERTS_ROOT = '/system/etc/security/cacerts';
 
+const ANDROID_BINARIES_CANDIDATES = [
+  'platform-tools',
+  'emulator',
+  ['cmdline-tools', 'latest', 'bin'],
+  'tools',
+  ['tools', 'bin']
+];
+
 /**
  * Retrieve full path to the given binary.
  *
@@ -64,14 +72,6 @@ function getBinaryNameForOS (binaryName) {
   }
   return binaryName;
 }
-
-const ANDROID_BINARIES_CANDIDATES = [
-  'platform-tools',
-  'emulator',
-  ['cmdline-tools', 'latest', 'bin'],
-  'tools',
-  ['tools', 'bin']
-];
 
 /**
  * Retrieve full path to the given binary and caches it into `binaries`

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -22,7 +22,7 @@ const DEVICE_CONNECTING_ERROR_REGEXP = new RegExp('error: device still connectin
 
 const CERTS_ROOT = '/system/etc/security/cacerts';
 
-const ANDROID_BINARIES_CANDIDATES = [
+const SDK_BINARY_ROOTS = [
   'platform-tools',
   'emulator',
   ['cmdline-tools', 'latest', 'bin'],
@@ -90,7 +90,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
     return this.binaries[binaryName];
   }
   const fullBinaryName = this.getBinaryNameForOS(binaryName);
-  const binaryLocs = getAndroidBinariesLocations(this.sdkRoot, fullBinaryName);
+  const binaryLocs = getSdkBinaryLocationCandidates(this.sdkRoot, fullBinaryName);
 
   // get subpaths for currently installed build tool directories
   let buildToolsDirs = await getBuildToolsDirs(this.sdkRoot);
@@ -132,9 +132,11 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
  *
  * @param {string} sdkRoot The path to Andoird SDK root.
  * @param {string} fullBinaryName The name of full binary name.
+ * @return {Array<string>} The list of SDK_BINARY_ROOTS paths
+ *                          with sdkRoot and fullBinaryName.
  */
-function getAndroidBinariesLocations (sdkRoot, fullBinaryName) {
-  return ANDROID_BINARIES_CANDIDATES.map((x) =>
+function getSdkBinaryLocationCandidates (sdkRoot, fullBinaryName) {
+  return SDK_BINARY_ROOTS.map((x) =>
     path.resolve(sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
 }
 
@@ -143,10 +145,12 @@ function getAndroidBinariesLocations (sdkRoot, fullBinaryName) {
  * This method does not have cache.
  *
  * @param {string} binaryName - Simple name of a binary file.
+ *                              e.g. 'adb', 'android'
  * @return {string} Full path to the given binary. The method tries
  *                  to enumerate all the known locations where the binary
  *                  might be located and stops the search as soon as the first
  *                  match is found on the local file system.
+ *                  e.g. '/Path/To/Android/sdk/platform-tools/adb'
  * @throws {Error} If the binary with given name is not present at any
  *                 of known locations or Android SDK is not installed on the
  *                 local file system.
@@ -154,22 +158,14 @@ function getAndroidBinariesLocations (sdkRoot, fullBinaryName) {
 async function getAndroidBinaryPath (binaryName) {
   const fullBinaryName = getBinaryNameForOS(binaryName);
   const sdkRoot = getSdkRootFromEnv();
-  const binaryLocs = getAndroidBinariesLocations(sdkRoot, fullBinaryName);
-  // get subpaths for currently installed build tool directories
-
-  let binaryLoc = null;
+  const binaryLocs = getSdkBinaryLocationCandidates(sdkRoot, fullBinaryName);
   for (const loc of binaryLocs) {
     if (await fs.exists(loc)) {
-      binaryLoc = loc;
-      break;
+      return loc;
     }
   }
-  if (_.isNull(binaryLoc)) {
-    throw new Error(`Could not find '${fullBinaryName}' in ${JSON.stringify(binaryLocs)}. ` +
-      `Do you have Android Build Tools at '${sdkRoot}'?`);
-  }
-
-  return binaryLoc;
+  throw new Error(`Could not find '${fullBinaryName}' in ${JSON.stringify(binaryLocs)}. ` +
+    `Do you have Android Build Tools installed at '${sdkRoot}'?`);
 }
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -33,14 +33,14 @@ systemCallMethods.getSdkBinaryPath = async function getSdkBinaryPath (binaryName
 };
 
 /**
- * Retrieve full binary name for the current operating system.
+ * Retrieve full binary name for the current operating system as memotize.
  *
  * @param {string} binaryName - simple binary name, for example 'android'.
  * @return {string} Formatted binary name depending on the current platform,
  *                  for example, 'android.bat' on Windows.
  */
-systemCallMethods.getBinaryNameForOS = _.memoize(function getBinaryNameForOS (binaryName) {
-  return getBinaryName(binaryName);
+systemCallMethods.getBinaryNameForOS = _.memoize(function getBinaryNameForOSMemorize (binaryName) {
+  return getBinaryNameForOS(binaryName);
 });
 
 /**
@@ -51,7 +51,7 @@ systemCallMethods.getBinaryNameForOS = _.memoize(function getBinaryNameForOS (bi
  *                  for example, 'android.bat' on Windows.
  */
 
-function getBinaryName (binaryName) {
+function getBinaryNameForOS (binaryName) {
   if (!system.isWindows()) {
     return binaryName;
   }
@@ -144,10 +144,11 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
  *                 local file system.
  */
 async function getAndroidBinaryPath (binaryName) {
-  const fullBinaryName = getBinaryName(binaryName);
+  const fullBinaryName = getBinaryNameForOS(binaryName);
   const sdkRoot = getSdkRootFromEnv();
 
-  const binaryLocs = ANDROID_BINARIES_CANDIDATES.map((x) => path.resolve(sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
+  const binaryLocs = ANDROID_BINARIES_CANDIDATES.map((x) =>
+    path.resolve(sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
   // get subpaths for currently installed build tool directories
 
   let binaryLoc = null;
@@ -159,7 +160,7 @@ async function getAndroidBinaryPath (binaryName) {
   }
   if (_.isNull(binaryLoc)) {
     throw new Error(`Could not find '${fullBinaryName}' in ${JSON.stringify(binaryLocs)}. ` +
-      `Do you have Android Build Tools at '${this.sdkRoot}'?`);
+      `Do you have Android Build Tools at '${sdkRoot}'?`);
   }
 
   return binaryLoc;

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -21,7 +21,6 @@ const DEVICE_NOT_FOUND_ERROR_REGEXP = new RegExp(`error: device ('.+' )?not foun
 const DEVICE_CONNECTING_ERROR_REGEXP = new RegExp('error: device still connecting', 'i');
 
 const CERTS_ROOT = '/system/etc/security/cacerts';
-
 const SDK_BINARY_ROOTS = [
   'platform-tools',
   'emulator',

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -143,13 +143,11 @@ function getAndroidBinariesLocations (sdkRoot, fullBinaryName) {
  * This method does not have cache.
  *
  * @param {string} binaryName - Simple name of a binary file.
- * @return {string} Full path to the given binary. The method tries
- *                  to enumerate all the known locations where the binary
- *                  might be located and stops the search as soon as the first
- *                  match is found on the local file system.
- * @throws {Error} If the binary with given name is not present at any
- *                 of known locations or Android SDK is not installed on the
- *                 local file system.
+ * @return {?string} Full path to the given binary. The method tries
+ *                   to enumerate all the known locations where the binary
+ *                   might be located and stops the search as soon as the first
+ *                   match is found on the local file system.
+ *                   It returns null if no matched path.
  */
 async function getAndroidBinaryPath (binaryName) {
   const fullBinaryName = getBinaryNameForOS(binaryName);
@@ -164,11 +162,6 @@ async function getAndroidBinaryPath (binaryName) {
       break;
     }
   }
-  if (_.isNull(binaryLoc)) {
-    throw new Error(`Could not find '${fullBinaryName}' in ${JSON.stringify(binaryLocs)}. ` +
-      `Do you have Android Build Tools at '${sdkRoot}'?`);
-  }
-
   return binaryLoc;
 }
 

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -91,9 +91,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
     return this.binaries[binaryName];
   }
   const fullBinaryName = this.getBinaryNameForOS(binaryName);
-
-  const binaryLocs = ANDROID_BINARIES_CANDIDATES.map((x) =>
-    path.resolve(this.sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
+  const binaryLocs = getAndroidBinariesLocations(this.sdkRoot, fullBinaryName);
 
   // get subpaths for currently installed build tool directories
   let buildToolsDirs = await getBuildToolsDirs(this.sdkRoot);
@@ -131,6 +129,17 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
 };
 
 /**
+ *  Returns the Android binaries locations
+ *
+ * @param {string} sdkRoot The path to Andoird SDK root.
+ * @param {string} fullBinaryName The name of full binary name.
+ */
+function getAndroidBinariesLocations (sdkRoot, fullBinaryName) {
+  return ANDROID_BINARIES_CANDIDATES.map((x) =>
+    path.resolve(sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
+}
+
+/**
  * Retrieve full path to the given binary.
  * This method does not have cache.
  *
@@ -146,9 +155,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
 async function getAndroidBinaryPath (binaryName) {
   const fullBinaryName = getBinaryNameForOS(binaryName);
   const sdkRoot = getSdkRootFromEnv();
-
-  const binaryLocs = ANDROID_BINARIES_CANDIDATES.map((x) =>
-    path.resolve(sdkRoot, ...(_.isArray(x) ? x : [x]), fullBinaryName));
+  const binaryLocs = getAndroidBinariesLocations(sdkRoot, fullBinaryName);
   // get subpaths for currently installed build tool directories
 
   let binaryLoc = null;


### PR DESCRIPTION
I want to call only `getAndroidBinaryPath` to resolve android related binaries in appium-doctor in https://github.com/appium/appium-doctor/pull/101

For it, would like to expose the method outside of ADB instance.
Is this PR correct way?

I tested this branch worked on the doctor and UIA2 on my local (with `link`)