### PR TITLE
fix: ensure the ime is enabled for API level 30

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1626,6 +1626,7 @@ methods.runInImeContext = async function runInImeContext (ime, fn) {
   if (originalIme === ime) {
     log.debug(`The original IME is the same as '${ime}'. There is no need to reset it`);
   } else {
+    await this.enableIME(ime);
     await this.setIME(ime);
   }
   try {


### PR DESCRIPTION
When I ran tests against emulator API Level 30 https://github.com/appium/ruby_lib_core/pull/268, only `@driver.execute_script 'mobile: performEditorAction', { action: 'normal' }` failed.
I ran the command on my local, then exactly it did not work because the IME was not enabled.
Emulators such as API Level 29 did not need call `enableIME` in the scenario.

It worked after I enabled the IME manually, but it's safe to calls `this.enableIME(ime);` here to keep the current behaviour of `runInImeContext`. I ran a couple of times with this PR style against different API emulators, but they had no issue. 

This increases adb call time, but it should not impact rather than the `runInImeContext` behaves differently.