### PR TITLE
feat: Added optional speed parameter to properly mock locations for android devices

### DIFF
--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -171,7 +171,7 @@ commands.setDeviceSysLocaleViaSettingApp = async function setDeviceSysLocaleViaS
  * @property {number|string} longitude - Valid longitude value.
  * @property {number|string} latitude - Valid latitude value.
  * @property {?number|string} altitude - Valid altitude value.
- * @property {?number|string} speed - Valid speed value. Should be bigger then 0.0 meters/second.
+ * @property {?number|string} speed - Valid speed value. Should be greater then 0.0 meters/second.
  */
 
 /**

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -171,7 +171,7 @@ commands.setDeviceSysLocaleViaSettingApp = async function setDeviceSysLocaleViaS
  * @property {number|string} longitude - Valid longitude value.
  * @property {number|string} latitude - Valid latitude value.
  * @property {?number|string} altitude - Valid altitude value.
- * @property {?number|string} speed - Valid speed value. Should be greater then 0.0 meters/second.
+ * @property {?number|string} speed - Valid speed value. Should be greater than 0.0 meters/second.
  */
 
 /**

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -171,6 +171,7 @@ commands.setDeviceSysLocaleViaSettingApp = async function setDeviceSysLocaleViaS
  * @property {number|string} longitude - Valid longitude value.
  * @property {number|string} latitude - Valid latitude value.
  * @property {?number|string} altitude - Valid altitude value.
+ * @property {?number|string} speed - Valid speed value. Should be bigger then 0.0 meters/second.
  */
 
 /**
@@ -202,6 +203,7 @@ commands.setGeoLocation = async function setGeoLocation (location, isEmulator = 
   const longitude = formatLocationValue('longitude');
   const latitude = formatLocationValue('latitude');
   const altitude = formatLocationValue('altitude', false);
+  const speed = formatLocationValue('speed', false);
   if (isEmulator) {
     await this.resetTelnetAuthToken();
     await this.adbExec(['emu', 'geo', 'fix', longitude, latitude]);
@@ -215,6 +217,9 @@ commands.setGeoLocation = async function setGeoLocation (location, isEmulator = 
     ];
     if (util.hasValue(altitude)) {
       args.push('-e', 'altitude', altitude);
+    }
+    if (util.hasValue(speed)) {
+      args.push('-e', 'speed', speed);
     }
     args.push(LOCATION_SERVICE);
     await this.shell(args);


### PR DESCRIPTION
Enable applications that use location speed to mock properly mock locations from inside a test.
This is related to:
- **python-client** pull request: https://github.com/appium/python-client/pull/594
- **io.appium.settings** pull request https://github.com/appium/io.appium.settings/pull/70