### PR TITLE
chore: Remove the obsolete validation for zipalign

### DIFF
--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -154,28 +154,14 @@ apkSigningMethods.sign = async function sign (appPath) {
     return;
   }
 
-  let apksignerFound = true;
-  try {
-    await getApksignerForOs(this);
-  } catch (err) {
-    apksignerFound = false;
-  }
-
-  if (apksignerFound) {
-    // it is necessary to apply zipalign only before signing
-    // if apksigner is used or only after signing if we only have
-    // sign.jar utility
-    await this.zipAlignApk(appPath);
-  }
+  // it is necessary to apply zipalign only before signing
+  // if apksigner is used
+  await this.zipAlignApk(appPath);
 
   if (this.useKeystore) {
     await this.signWithCustomCert(appPath);
   } else {
     await this.signWithDefaultCert(appPath);
-  }
-
-  if (!apksignerFound) {
-    await this.zipAlignApk(appPath);
   }
 };
 


### PR DESCRIPTION
This is not needed anymore after sign.jar has been deprecated