### PR TITLE
feat: Add a possibility to disable incremental install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ console.log(await adb.getPIDsByName('com.android.phone'));
 - `createADB`
 - `initJars`
 - `getAdbWithCorrectAdbPath`
-- `getAdbVersion`
 - `initAapt`
 - `initZipAlign`
 - `getApiLevel`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,21 +1,5 @@
 # Usage
 
-# getAdbVersion
-
-```javascript
-await adb.getAdbVersion();
-```
-
-```json
-{
-  "versionString": "1.0.39",
-  "versionFloat": 1,
-  "major": 1,
-  "minor": 0,
-  "patch": 39
-}
-```
-
 # powerAC
 
 ```javascript

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1707,4 +1707,21 @@ methods.isStreamedInstallSupported = async function isStreamedInstallSupported (
   return proto._helpOutput.includes('--streaming') && (await this.listFeatures()).includes('cmd');
 };
 
+/**
+ * Checks whether incremental install feature is supported by ADB.
+ * Read https://developer.android.com/preview/features#incremental
+ * for more details on it.
+ *
+ * @returns {boolean} `true` if the feature is supported by both adb and the
+ * device under test
+ */
+methods.isIncrementalInstallSupported = async function isIncrementalInstallSupported () {
+  const {binary} = await this.getVersion();
+  if (!binary) {
+    return false;
+  }
+  return await this.isStreamedInstallSupported()
+    && util.compareVersions(binary.version, '>=', '30.0.1');
+};
+
 export default methods;

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -512,6 +512,9 @@ apkUtilsMethods.cacheApk = async function cacheApk (apkPath, options = {}) {
  * @property {boolean} replace [true] - Set it to false if you don't want
  *                                      the application to be upgraded/reinstalled
  *                                      if it is already present on the device.
+ * @property {boolean} noIncremental [false] - Forcefully disables incremental installs if set to `true`.
+ *                                             Read https://developer.android.com/preview/features#incremental
+ *                                             for more details.
  */
 
 /**
@@ -534,6 +537,12 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
   });
 
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
+  if (options.noIncremental && await this.isIncrementalInstallSupported()) {
+    // Adb will throw an error if it does not know about this arg,
+    // which is the case for older versions of it.
+    // So we need to check whether it is supported first
+    installArgs.push('--no-incremental');
+  }
   const installOpts = {
     timeout: options.timeout,
     timeoutCapName: options.timeoutCapName,

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -538,9 +538,8 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
 
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
   if (options.noIncremental && await this.isIncrementalInstallSupported()) {
-    // Adb will throw an error if it does not know about this arg,
-    // which is the case for older versions of it.
-    // So we need to check whether it is supported first
+    // Adb throws an error if it does not know about an arg,
+    // which is the case here for older adb versions.
     installArgs.push('--no-incremental');
   }
   const installOpts = {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -9,6 +9,7 @@ import {
 import { exec, SubProcess } from 'teen_process';
 import { sleep, retry, retryInterval, waitForCondition } from 'asyncbox';
 import _ from 'lodash';
+import semver from 'semver';
 
 
 let systemCallMethods = {};
@@ -19,6 +20,8 @@ const LINKER_WARNING_REGEXP = /^WARNING: linker.+$/m;
 const PROTOCOL_FAULT_ERROR_REGEXP = new RegExp('protocol fault \\(no status\\)', 'i');
 const DEVICE_NOT_FOUND_ERROR_REGEXP = new RegExp(`error: device ('.+' )?not found`, 'i');
 const DEVICE_CONNECTING_ERROR_REGEXP = new RegExp('error: device still connecting', 'i');
+const BINARY_VERSION_PATTERN = /^Version ([\d.]+)-(\d+)/m;
+const BRIDGE_VERSION_PATTERN = /^Android Debug Bridge version ([\d.]+)/m;
 
 const CERTS_ROOT = '/system/etc/security/cacerts';
 const SDK_BINARY_ROOTS = [
@@ -826,36 +829,52 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {
 };
 
 /**
- * @typedef {Object} ADBVersion
- * @property {string} versionString - ADB version as a string.
- * @property {float} versionFloat - Version number as float value (useful for comparison).
- * @property {number} major - Major version number.
- * @property {number} minor - Minor version number.
- * @property {number} patch - Patch version number.
+ * @typedef {Object} BinaryVersion
+ * @property {SemVer} version - The ADB binary version number
+ * @property {number} build - The ADB binary build number
  */
 
 /**
- * Get the adb version. The result of this method is cached.
- *
- * @return {ADBVersion} The current adb version.
- * @throws {Error} If it is not possible to parse adb version.
+ * @typedef {Object} BridgeVersion
+ * @property {SemVer} version - The Android Debug Bridge version
  */
-systemCallMethods.getAdbVersion = _.memoize(async function getAdbVersion () {
+
+/**
+ * @typedef {Object} Version
+ * @property {?BinaryVersion} binary
+ * @property {?BridgeVersion} bridge
+ */
+
+/**
+ * Get the adb tool version. The result of this method is cached.
+ *
+ * @return {?Version} The current adb binary version or null if it cannot
+ * be parsed (or an older ADB tool version is used)
+ * @throws {Error} If it is not possible to parse adb binary version.
+ */
+systemCallMethods.getVersion = _.memoize(async function getVersion () {
+  let stdout;
   try {
-    let adbVersion = (await this.adbExec('version'))
-      .replace(/Android\sDebug\sBridge\sversion\s([\d.]*)[\s\w-]*/, '$1');
-    let parts = adbVersion.split('.');
-    return {
-      versionString: adbVersion,
-      versionFloat: parseFloat(adbVersion),
-      major: parseInt(parts[0], 10),
-      minor: parseInt(parts[1], 10),
-      patch: parts[2] ? parseInt(parts[2], 10) : undefined,
-    };
+    stdout = await this.adbExec('version');
   } catch (e) {
-    throw new Error(`Error getting adb version. Original error: '${e.message}'; ` +
-                        `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`);
+    throw new Error(`Error getting adb version: ${e.stderr || e.message}`);
   }
+
+  const result = {};
+  const binaryVersionMatch = BINARY_VERSION_PATTERN.exec(stdout);
+  if (binaryVersionMatch) {
+    result.binary = {
+      version: semver.coerce(binaryVersionMatch[1]),
+      build: parseInt(binaryVersionMatch[2], 10),
+    };
+  }
+  const bridgeVersionMatch = BRIDGE_VERSION_PATTERN.exec(stdout);
+  if (bridgeVersionMatch) {
+    result.bridge = {
+      version: semver.coerce(bridgeVersionMatch[1]),
+    };
+  }
+  return result;
 });
 
 /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -836,20 +836,20 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {
 
 /**
  * @typedef {Object} BridgeVersion
- * @property {SemVer} version - The Android Debug Bridge version
+ * @property {SemVer} version - The Android Debug Bridge version number
  */
 
 /**
  * @typedef {Object} Version
- * @property {?BinaryVersion} binary
- * @property {?BridgeVersion} bridge
+ * @property {?BinaryVersion} binary This version number might not be
+ * be present for older ADB releases.
+ * @property {BridgeVersion} bridge
  */
 
 /**
  * Get the adb tool version. The result of this method is cached.
  *
- * @return {?Version} The current adb binary version or null if it cannot
- * be parsed (or an older ADB tool version is used)
+ * @return {Version}
  * @throws {Error} If it is not possible to parse adb binary version.
  */
 systemCallMethods.getVersion = _.memoize(async function getVersion () {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -847,7 +847,7 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {
  */
 
 /**
- * Get the adb tool version. The result of this method is cached.
+ * Get the adb version. The result of this method is cached.
  *
  * @return {Version}
  * @throws {Error} If it is not possible to parse adb binary version.

--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -287,4 +287,9 @@ describe('adb commands', function () {
     });
   });
 
+  describe('isIncrementalInstallSupported', function () {
+    it('should return boolean value', async function () {
+      _.isBoolean(await adb.isIncrementalInstallSupported()).should.be.true;
+    });
+  });
 });

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -5,6 +5,7 @@ import { apiLevel, avdName, MOCHA_TIMEOUT, MOCHA_LONG_TIMEOUT } from './setup';
 import path from 'path';
 import { rootDir } from '../../lib/helpers.js';
 import { fs } from 'appium-support';
+import _ from 'lodash';
 
 const DEFAULT_CERTIFICATE = path.resolve(rootDir, 'keys', 'testkey.x509.pem');
 
@@ -78,5 +79,13 @@ describe('System calls', function () {
   it('should check if the given certificate is already installed', async function () {
     const certBuffer = await fs.readFile(DEFAULT_CERTIFICATE);
     (await adb.isMitmCertificateInstalled(certBuffer)).should.be.false;
+  });
+  it('should return version', async function () {
+    const {binary, bridge} = await adb.getVersion();
+    if (binary) {
+      _.has(binary, 'version').should.be.true;
+      _.has(binary, 'build').should.be.true;
+    }
+    _.has(bridge, 'version').should.be.true;
   });
 });

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -4,7 +4,6 @@ import ADB from '../..';
 import * as teen_process from 'teen_process';
 import { withMocks } from 'appium-test-support';
 import B from 'bluebird';
-import _ from 'lodash';
 
 
 chai.use(chaiAsPromised);
@@ -123,27 +122,6 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
     mocks.verify();
   });
 
-  it('should return adb version', async function () {
-    mocks.adb.expects('adbExec')
-      .once()
-      .withExactArgs('version')
-      .returns('Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android');
-    let adbVersion = await adb.getAdbVersion();
-    adbVersion.versionString.should.equal('1.0.39');
-    adbVersion.versionFloat.should.be.within(1.0, 1.0);
-    adbVersion.major.should.equal(1);
-    adbVersion.minor.should.equal(0);
-    adbVersion.patch.should.equal(39);
-  });
-  it('should cache adb results', async function () {
-    adb.getAdbVersion.cache = new _.memoize.Cache();
-    mocks.adb.expects('adbExec')
-      .once()
-      .withExactArgs('version')
-      .returns('Android Debug Bridge version 1.0.39\nRevision 5943271ace17-android');
-    await adb.getAdbVersion();
-    await adb.getAdbVersion();
-  });
   it('fileExists should return true if file/dir exists', async function () {
     mocks.adb.expects('shell')
       .once().withExactArgs([`[ -e 'foo' ] && echo __PASS__`])


### PR DESCRIPTION
Google has recently added incremental install feature for ADB. It gets enabled automatically by default if the device under test supports it, however it is still not very stable and breaks server install: https://github.com/appium/appium/issues/14387

This PR adds an option to forcefully disable incremental installs, which is going to be used for server deployment.