### PR TITLE
chore: Only use -delay-adb emulator startup detection if image API version is above 27

### DIFF
--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -4,6 +4,8 @@ import net from 'net';
 import { util, fs } from 'appium-support';
 import B from 'bluebird';
 import path from 'path';
+import ini from 'ini';
+import { exec } from 'teen_process';
 
 const PHONE_NUMBER_PATTERN = /^[+]?[(]?[0-9]*[)]?[-\s.]?[0-9]*[-\s.]?[0-9]{2,}$/im;
 
@@ -363,6 +365,37 @@ emuMethods.getEmuVersionInfo = async function getEmuVersionInfo () {
     result.buildId = parseInt(buildIdMatch[1], 10);
   }
   return result;
+};
+
+/**
+ * Retrieves emulator image properties from the local file system
+ *
+ * @param {string} name Emulator name. Should NOT start with '@' character
+ * @returns {Object} The content of emulator image properties file.
+ * Usually this configuration .ini file has the following content:
+ *   avd.ini.encoding=UTF-8
+ *   path=/Users/username/.android/avd/Pixel_XL_API_30.avd
+ *   path.rel=avd/Pixel_XL_API_30.avd
+ *   target=android-30
+ */
+emuMethods.getEmuImageProperties = async function getEmuImageProperties (name) {
+  const avdManager = await this.getSdkBinaryPath('avdmanager');
+  const {stdout} = await exec(avdManager, ['list', 'avd']);
+  const entryMatch = new RegExp(`^\\s*Name:\\s+${_.escapeRegExp(name)}$(.+)$`, 'sm').exec(stdout);
+  if (!entryMatch) {
+    log.debug(stdout);
+    throw new Error(`Cannot find '${name}' emulator entry in avdmanager output`);
+  }
+  const pathMatch = /^\s*Path:\s+(.+)$/m.exec(entryMatch[1]);
+  if (!pathMatch) {
+    log.debug(entryMatch[1]);
+    throw new Error(`Cannot parse '${name}' emulator image location from avdmanager output`);
+  }
+  const configLocation = path.resolve(pathMatch[1], `${name}.ini`);
+  if (!await fs.exists(configLocation)) {
+    throw new Error(`Cannot find '${name}' emulator config at '${configLocation}`);
+  }
+  return ini.parse(await fs.readFile(configLocation, 'utf8'));
 };
 
 export default emuMethods;

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -391,7 +391,7 @@ emuMethods.getEmuImageProperties = async function getEmuImageProperties (name) {
     log.debug(entryMatch[1]);
     throw new Error(`Cannot parse '${name}' emulator image location from avdmanager output`);
   }
-  const configLocation = path.resolve(pathMatch[1], `${name}.ini`);
+  const configLocation = path.resolve(path.dirname(pathMatch[1]), `${name}.ini`);
   if (!await fs.exists(configLocation)) {
     throw new Error(`Cannot find '${name}' emulator config at '${configLocation}`);
   }

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -371,6 +371,7 @@ emuMethods.getEmuVersionInfo = async function getEmuVersionInfo () {
  * Retrieves emulator image properties from the local file system
  *
  * @param {string} name Emulator name. Should NOT start with '@' character
+ * @throws {Error} if there was a failure while extracting the properties
  * @returns {Object} The content of emulator image properties file.
  * Usually this configuration .ini file has the following content:
  *   avd.ini.encoding=UTF-8

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -792,8 +792,20 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {
   let supportsDelayAdbFeature = false;
   if (revision && util.compareVersions(revision, '>=', '29.0.7')) {
     // https://androidstudio.googleblog.com/2019/05/emulator-2907-canary.html
-    launchArgs.push('-delay-adb');
-    supportsDelayAdbFeature = true;
+    try {
+      const {target} = await this.getEmuImageProperties(avdName);
+      const apiMatch = /\d+/.exec(target);
+      // https://issuetracker.google.com/issues/142533355
+      if (apiMatch && parseInt(apiMatch[0], 10) >= 28) {
+        launchArgs.push('-delay-adb');
+        supportsDelayAdbFeature = true;
+      } else {
+        throw new Error(`The actual image API version is below 28`);
+      }
+    } catch (e) {
+      log.info(`The -delay-adb emulator startup detection feature will not be enabled. ` +
+        `Original error: ${e.message}`);
+    }
   }
 
   if (!_.isEmpty(args)) {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "async-lock": "^1.0.0",
     "asyncbox": "^2.6.0",
     "bluebird": "^3.4.7",
+    "ini": "^1.3.5",
     "lodash": "^4.0.0",
     "lru-cache": "^6.0.0",
     "semver": "^7.0.0",

--- a/test/functional/adb-emu-commands-e2e-specs.js
+++ b/test/functional/adb-emu-commands-e2e-specs.js
@@ -62,4 +62,13 @@ describe('adb emu commands', function () {
       (buildId > 0).should.be.true;
     });
   });
+
+  describe('getEmuImageProperties', function () {
+    it('should get emulator image properties', async function () {
+      const name = await adb.execEmuConsoleCommand(['avd', 'name']);
+      const {target} = await adb.getEmuImageProperties(name);
+      const apiMatch = /\d+/.exec(target);
+      (parseInt(apiMatch[0], 10) > 0).should.be.true;
+    });
+  });
 });

--- a/test/functional/adb-emu-commands-e2e-specs.js
+++ b/test/functional/adb-emu-commands-e2e-specs.js
@@ -1,46 +1,14 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import ADB from '../..';
-import path from 'path';
-import { rootDir } from '../../lib/helpers.js';
-import { sleep } from 'asyncbox';
-
 
 chai.use(chaiAsPromised);
 chai.should();
-
-const fingerprintPath = path.resolve(rootDir, 'test', 'fixtures', 'Fingerprint.apk');
-const pkg = 'com.example.fingerprint';
-const activity = '.MainActivity';
-const secretActivity = '.SecretActivity';
 
 describe('adb emu commands', function () {
   let adb;
   before(async function () {
     adb = await ADB.createADB();
-
-    // the test here only works if we have API level 23 or above
-    // it will also fail on emulators
-    if (await adb.getApiLevel() < 23 || !process.env.REAL_DEVICE) {
-      return this.skip();
-    }
-  });
-  it('fingerprint should open the secret activity on emitted valid finger touch event', async function () {
-    if (await adb.isAppInstalled(pkg)) {
-      await adb.forceStop(pkg);
-      await adb.uninstallApk(pkg);
-    }
-    await adb.install(fingerprintPath);
-    await adb.startApp({pkg, activity});
-    await sleep(500);
-
-    let app = await adb.getFocusedPackageAndActivity();
-    app.appActivity.should.equal(activity);
-    await adb.fingerprint(1111);
-    await sleep(2500);
-
-    app = await adb.getFocusedPackageAndActivity();
-    app.appActivity.should.equal(secretActivity);
   });
 
   describe('execEmuConsoleCommand', function () {

--- a/test/functional/adb-emu-commands-e2e-specs.js
+++ b/test/functional/adb-emu-commands-e2e-specs.js
@@ -8,7 +8,13 @@ chai.should();
 describe('adb emu commands', function () {
   let adb;
   before(async function () {
+    if (process.env.REAL_DEVICE) {
+      return this.skip();
+    }
+
     adb = await ADB.createADB();
+    const devices = await adb.getConnectedEmulators();
+    adb.setDevice(devices[0]);
   });
 
   describe('execEmuConsoleCommand', function () {


### PR DESCRIPTION
https://github.com/appium/appium/issues/14347#issuecomment-670440234