### PR TITLE
feat: Allow sdkRoot to specify a full folder path

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -31,7 +31,8 @@ const SDK_BINARY_ROOTS = [
   'emulator',
   ['cmdline-tools', 'latest', 'bin'],
   'tools',
-  ['tools', 'bin']
+  ['tools', 'bin'],
+  '.' // Allow custom sdkRoot to specify full folder path
 ];
 
 /**
@@ -134,7 +135,7 @@ systemCallMethods.getBinaryFromSdkRoot = async function getBinaryFromSdkRoot (bi
 /**
  *  Returns the Android binaries locations
  *
- * @param {string} sdkRoot The path to Andoird SDK root.
+ * @param {string} sdkRoot The path to Android SDK root.
  * @param {string} fullBinaryName The name of full binary name.
  * @return {Array<string>} The list of SDK_BINARY_ROOTS paths
  *                          with sdkRoot and fullBinaryName.


### PR DESCRIPTION
The current code assumes that the user has installed the full Android build tools, which is probably true in the vast number of cases. However, if someone has installed a subset of the tools (for example, installing ADB.exe from https://androidstudio.io/downloads/tools/download-the-latest-version-of-adb.exe.html), then those tools could be in any folder location and are not necessarily constrained to the set of folders specified in SDK_BINARY_ROOTS.

This change simply allows someone to use sdkRoot to specify the full folder path to the tool in question. It's at the end of SDK_BINARY_ROOTS, so it will have no impact on users with the full build tools in place.

I also corrected a typo that I noticed while reading through the code.