### PR TITLE
fix: Update process lookup behaviour for newer Android versions

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1038,6 +1038,26 @@ methods.removeLogcatListener = function removeLogcatListener (listener) {
 };
 
 /**
+ * At some point of time Google has changed the default `ps` behaviour, so it only
+ * lists processes that belong to the current shell user rather to all
+ * users. It is necessary to execute ps with -A command line argument
+ * to mimic the previous behaviour.
+ *
+ * @returns {string} the output of `ps` command where all processes are included
+ */
+methods.listProcessStatus = async function listProcessStatus () {
+  if (!_.isBoolean(this._doesPsSupportAOption)) {
+    try {
+      this._doesPsSupportAOption = /^-A\b/m.test(await this.shell(['ps', '--help']));
+    } catch (e) {
+      log.debug(e.stack);
+      this._doesPsSupportAOption = false;
+    }
+  }
+  return await this.shell(this._doesPsSupportAOption ? ['ps', '-A'] : ['ps']);
+};
+
+/**
  * Returns process name for the given process identifier
  *
  * @param {string|number} pid - The valid process identifier
@@ -1051,7 +1071,7 @@ methods.getNameByPid = async function getNameByPid (pid) {
   }
   pid = parseInt(pid, 10);
 
-  const stdout = await this.shell(['ps']);
+  const stdout = await this.listProcessStatus();
   const titleMatch = PS_TITLE_PATTERN.exec(stdout);
   if (!titleMatch) {
     log.debug(stdout);
@@ -1103,7 +1123,7 @@ methods.getPIDsByName = async function getPIDsByName (name) {
     if (this._isPgrepAvailable || this._isPidofAvailable) {
       const shellCommand = this._isPgrepAvailable
         ? (this._canPgrepUseFullCmdLineSearch
-          ? ['pgrep', '-f', _.escapeRegExp(name)]
+          ? ['pgrep', '-x', _.escapeRegExp(name)]
           // https://github.com/appium/appium/issues/13872
           : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ || pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
         : ['pidof', name];
@@ -1124,7 +1144,7 @@ methods.getPIDsByName = async function getPIDsByName (name) {
   }
 
   log.debug('Using ps-based PID detection');
-  const stdout = await this.shell(['ps']);
+  const stdout = await this.listProcessStatus();
   const titleMatch = PS_TITLE_PATTERN.exec(stdout);
   if (!titleMatch) {
     log.debug(stdout);

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1123,7 +1123,7 @@ methods.getPIDsByName = async function getPIDsByName (name) {
     if (this._isPgrepAvailable || this._isPidofAvailable) {
       const shellCommand = this._isPgrepAvailable
         ? (this._canPgrepUseFullCmdLineSearch
-          ? ['pgrep', '-x', _.escapeRegExp(name)]
+          ? ['pgrep', '-f', `([[:blank:]]|^)${name.replace('.', '\\.')}([[:blank:]]|$)`]
           // https://github.com/appium/appium/issues/13872
           : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ || pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
         : ['pidof', name];

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1123,7 +1123,7 @@ methods.getPIDsByName = async function getPIDsByName (name) {
     if (this._isPgrepAvailable || this._isPidofAvailable) {
       const shellCommand = this._isPgrepAvailable
         ? (this._canPgrepUseFullCmdLineSearch
-          ? ['pgrep', '-f', `([[:blank:]]|^)${name.replace('.', '\\.')}([[:blank:]]|$)`]
+          ? ['pgrep', '-f', _.escapeRegExp(`([[:blank:]]|^)${name}([[:blank:]]|$)`)]
           // https://github.com/appium/appium/issues/13872
           : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ || pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
         : ['pidof', name];

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -405,7 +405,8 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
   const execFunc = async () => {
     try {
       const args = [...this.executable.defaultArgs, ...cmd];
-      log.debug(`Running '${this.executable.path} ${util.quote(args)}'`);
+      log.debug(`Running '${this.executable.path} ` +
+        (args.find((arg) => /\s+/.test(arg)) ? util.quote(args) : args.join(' ')) + `'`);
       let {stdout} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -624,9 +624,8 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
     });
     describe('getNameByPid', function () {
       it('should get package name from valid ps output', async function () {
-        mocks.adb.expects('shell')
-          .once().withExactArgs(['ps'])
-          .returns(`
+        mocks.adb.expects('listProcessStatus')
+          .once().returns(`
           USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
           radio     929   69    1228184 40844 ffffffff b6db0920 S com.android.phone
           radio     930   69    1228184 40844 ffffffff b6db0920 S com.android.phone
@@ -653,9 +652,8 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         await adb.getNameByPid('bla').should.eventually.be.rejectedWith(/valid number/);
       });
       it('should fail if no PID could be found in ps output', async function () {
-        mocks.adb.expects('shell')
-          .once().withExactArgs(['ps'])
-          .returns(`
+        mocks.adb.expects('listProcessStatus')
+          .once().returns(`
           USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
           u0_a12    1156  69    1246756 58588 ffffffff b6db0920 S com.android.systemui
           `);
@@ -700,9 +698,8 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       it('should fall back to ps if pidof is not available', async function () {
         adb._isPidofAvailable = false;
         adb._isPgrepAvailable = false;
-        mocks.adb.expects('shell')
-          .once().withExactArgs(['ps'])
-          .returns(`
+        mocks.adb.expects('listProcessStatus')
+          .once().returns(`
           USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
           radio     929   69    1228184 40844 ffffffff b6db0920 S com.android.phone
           radio     930   69    1228184 40844 ffffffff b6db0920 S com.android.phone
@@ -728,9 +725,8 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       it('should fall back to ps and return empty list if no processes were found', async function () {
         adb._isPidofAvailable = false;
         adb._isPgrepAvailable = false;
-        mocks.adb.expects('shell')
-          .once().withExactArgs(['ps'])
-          .returns(`
+        mocks.adb.expects('listProcessStatus')
+          .once().returns(`
           USER     PID   PPID  VSIZE  RSS     WCHAN    PC        NAME
           radio     929   69    1228184 40844 ffffffff b6db0920 S com.android.phone
           radio     930   69    1228184 40844 ffffffff b6db0920 S com.android.phone
@@ -744,9 +740,8 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       it('should properly parse different ps output formats', async function () {
         adb._isPidofAvailable = false;
         adb._isPgrepAvailable = false;
-        mocks.adb.expects('shell')
-          .once().withExactArgs(['ps'])
-          .returns(`
+        mocks.adb.expects('listProcessStatus')
+          .once().returns(`
           USER           PID  PPID     VSZ    RSS WCHAN            ADDR S NAME
           shell        21989 32761    4952   2532 sigsuspend   b2f1d778 S sh
           shell        21992 21989    5568   3016 0            b4396448 R ps


### PR DESCRIPTION
At some point of time Google has changed the default `ps` behaviour, so it only lists processes that belong to the current shell user rather to all users. It is necessary to execute ps with -A command line argument to mimic the previous behaviour.

Also related to https://github.com/appium/appium/issues/14709