### PR TITLE
fix: Android preferences root path on Windows

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -849,29 +849,41 @@ function toAvdLocaleArgs (language, country) {
  */
 async function getAndroidPrefsRoot () {
   let location = process.env.ANDROID_EMULATOR_HOME;
-  if (location && !await fs.exists(location)) {
-    log.debug(`Value of $ANDROID_EMULATOR_HOME '${location}' does not exist`);
-    return null;
+  if (await dirExists(location)) {
+    return location;
   }
 
-  if (!location) {
-    const home = process.env.HOME || process.env.USERPROFILE;
-    if (home) {
-      location = path.resolve(home, '.android');
-    }
+  if (location) {
+    log.debug(`Value of $ANDROID_EMULATOR_HOME '${location}' is not an existing directory`);
   }
 
-  if (!location || !await fs.exists(location)) {
-    log.debug(`Android config root '${location}' does not exist`);
-    return null;
+  const home = process.env.HOME || process.env.USERPROFILE;
+  if (home) {
+    location = path.resolve(home, '.android');
   }
 
-  if (!(await fs.stat(location)).isDirectory()) {
-    log.debug(`Android config root '${location}' is not a directory`);
+  if (!await dirExists(location)) {
+    log.debug(`Android config root '${location}' is not an existing directory`);
     return null;
   }
 
   return location;
+}
+
+function dirExists (location) {
+  if (!location) {
+    return false;
+  }
+
+  if (!await fs.exists(location)) {
+    return false;
+  }
+
+  if (!(await fs.stat(location)).isDirectory()) {
+    return false;
+  }
+
+  return true;
 }
 
 export {
@@ -883,5 +895,5 @@ export {
   APK_INSTALL_TIMEOUT, APKS_INSTALL_TIMEOUT, buildInstallArgs, APK_EXTENSION,
   DEFAULT_ADB_EXEC_TIMEOUT, parseManifest, parseAaptStrings, parseAapt2Strings,
   formatConfigMarker, parseJsonData, unsignApk, toAvdLocaleArgs, requireSdkRoot,
-  getSdkRootFromEnv, getAndroidPrefsRoot,
+  getSdkRootFromEnv, getAndroidPrefsRoot, dirExists,
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -854,7 +854,7 @@ async function getAndroidPrefsRoot () {
   }
 
   if (location) {
-    log.warn(`The value of $ANDROID_EMULATOR_HOME '${location}' is not an existing directory`);
+    log.warn(`The value of the ANDROID_EMULATOR_HOME environment variable '${location}' is not an existing directory`);
   }
 
   const home = process.env.HOME || process.env.USERPROFILE;
@@ -872,7 +872,7 @@ async function getAndroidPrefsRoot () {
 
 /**
  * Check if a path exists on the filesystem and is a directory
- * 
+ *
  * @param {?string} location The full path to the directory
  * @returns {boolean}
  */

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -858,15 +858,17 @@ async function getAndroidPrefsRoot () {
     }
   }
 
-  if (location && await fs.exists(location)) {
-    if (!(await fs.stat(location)).isDirectory()) {
-      log.debug(`Android config root '${location}' is not a directory`);
-      return null;
-    }
-    return location;
+  if (!location || !await fs.exists(location)) {
+    log.debug(`Android config root '${location}' does not exist`);
+    return null;
   }
 
-  return null;
+  if (!(await fs.stat(location)).isDirectory()) {
+    log.debug(`Android config root '${location}' is not a directory`);
+    return null;
+  }
+
+  return location;
 }
 
 export {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -870,7 +870,7 @@ async function getAndroidPrefsRoot () {
   return location;
 }
 
-function dirExists (location) {
+async function dirExists (location) {
   if (!location) {
     return false;
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -852,7 +852,7 @@ async function getAndroidPrefsRoot () {
   let location = process.env.ANDROID_EMULATOR_HOME;
 
   if (!location || !await fs.exists(location)) {
-    const home = process.env.ANDROID_SDK_HOME || process.env.HOME || process.env.USERPROFILE;
+    const home = process.env.HOME || process.env.USERPROFILE;
     if (home) {
       location = path.resolve(home, '.android');
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -871,19 +871,9 @@ async function getAndroidPrefsRoot () {
 }
 
 async function dirExists (location) {
-  if (!location) {
-    return false;
-  }
-
-  if (!await fs.exists(location)) {
-    return false;
-  }
-
-  if (!(await fs.stat(location)).isDirectory()) {
-    return false;
-  }
-
-  return true;
+  return location
+    && await fs.exists(location)
+    && (await fs.stat(location)).isDirectory();
 }
 
 export {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -849,10 +849,13 @@ function toAvdLocaleArgs (language, country) {
  */
 async function getAndroidPrefsRoot () {
   // https://gerrit.pixelexperience.org/plugins/gitiles/development/+/5c11852110eeb03dc5a69111354b383f98d15336/tools/androidprefs/src/com/android/prefs/AndroidLocation.java
-  let location = null;
-  const home = process.env.HOME || process.env.USERPROFILE;
-  if (home) {
-    location = path.resolve(home, '.android');
+  let location = process.env.ANDROID_EMULATOR_HOME;
+
+  if (!location) {
+    const home = process.env.ANDROID_SDK_HOME || process.env.HOME || process.env.USERPROFILE;
+    if (home) {
+      location = path.resolve(home, '.android');
+    }
   }
 
   if (location && await fs.exists(location)) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -850,22 +850,9 @@ function toAvdLocaleArgs (language, country) {
 async function getAndroidPrefsRoot () {
   // https://gerrit.pixelexperience.org/plugins/gitiles/development/+/5c11852110eeb03dc5a69111354b383f98d15336/tools/androidprefs/src/com/android/prefs/AndroidLocation.java
   let location = null;
-  if (system.isWindows()) {
-    let localAppData = process.env.LOCALAPPDATA;
-    if (!localAppData) {
-      localAppData = process.env.USERPROFILE;
-      if (localAppData) {
-        localAppData = path.resolve(localAppData, 'Local Settings', 'Application Data');
-      }
-    }
-    if (localAppData) {
-      location = path.resolve(localAppData, 'Android');
-    }
-  } else {
-    const home = process.env.HOME;
-    if (home) {
-      location = path.resolve(home, '.android');
-    }
+  const home = process.env.HOME || process.env.USERPROFILE;
+  if (home) {
+    location = path.resolve(home, '.android');
   }
 
   if (location && await fs.exists(location)) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -848,7 +848,6 @@ function toAvdLocaleArgs (language, country) {
  * @returns {?string} The full path to the folder or `null` if the folder cannot be found
  */
 async function getAndroidPrefsRoot () {
-  // https://gerrit.pixelexperience.org/plugins/gitiles/development/+/5c11852110eeb03dc5a69111354b383f98d15336/tools/androidprefs/src/com/android/prefs/AndroidLocation.java
   let location = process.env.ANDROID_EMULATOR_HOME;
   if (location && !await fs.exists(location)) {
     log.debug(`Value of $ANDROID_EMULATOR_HOME '${location}' does not exist`);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -854,7 +854,7 @@ async function getAndroidPrefsRoot () {
   }
 
   if (location) {
-    log.debug(`Value of $ANDROID_EMULATOR_HOME '${location}' is not an existing directory`);
+    log.warn(`The value of $ANDROID_EMULATOR_HOME '${location}' is not an existing directory`);
   }
 
   const home = process.env.HOME || process.env.USERPROFILE;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -870,6 +870,12 @@ async function getAndroidPrefsRoot () {
   return location;
 }
 
+/**
+ * Check if a path exists on the filesystem and is a directory
+ * 
+ * @param {?string} location The full path to the directory
+ * @returns {boolean}
+ */
 async function dirExists (location) {
   return location
     && await fs.exists(location)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -850,8 +850,12 @@ function toAvdLocaleArgs (language, country) {
 async function getAndroidPrefsRoot () {
   // https://gerrit.pixelexperience.org/plugins/gitiles/development/+/5c11852110eeb03dc5a69111354b383f98d15336/tools/androidprefs/src/com/android/prefs/AndroidLocation.java
   let location = process.env.ANDROID_EMULATOR_HOME;
+  if (location && !await fs.exists(location)) {
+    log.debug(`Value of $ANDROID_EMULATOR_HOME '${location}' does not exist`);
+    return null;
+  }
 
-  if (!location || !await fs.exists(location)) {
+  if (!location) {
     const home = process.env.HOME || process.env.USERPROFILE;
     if (home) {
       location = path.resolve(home, '.android');

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -851,7 +851,7 @@ async function getAndroidPrefsRoot () {
   // https://gerrit.pixelexperience.org/plugins/gitiles/development/+/5c11852110eeb03dc5a69111354b383f98d15336/tools/androidprefs/src/com/android/prefs/AndroidLocation.java
   let location = process.env.ANDROID_EMULATOR_HOME;
 
-  if (!location) {
+  if (!location || !await fs.exists(location)) {
     const home = process.env.ANDROID_SDK_HOME || process.env.HOME || process.env.USERPROFILE;
     if (home) {
       location = path.resolve(home, '.android');

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -91,7 +91,7 @@ async function listEmulators () {
 /**
  * Get configuration paths of all virtual devices
  *
- * @param {string} avdsRoot path to the directory that contains the AVD .ini files
+ * @param {string} avdsRoot Path to the directory that contains the AVD .ini files
  * @returns {Array<EmuInfo>}
  */
 async function getAvdConfigPaths (avdsRoot) {

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -65,13 +65,18 @@ emuMethods.SENSORS = {
  * @returns {Array<EmuInfo>}
  */
 async function listEmulators () {
-  // https://android.googlesource.com/platform/sdk/+/33f330d963c1bf24667eddb891531abcce9fb4de/sdkmanager/libs/sdklib/src/com/android/sdklib/internal/avd/AvdManager.java
-  const prefsRoot = await getAndroidPrefsRoot();
-  if (!prefsRoot) {
-    return [];
+  let avdsRoot = process.env.ANDROID_AVD_HOME;
+
+  if (!avdsRoot) {
+    // https://android.googlesource.com/platform/sdk/+/33f330d963c1bf24667eddb891531abcce9fb4de/sdkmanager/libs/sdklib/src/com/android/sdklib/internal/avd/AvdManager.java
+    const prefsRoot = await getAndroidPrefsRoot();
+    if (!prefsRoot) {
+      return [];
+    }
+
+    avdsRoot = path.resolve(prefsRoot, 'avd');
   }
 
-  const avdsRoot = path.resolve(prefsRoot, 'avd');
   if (!await fs.exists(avdsRoot)) {
     return [];
   }

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -67,7 +67,7 @@ emuMethods.SENSORS = {
 async function listEmulators () {
   let avdsRoot = process.env.ANDROID_AVD_HOME;
   if (await dirExists(avdsRoot)) {
-    return mapAvdDir(avdsRoot);
+    return await getAvdConfigPaths(avdsRoot);
   }
 
   if (avdsRoot) {
@@ -85,10 +85,10 @@ async function listEmulators () {
     return [];
   }
 
-  return mapAvdDir(avdsRoot);
+  return await getAvdConfigPaths(avdsRoot);
 }
 
-function mapAvdDir (avdsRoot) {
+async function getAvdConfigPaths (avdsRoot) {
   const configs = await fs.glob('*.ini', {
     cwd: avdsRoot,
     absolute: true,

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -1,5 +1,5 @@
 import log from '../logger.js';
-import { getAndroidPrefsRoot } from '../helpers';
+import { getAndroidPrefsRoot, dirExists } from '../helpers';
 import _ from 'lodash';
 import net from 'net';
 import { util, fs } from 'appium-support';
@@ -66,32 +66,29 @@ emuMethods.SENSORS = {
  */
 async function listEmulators () {
   let avdsRoot = process.env.ANDROID_AVD_HOME;
-  if (avdsRoot && !await fs.exists(avdsRoot)) {
+  if (await dirExists(avdsRoot)) {
+    return mapAvdDir(avdsRoot);
+  }
+
+  if (avdsRoot) {
     log.debug(`Value of $ANDROID_AVD_HOME '${location}' does not exist`);
+  }
+
+  const prefsRoot = await getAndroidPrefsRoot();
+  if (!prefsRoot) {
     return [];
   }
 
-  if (!avdsRoot) {
-    // https://android.googlesource.com/platform/sdk/+/33f330d963c1bf24667eddb891531abcce9fb4de/sdkmanager/libs/sdklib/src/com/android/sdklib/internal/avd/AvdManager.java
-    const prefsRoot = await getAndroidPrefsRoot();
-    if (!prefsRoot) {
-      return [];
-    }
-
-    avdsRoot = path.resolve(prefsRoot, 'avd');
-  }
-
-  if (!await fs.exists(avdsRoot)) {
-    log.debug(`Virtual devices config root '${avdsRoot}' does not exist`);
+  avdsRoot = path.resolve(prefsRoot, 'avd');
+  if (!await dirExists(avdsRoot)) {
+    log.debug(`Virtual devices config root '${avdsRoot}' is not an existing directory`);
     return [];
   }
 
-  const stats = await fs.stat(avdsRoot);
-  if (!stats.isDirectory()) {
-    log.debug(`Virtual devices config root '${avdsRoot}' is not a directory`);
-    return [];
-  }
+  return mapAvdDir(avdsRoot);
+}
 
+function mapAvdDir (avdsRoot) {
   const configs = await fs.glob('*.ini', {
     cwd: avdsRoot,
     absolute: true,

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -66,6 +66,10 @@ emuMethods.SENSORS = {
  */
 async function listEmulators () {
   let avdsRoot = process.env.ANDROID_AVD_HOME;
+  if (avdsRoot && !await fs.exists(avdsRoot)) {
+    log.debug(`Value of $ANDROID_AVD_HOME '${location}' does not exist`);
+    return [];
+  }
 
   if (!avdsRoot) {
     // https://android.googlesource.com/platform/sdk/+/33f330d963c1bf24667eddb891531abcce9fb4de/sdkmanager/libs/sdklib/src/com/android/sdklib/internal/avd/AvdManager.java

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -71,7 +71,7 @@ async function listEmulators () {
   }
 
   if (avdsRoot) {
-    log.debug(`Value of $ANDROID_AVD_HOME '${location}' does not exist`);
+    log.warn(`The value of $ANDROID_AVD_HOME '${location}' is not an existing directory`);
   }
 
   const prefsRoot = await getAndroidPrefsRoot();

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -78,6 +78,7 @@ async function listEmulators () {
   }
 
   if (!await fs.exists(avdsRoot)) {
+    log.debug(`Virtual devices config root '${avdsRoot}' does not exist`);
     return [];
   }
 

--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -71,7 +71,7 @@ async function listEmulators () {
   }
 
   if (avdsRoot) {
-    log.warn(`The value of $ANDROID_AVD_HOME '${location}' is not an existing directory`);
+    log.warn(`The value of the ANDROID_AVD_HOME environment variable '${avdsRoot}' is not an existing directory`);
   }
 
   const prefsRoot = await getAndroidPrefsRoot();
@@ -88,6 +88,12 @@ async function listEmulators () {
   return await getAvdConfigPaths(avdsRoot);
 }
 
+/**
+ * Get configuration paths of all virtual devices
+ *
+ * @param {string} avdsRoot path to the directory that contains the AVD .ini files
+ * @returns {Array<EmuInfo>}
+ */
 async function getAvdConfigPaths (avdsRoot) {
   const configs = await fs.glob('*.ini', {
     cwd: avdsRoot,


### PR DESCRIPTION
On Windows avds are stored, by default, in `C:\Users\{USER}\.android\avd`.

The current version of `listEmulators()` searches for the avd folder in `C:\Users\{USER}\AppData\Local\Android` (via `getAndroidPrefsRoot()`), but that's the wrong location.

> By default, the emulator stores configuration files under $HOME/.android/ and AVD data under $HOME/.android/avd/. You can override the defaults by setting the following environment variables. The emulator -avd <avd_name> command searches the avd directory in the order of the values in $ANDROID_AVD_HOME, $ANDROID_SDK_HOME/.android/avd/, and $HOME/.android/avd/.

Source: https://developer.android.com/studio/command-line/variables