### PR TITLE
fix: Update screen lock detection based on KeyguardStateMonitor

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -221,7 +221,7 @@ async function getApkanalyzerForOs (sysHelpers) {
 function isShowingLockscreen (dumpsys) {
   return _.some(['mShowingLockscreen=true', 'mDreamingLockscreen=true'], (x) => dumpsys.includes(x))
     // `mIsShowing` and `mInputRestricted` are `true` in lock condition. `false` is unlock condition.
-    || _.every(['mIsShowing=false', 'mInputRestricted=false'], (x) => dumpsys.includes(x));
+    || _.every([/KeyguardStateMonitor[\n\s]+mIsShowing=true/, /\s+mInputRestricted=true/], (x) => x.test(dumpsys));
 }
 
 /*

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -60,7 +60,7 @@ describe('helpers', withMocks({fs}, function (mocks) {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=true mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.true;
     });
-    it('should assume that screen is locked if keyguard is shown', async function () {
+    it('should assume that screen is unlocked if keyguard is shown, but mInputRestricted is false', async function () {
       let dumpsys = `
       KeyguardServiceDelegate
       ....
@@ -71,7 +71,7 @@ describe('helpers', withMocks({fs}, function (mocks) {
           mCurrentUserId=0
           ...
       `;
-      (await isShowingLockscreen(dumpsys)).should.be.true;
+      (await isShowingLockscreen(dumpsys)).should.be.false;
     });
     it('should return false if mShowingLockscreen and mDreamingLockscreen are false', async function () {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=false mTopIsFullscreen=false';

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -60,12 +60,12 @@ describe('helpers', withMocks({fs}, function (mocks) {
       let dumpsys = 'mShowingLockscreen=false mShowingDream=false mDreamingLockscreen=true mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.true;
     });
-    it('should assume that screen is locked if keyguard is unlocked', async function () {
+    it('should assume that screen is locked if keyguard is shown', async function () {
       let dumpsys = `
       KeyguardServiceDelegate
       ....
         KeyguardStateMonitor
-          mIsShowing=false
+          mIsShowing=true
           mSimSecure=false
           mInputRestricted=false
           mCurrentUserId=0
@@ -81,7 +81,7 @@ describe('helpers', withMocks({fs}, function (mocks) {
       let dumpsys = 'mShowingDream=false mTopIsFullscreen=false';
       (await isShowingLockscreen(dumpsys)).should.be.false;
     });
-    it('should assume that screen is unlocked if mInputRestricted and mIsShowing were true', async function () {
+    it('should assume that screen is locked if mInputRestricted and mIsShowing were true', async function () {
       let dumpsys = `
       KeyguardServiceDelegate
       ....
@@ -92,14 +92,14 @@ describe('helpers', withMocks({fs}, function (mocks) {
           mCurrentUserId=0
           ...
       `;
-      (await isShowingLockscreen(dumpsys)).should.be.false;
+      (await isShowingLockscreen(dumpsys)).should.be.true;
     });
-    it('should assume that screen is unlocked if mIsShowing was true', async function () {
+    it('should assume that screen is unlocked if mIsShowing was false', async function () {
       let dumpsys = `
       KeyguardServiceDelegate
       ....
         KeyguardStateMonitor
-          mIsShowing=true
+          mIsShowing=false
           mSimSecure=false
           mInputRestricted=false
           mCurrentUserId=0


### PR DESCRIPTION
I assume there was a typo is in the code, because the screen is supposed to be locked if Keyguard is shown and vice versa.
