### PR TITLE
chore: Include stdout as well if apksigner fails

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -22,7 +22,7 @@ const DEFAULT_CERT_HASH = {
 };
 
 
-let apkSigningMethods = {};
+const apkSigningMethods = {};
 
 /**
  * Execute apksigner utility with given arguments.
@@ -79,7 +79,7 @@ apkSigningMethods.signWithDefaultCert = async function signWithDefaultCert (apk)
     await this.executeApksigner(args);
   } catch (e) {
     throw new Error(`Could not sign '${apk}' with the default certificate. ` +
-      `Original error: ${e.stderr || e.message}`);
+      `Original error: ${e.stderr || e.stdout || e.message}`);
   }
 };
 
@@ -107,7 +107,7 @@ apkSigningMethods.signWithCustomCert = async function signWithCustomCert (apk) {
       apk]);
   } catch (err) {
     log.warn(`Cannot use apksigner tool for signing. Defaulting to jarsigner. ` +
-      `Original error: ${err.stderr || err.message}`);
+      `Original error: ${err.stderr || err.stdout || err.message}`);
     try {
       if (await unsignApk(apk)) {
         log.debug(`'${apk}' has been successfully unsigned`);


### PR DESCRIPTION
It looks like this strange tool may print error output into stdout instead of stderr