### PR TITLE
fix: Update incremental install support detection

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1704,7 +1704,8 @@ methods.listFeatures = async function listFeatures () {
 methods.isStreamedInstallSupported = async function isStreamedInstallSupported () {
   const proto = Object.getPrototypeOf(this);
   proto._helpOutput = proto._helpOutput || await this.adbExec(['help']);
-  return proto._helpOutput.includes('--streaming') && (await this.listFeatures()).includes('cmd');
+  return proto._helpOutput.includes('--streaming')
+    && (await this.listFeatures()).includes('cmd');
 };
 
 /**
@@ -1720,8 +1721,8 @@ methods.isIncrementalInstallSupported = async function isIncrementalInstallSuppo
   if (!binary) {
     return false;
   }
-  return await this.isStreamedInstallSupported()
-    && util.compareVersions(binary.version, '>=', '30.0.1');
+  return util.compareVersions(binary.version, '>=', '30.0.1')
+    && (await this.listFeatures()).includes('abb_exec');
 };
 
 export default methods;


### PR DESCRIPTION
After some more source code analysis I've figured out more precise way to detect incremental install feature support (see `calculate_install_mode` method from `adb_install.cpp`).