### PR TITLE
feat: expose install-multiple adb call

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -464,6 +464,8 @@ const extractMatchingPermissions = function (dumpsysOutput, groupNames, grantedS
  * @property {boolean} replace [true] - Set it to false if you don't want
  *                                      the application to be upgraded/reinstalled
  *                                      if it is already present on the device.
+ * @property {boolean} partialInstall [true] - Install apks partially. It is used for 'install-multiple'.
+ *                                             https://android.stackexchange.com/questions/111064/what-is-a-partial-application-install-via-adb
  */
 
 /**
@@ -493,6 +495,10 @@ function buildInstallArgs (apiLevel, options = {}) {
     } else {
       result.push('-g');
     }
+  }
+  // For multiple-install
+  if (options.partialInstall) {
+    result.push('-p');
   }
 
   return result;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -464,7 +464,7 @@ const extractMatchingPermissions = function (dumpsysOutput, groupNames, grantedS
  * @property {boolean} replace [true] - Set it to false if you don't want
  *                                      the application to be upgraded/reinstalled
  *                                      if it is already present on the device.
- * @property {boolean} partialInstall [true] - Install apks partially. It is used for 'install-multiple'.
+ * @property {boolean} partialInstall [false] - Install apks partially. It is used for 'install-multiple'.
  *                                             https://android.stackexchange.com/questions/111064/what-is-a-partial-application-install-via-adb
  */
 

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -147,6 +147,8 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
  *                                                permissions requested in the application's manifest
  *                                                automatically after the installation is completed
  *                                                under Android 6+.
+ * @property {boolean} partialInstall [false] - Install apks partially. It is used for 'install-multiple'.
+ *                                             https://android.stackexchange.com/questions/111064/what-is-a-partial-application-install-via-adb
  */
 
 /**
@@ -154,13 +156,8 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
  *
  * @param {Array<string>} apkPathsToInstall - The full paths to install apks
  * @param {?installMultipleApksOptions} options - Installation options
- * @throws {Error} If the apkPathsToInstall is empty
  */
 apksUtilsMethods.installMultipleApks = async function installMultipleApks (apkPathsToInstall, options = {}) {
-  if (_.isEmpty(apkPathsToInstall)) {
-    throw new Error('No APKs were given.');
-  }
-
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
   return await this.adbExec(['install-multiple', ...installArgs, ...apkPathsToInstall], {
     timeout: options.timeout,

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -134,7 +134,7 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
 };
 
 /**
- * @typedef {Object} InstallApksOptions
+ * @typedef {Object} installMultipleApksOptions
  * @property {?number|string} timeout [20000] - The number of milliseconds to wait until
  *                                              the installation is completed
  * @property {string} timeoutCapName [androidInstallTimeout] - The timeout option name
@@ -150,10 +150,29 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
  */
 
 /**
+ * Installs the given apks into the device under test
+ *
+ * @param {Array<string>} apkPathsToInstall - The full paths to install apks
+ * @param {?installMultipleApksOptions} options - Installation options
+ * @throws {Error} If the apkPathsToInstall is empty
+ */
+apksUtilsMethods.installMultipleApks = async function installMultipleApks (apkPathsToInstall, options = {}) {
+  if (_.isEmpty(apkPathsToInstall)) {
+    throw new Error('No APKs were given.');
+  }
+
+  const installArgs = buildInstallArgs(await this.getApiLevel(), options);
+  return await this.adbExec(['install-multiple', ...installArgs, ...apkPathsToInstall], {
+    timeout: options.timeout,
+    timeoutCapName: options.timeoutCapName,
+  });
+};
+
+/**
  * Installs the given .apks package into the device under test
  *
  * @param {string} apks - The full path to the .apks file
- * @param {?InstallApksOptions} options - Installation options
+ * @param {?installMultipleApksOptions} options - Installation options
  * @throws {Error} If the .apks bundle cannot be installed
  */
 apksUtilsMethods.installApks = async function installApks (apks, options = {}) {
@@ -175,16 +194,12 @@ apksUtilsMethods.installApks = async function installApks (apks, options = {}) {
     ];
     log.debug(`Extracting the apk files from '${apks}'`);
     await this.execBundletool(args, `Cannot extract the application bundle at '${apks}'`);
-    const installArgs = buildInstallArgs(await this.getApiLevel(), options);
     const apkPathsToInstall = (await fs.readdir(tmpRoot))
       .filter((name) => name.endsWith(APK_EXTENSION))
       .map((name) => path.resolve(tmpRoot, name));
     log.debug('Got the following apk files to install: ' +
       JSON.stringify(apkPathsToInstall.map((x) => path.basename(x))));
-    const output = await this.adbExec(['install-multiple', ...installArgs, ...apkPathsToInstall], {
-      timeout: options.timeout,
-      timeoutCapName: options.timeoutCapName,
-    });
+    const output = await this.installMultipleApks(apkPathsToInstall, options);
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;
     log.debug(`Install command stdout: ${truncatedOutput}`);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -1015,7 +1015,7 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       });
     });
 
-    it('should call', async function () {
+    it('should raise an error if no valid apks', async function () {
       mocks.adb.expects('getApiLevel').once().returns(28);
       await adb.installMultipleApks([], {}).should.eventually.be.rejected;
     });

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -982,4 +982,42 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       apksUtilsMethods.isTestPackageOnlyError('[INSTALL_FAILED_OTHER]').should.equal(false);
     });
   });
+  describe('installMultipleApks', function () {
+    it('should call adbExec with an apk', async function () {
+      mocks.adb.expects('getApiLevel').once().returns(28);
+      mocks.adb.expects('adbExec').withArgs([
+        'install-multiple', '-r', '/dummy/apk.apk'
+      ], {
+        timeout: undefined, timeoutCapName: undefined
+      }).once();
+      await adb.installMultipleApks(['/dummy/apk.apk'], {});
+    });
+
+    it('should call adbExec with two apks', async function () {
+      mocks.adb.expects('getApiLevel').once().returns(28);
+      mocks.adb.expects('adbExec').withArgs([
+        'install-multiple', '-r', '/dummy/apk.apk', '/dummy/apk2.apk'
+      ], {
+        timeout: undefined, timeoutCapName: undefined
+      }).once();
+      await adb.installMultipleApks(['/dummy/apk.apk', '/dummy/apk2.apk'], {});
+    });
+
+    it('should call adbExec with an apk and options', async function () {
+      mocks.adb.expects('getApiLevel').once().returns(28);
+      mocks.adb.expects('adbExec').withArgs([
+        'install-multiple', '-r', '/dummy/apk.apk'
+      ], {
+        timeout: 60, timeoutCapName: 'androidInstallTimeout'
+      }).once();
+      await adb.installMultipleApks(['/dummy/apk.apk'], {
+        timeout: 60, timeoutCapName: 'androidInstallTimeout'
+      });
+    });
+
+    it('should call', async function () {
+      mocks.adb.expects('getApiLevel').once().returns(28);
+      await adb.installMultipleApks([], {}).should.eventually.be.rejected;
+    });
+  });
 }));

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -1023,10 +1023,5 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         partialInstall: true
       });
     });
-
-    it('should raise an error if no valid apks', async function () {
-      mocks.adb.expects('getApiLevel').once().returns(28);
-      await adb.installMultipleApks([], {}).should.eventually.be.rejected;
-    });
   });
 }));

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -1006,12 +1006,21 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     it('should call adbExec with an apk and options', async function () {
       mocks.adb.expects('getApiLevel').once().returns(28);
       mocks.adb.expects('adbExec').withArgs([
-        'install-multiple', '-r', '/dummy/apk.apk'
+        'install-multiple',
+        '-r', '-t', '-s', '-g', '-p',
+        '/dummy/apk.apk'
       ], {
-        timeout: 60, timeoutCapName: 'androidInstallTimeout'
+        timeout: 60,
+        timeoutCapName: 'androidInstallTimeout',
       }).once();
       await adb.installMultipleApks(['/dummy/apk.apk'], {
-        timeout: 60, timeoutCapName: 'androidInstallTimeout'
+        timeout: 60,
+        timeoutCapName: 'androidInstallTimeout',
+        grantPermissions: true,
+        useSdcard: true,
+        allowTestPackages: true,
+        replace: true,
+        partialInstall: true
       });
     });
 


### PR DESCRIPTION
Part of https://github.com/appium/appium/issues/14823#issuecomment-775729347


```
app installation (see also `adb shell cmd package help`):
 install [-lrtsdg] [--instant] PACKAGE
     push a single package to the device and install it
 install-multiple [-lrtsdpg] [--instant] PACKAGE...
     push multiple APKs to the device for a single package and install them
...
     -r: replace existing application
     -t: allow test packages
     -d: allow version code downgrade (debuggable packages only)
     -p: partial application install (install-multiple only)
     -g: grant all runtime permissions
...
```