### PR TITLE
feat: Add reconnect command handler

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -973,7 +973,7 @@ methods.restart = async function restart () {
     await this.stopLogcat();
     await this.restartAdb();
     await this.waitForDevice(60);
-    await this.startLogcat();
+    await this.startLogcat(this._logcatStartupParams);
   } catch (e) {
     throw new Error(`Restart failed. Original error: ${e.message}`);
   }
@@ -1018,6 +1018,7 @@ methods.startLogcat = async function startLogcat (opts = {}) {
     clearDeviceLogsOnStart: !!this.clearDeviceLogsOnStart,
   });
   await this.logcat.startCapture(opts);
+  this._logcatStartupParams = opts;
 };
 
 /**

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -977,8 +977,11 @@ apkUtilsMethods.ensureCurrentLocale = async function ensureCurrentLocale (langua
     } catch (err) {
       // if there has been an error, restart adb and retry
       log.error(`Unable to check device localization: ${err.message}`);
-      log.debug('Restarting ADB and retrying...');
-      await this.restartAdb();
+      try {
+        await this.reconnect();
+      } catch (ign) {
+        await this.restartAdb();
+      }
       throw err;
     }
   });

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -267,13 +267,41 @@ systemCallMethods.getDevicesWithRetry = async function getDevicesWithRetry (time
       }
     } catch (ign) {}
 
-    log.debug('Could not find devices, restarting adb server...');
-    await this.restartAdb();
+    log.debug('Could not find online devices');
+    try {
+      await this.reconnect();
+    } catch (ign) {
+      await this.restartAdb();
+    }
     // cool down
     await sleep(200);
     return await getDevices();
   };
   return await getDevices();
+};
+
+/**
+ * Kick current connection from host/device side and make it reconnect
+ *
+ * @param {?string} target [offline] One of possible targets to reconnect:
+ * offline, device or null
+ * Providing `null` will cause reconnection to happen from the host side.
+ *
+ * @throws {Error} If either ADB version is too old and does not support this
+ * command or there was a failure during reconnect.
+ */
+systemCallMethods.reconnect = async function reconnect (target = 'offline') {
+  log.debug(`Reconnecting adb (target ${target})`);
+
+  const args = ['reconnect'];
+  if (target) {
+    args.push(target);
+  }
+  try {
+    await this.adbExec(args);
+  } catch (e) {
+    throw new Error(`Cannot reconnect adb. Original error: ${e.stderr || e.message}`);
+  }
 };
 
 /**
@@ -906,13 +934,17 @@ systemCallMethods.waitForEmulatorReady = async function waitForEmulatorReady (ti
 systemCallMethods.waitForDevice = async function waitForDevice (appDeviceReadyTimeout = 30) {
   this.appDeviceReadyTimeout = appDeviceReadyTimeout;
   const retries = 3;
-  const timeout = parseInt(this.appDeviceReadyTimeout, 10) / retries * 1000;
+  const timeout = parseInt(this.appDeviceReadyTimeout, 10) * 1000 / retries;
   await retry(retries, async () => {
     try {
       await this.adbExec('wait-for-device', {timeout});
       await this.ping();
     } catch (e) {
-      await this.restartAdb();
+      try {
+        await this.reconnect();
+      } catch (ign) {
+        await this.restartAdb();
+      }
       await this.getConnectedDevices();
       throw new Error(`Error waiting for the device to be available. Original error: '${e.message}'`);
     }
@@ -986,7 +1018,11 @@ systemCallMethods.changeUserPrivileges = async function changeUserPrivileges (is
       if (['closed', 'device offline', 'timeout expired']
           .some((x) => (err.stderr || '').toLowerCase().includes(x))) {
         log.warn(`Attempt to ${cmd} caused ADB to think the device went offline`);
-        await this.restartAdb();
+        try {
+          await this.reconnect();
+        } catch (ign) {
+          await this.restartAdb();
+        }
         return await cmdFunc();
       } else {
         throw err;

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -272,7 +272,7 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
           stderr: 'adb: unable to connect for root: closed\n',
           code: 1
         });
-      mocks.adb.expects('restartAdb').once();
+      mocks.adb.expects('reconnect').once();
       await adb.root().should.eventually.eql({isSuccessful: false, wasAlreadyRooted: false});
     });
     it('should not restart adb if root throws err but stderr does not contain "closed" in message', async function () {
@@ -285,7 +285,7 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
           stderr: 'some error that does not close device',
           code: 1
         });
-      mocks.adb.expects('restartAdb').never();
+      mocks.adb.expects('reconnect').never();
       await adb.root().should.eventually.eql({isSuccessful: false, wasAlreadyRooted: false});
     });
     it('should call "unroot" on shell if call .unroot', async function () {


### PR DESCRIPTION
Killing the whole adb server can sometimes corrupt other parallel tests that are running on the same machine and expect adb connection to be stable. The `reconnect` command affects only offline devices and does not touch other properly connected units, which is much more convenient for us from this perspective.