### PR TITLE
feat: Add '-d' option to adb install command

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -455,6 +455,8 @@ const extractMatchingPermissions = function (dumpsysOutput, groupNames, grantedS
  * @typedef {Object} InstallOptions
  * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
  *                                                 packages installation.
+ * @property {boolean} allowDowngrade [false] - Set to true in order to allow
+ *                                              package downgrades.
  * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
  *                                         instead of the device memory.
  * @property {boolean} grantPermissions [false] - Set to true in order to grant all the
@@ -484,6 +486,9 @@ function buildInstallArgs (apiLevel, options = {}) {
   }
   if (options.useSdcard) {
     result.push('-s');
+  }
+  if (options.allowDowngrade) {
+    result.push('-d');
   }
   if (options.grantPermissions) {
     if (apiLevel < 23) {

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -696,6 +696,8 @@ apkUtilsMethods.getApplicationInstallState = async function getApplicationInstal
  *                                      app is installed.
  * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
  *                                                 packages installation.
+ * @property {boolean} allowDowngrade [false] - Set to true in order to allow
+ *                                              package downgrades.
  * @property {boolean} useSdcard [false] - Set to true to install the app on SDCard
  *                                         instead of the device memory.
  * @property {boolean} grantPermissions [false] - Set to true in order to grant all the

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -123,6 +123,8 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
  *                                                             users can increase the timeout.
  * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
  *                                                 packages installation.
+ * @property {boolean} allowDowngrade [false] - Set to true in order to allow
+ *                                              package downgrades.
  * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
  *                                         instead of the device memory.
  * @property {boolean} grantPermissions [false] - Set to true in order to grant all the


### PR DESCRIPTION
As documented at https://developer.android.com/studio/command-line/adb, recent versions of `adb install` support the -d flag to support downgrades. Appium-adb currently provides no way to enable this flag. This change simply enables the option in buildInstallArgs, then exposes the parameter up the stack to the caller.

Note: 4 aapt-related unit tests are failing, but they are also failing in master and not related to this change.