### PR TITLE
feat: consider NotificationShade and StatusBar as lock screen for newer android versions

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -210,15 +210,21 @@ async function getApkanalyzerForOs (sysHelpers) {
  * in comparison to `adb dumpsys window` output parsing.
  * But the trust command does not work for `Swipe` unlock pattern.
  *
- * In some Android devices (Probably around Android 10+) show `mCurrentFocus` as `NotificationShade` or `StatusBar`
- * as the lock screen while they do not have mShowingLockscreen nor mDreamingLockscreen.
- * Although, these `NotificationShade` and `StatusBar` could be also regular notification view.
+ * In some Android devices (Probably around Android 10+), `mShowingLockscreen` and `mDreamingLockscreen`
+ * do not work to detect lock status. Instead, keyguard preferences helps to detect the lock condition.
+ * Some devices such as Android TV do not have keyguard, so we should keep
+ * screen condition as this primary method.
  *
  * @param {string} dumpsys - The output of dumpsys window command.
  * @return {boolean} True if lock screen is showing.
  */
 function isShowingLockscreen (dumpsys) {
-  return /(mShowingLockscreen=true|mDreamingLockscreen=true|mCurrentFocus=.+NotificationShade|mCurrentFocus=.+StatusBar)/gi.test(dumpsys);
+  if (/(mShowingLockscreen=true|mDreamingLockscreen=true)/gi.test(dumpsys)) {
+    return true;
+  }
+  // Fallback to KeyguardServiceDelegate preference.
+  // mIsShowing and mInputRestricted are true in lock condition.
+  return dumpsys.includes('mIsShowing=false', 'mInputRestricted=false');
 }
 
 /*

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -214,15 +214,14 @@ async function getApkanalyzerForOs (sysHelpers) {
  * do not work to detect lock status. Instead, keyguard preferences helps to detect the lock condition.
  * Some devices such as Android TV do not have keyguard, so we should keep
  * screen condition as this primary method.
- * `mIsShowing` and `mInputRestricted` are `true` in lock condition.
- * Both `false` is unlock condition.
  *
  * @param {string} dumpsys - The output of dumpsys window command.
  * @return {boolean} True if lock screen is showing.
  */
 function isShowingLockscreen (dumpsys) {
   return _.some(['mShowingLockscreen=true', 'mDreamingLockscreen=true'], (x) => dumpsys.includes(x))
-  || _.every(['mIsShowing=false', 'mInputRestricted=false'], (x) => dumpsys.includes(x));
+    // `mIsShowing` and `mInputRestricted` are `true` in lock condition. `false` is unlock condition.
+    || _.every(['mIsShowing=false', 'mInputRestricted=false'], (x) => dumpsys.includes(x));
 }
 
 /*

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -214,17 +214,15 @@ async function getApkanalyzerForOs (sysHelpers) {
  * do not work to detect lock status. Instead, keyguard preferences helps to detect the lock condition.
  * Some devices such as Android TV do not have keyguard, so we should keep
  * screen condition as this primary method.
+ * `mIsShowing` and `mInputRestricted` are `true` in lock condition.
+ * Both `false` is unlock condition.
  *
  * @param {string} dumpsys - The output of dumpsys window command.
  * @return {boolean} True if lock screen is showing.
  */
 function isShowingLockscreen (dumpsys) {
-  if (/(mShowingLockscreen=true|mDreamingLockscreen=true)/gi.test(dumpsys)) {
-    return true;
-  }
-  // Fallback to KeyguardServiceDelegate preference.
-  // mIsShowing and mInputRestricted are true in lock condition.
-  return dumpsys.includes('mIsShowing=false', 'mInputRestricted=false');
+  return _.some(['mShowingLockscreen=true', 'mDreamingLockscreen=true'], (x) => dumpsys.includes(x))
+  || _.every(['mIsShowing=false', 'mInputRestricted=false'], (x) => dumpsys.includes(x));
 }
 
 /*

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -210,11 +210,15 @@ async function getApkanalyzerForOs (sysHelpers) {
  * in comparison to `adb dumpsys window` output parsing.
  * But the trust command does not work for `Swipe` unlock pattern.
  *
+ * In some Android devices (Probably around Android 10+) show `mCurrentFocus` as `NotificationShade` or `StatusBar`
+ * as the lock screen while they do not have mShowingLockscreen nor mDreamingLockscreen.
+ * Although, these `NotificationShade` and `StatusBar` could be also regular notification view.
+ *
  * @param {string} dumpsys - The output of dumpsys window command.
  * @return {boolean} True if lock screen is showing.
  */
 function isShowingLockscreen (dumpsys) {
-  return /(mShowingLockscreen=true|mDreamingLockscreen=true)/gi.test(dumpsys);
+  return /(mShowingLockscreen=true|mDreamingLockscreen=true|mCurrentFocus=.+NotificationShade|mCurrentFocus=.+StatusBar)/gi.test(dumpsys);
 }
 
 /*

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -60,12 +60,28 @@ describe('helpers', withMocks({fs}, function (mocks) {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=true mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.true;
     });
+    it('should assume that screen is locked if NotificationShade is active', async function () {
+      let dumpsys = 'mCurrentFocus=Window{4bdb8b5 u0 NotificationShade}';
+      (await isShowingLockscreen(dumpsys)).should.be.true;
+    });
+    it('should assume that screen is locked if StatusBar is active', async function () {
+      let dumpsys = 'mCurrentFocus=Window{4bdb8b5 u0 StatusBar}';
+      (await isShowingLockscreen(dumpsys)).should.be.true;
+    });
     it('should return false if mShowingLockscreen and mDreamingLockscreen are false', async function () {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=false mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
     it('should assume that screen is unlocked if can not determine lock state', async function () {
       let dumpsys = 'mShowingDream=false mTopIsFullscreen=false';
+      (await isShowingLockscreen(dumpsys)).should.be.false;
+    });
+    it('should assume that screen is unlocked if mCurrentFocus is another activity', async function () {
+      let dumpsys = 'mCurrentFocus=Window{8b4bb70 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity}';
+      (await isShowingLockscreen(dumpsys)).should.be.false;
+    });
+    it('should assume that screen is unlocked if mCurrentFocus is another activity', async function () {
+      let dumpsys = 'mCurrentFocus=Window{8b4bb70 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity}';
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
   });

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -60,12 +60,17 @@ describe('helpers', withMocks({fs}, function (mocks) {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=true mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.true;
     });
-    it('should assume that screen is locked if NotificationShade is active', async function () {
-      let dumpsys = 'mCurrentFocus=Window{4bdb8b5 u0 NotificationShade}';
-      (await isShowingLockscreen(dumpsys)).should.be.true;
-    });
-    it('should assume that screen is locked if StatusBar is active', async function () {
-      let dumpsys = 'mCurrentFocus=Window{4bdb8b5 u0 StatusBar}';
+    it('should assume that screen is locked if keyguard is unlocked', async function () {
+      let dumpsys = `
+      KeyguardServiceDelegate
+      ....
+        KeyguardStateMonitor
+          mIsShowing=false
+          mSimSecure=false
+          mInputRestricted=false
+          mCurrentUserId=0
+          ...
+      `;
       (await isShowingLockscreen(dumpsys)).should.be.true;
     });
     it('should return false if mShowingLockscreen and mDreamingLockscreen are false', async function () {
@@ -77,11 +82,16 @@ describe('helpers', withMocks({fs}, function (mocks) {
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
     it('should assume that screen is unlocked if mCurrentFocus is another activity', async function () {
-      let dumpsys = 'mCurrentFocus=Window{8b4bb70 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity}';
-      (await isShowingLockscreen(dumpsys)).should.be.false;
-    });
-    it('should assume that screen is unlocked if mCurrentFocus is another activity', async function () {
-      let dumpsys = 'mCurrentFocus=Window{8b4bb70 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity}';
+      let dumpsys = `
+      KeyguardServiceDelegate
+      ....
+        KeyguardStateMonitor
+          mIsShowing=true
+          mSimSecure=false
+          mInputRestricted=true
+          mCurrentUserId=0
+          ...
+      `;
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
   });

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -81,7 +81,7 @@ describe('helpers', withMocks({fs}, function (mocks) {
       let dumpsys = 'mShowingDream=false mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
-    it('should assume that screen is unlocked if mCurrentFocus is another activity', async function () {
+    it('should assume that screen is unlocked if mInputRestricted and mIsShowing were true', async function () {
       let dumpsys = `
       KeyguardServiceDelegate
       ....
@@ -89,6 +89,19 @@ describe('helpers', withMocks({fs}, function (mocks) {
           mIsShowing=true
           mSimSecure=false
           mInputRestricted=true
+          mCurrentUserId=0
+          ...
+      `;
+      (await isShowingLockscreen(dumpsys)).should.be.false;
+    });
+    it('should assume that screen is unlocked if mIsShowing was true', async function () {
+      let dumpsys = `
+      KeyguardServiceDelegate
+      ....
+        KeyguardStateMonitor
+          mIsShowing=true
+          mSimSecure=false
+          mInputRestricted=false
           mCurrentUserId=0
           ...
       `;


### PR DESCRIPTION
I think we should relax locked screen condition logic for newer Android devices.
https://github.com/appium/appium-adb/blob/master/lib/tools/adb-commands.js#L615-L632

Newer Android devices (i tested a few real devices), lock screen is simply `NotificationShade` or `StatusBar` after keycode 62. But current our logic does not consider such case as locked screen. So, our `lock` never be succeeded.

When these app is focused, Appium can unlock them with https://github.com/appium/appium-android-driver/blob/9d120ba76df18ada8c5793af3d42f9b1aa4937cb/lib/android-helpers.js#L648-L679 , so I think we can consider `NotificationShade` and `StatusBar` as part of `isShowingLockscreen`.

(at least, an Android 7.1 real device had `mShowingLockscreen`. Haven't checked with android 8 and 9.)