### PR TITLE
fix: Escape command line arguments for Windows

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -896,15 +896,18 @@ async function dirExists (location) {
 }
 
 /**
- * Escapes special characters in command line arguments
+ * Escapes special characters in command line arguments.
+ * This is needed to avoid possible issues with how system `spawn`
+ * call handles them. See https://github.com/appium/appium/issues/15285
+ * for more details.
  *
- * @param {string} arg Unescaped argument string
+ * @param {string} arg Non-escaped argument string
  * @returns The escaped argument
  */
-function escapeArg (arg) {
+function escapeShellArg (arg) {
   arg = `${arg}`;
   if (system.isWindows()) {
-    return /[&\s]/.test(arg) ? `"${arg.replace(/"/g, '""')}"` : arg;
+    return /[&|^\s]/.test(arg) ? `"${arg.replace(/"/g, '""')}"` : arg;
   }
   return arg.replace(/&/g, '\\&');
 }
@@ -918,5 +921,5 @@ export {
   APK_INSTALL_TIMEOUT, APKS_INSTALL_TIMEOUT, buildInstallArgs, APK_EXTENSION,
   DEFAULT_ADB_EXEC_TIMEOUT, parseManifest, parseAaptStrings, parseAapt2Strings,
   formatConfigMarker, parseJsonData, unsignApk, toAvdLocaleArgs, requireSdkRoot,
-  getSdkRootFromEnv, getAndroidPrefsRoot, dirExists, escapeArg,
+  getSdkRootFromEnv, getAndroidPrefsRoot, dirExists, escapeShellArg,
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -898,7 +898,8 @@ async function dirExists (location) {
 /**
  * Escapes special characters in command line arguments.
  * This is needed to avoid possible issues with how system `spawn`
- * call handles them. See https://github.com/appium/appium/issues/15285
+ * call handles them.
+ * See https://discuss.appium.io/t/how-to-modify-wd-proxy-and-uiautomator2-source-code-to-support-unicode/33466
  * for more details.
  *
  * @param {string} arg Non-escaped argument string

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1152,8 +1152,8 @@ methods.getPIDsByName = async function getPIDsByName (name) {
         ? (this._canPgrepUseFullCmdLineSearch
           ? ['pgrep', '-f', escapeShellArg(_.escapeRegExp(`([[:blank:]]|^)${name}([[:blank:]]|$)`))]
           // https://github.com/appium/appium/issues/13872
-          : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ ` +
-              `|| pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
+          : [`pgrep ${escapeShellArg('^' + _.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN)) + '$')} ` +
+              `|| pgrep ${escapeShellArg('^' + _.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN)) + '$')}`])
         : ['pidof', name];
       try {
         return (await this.shell(shellCommand))

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -2,6 +2,7 @@ import log from '../logger.js';
 import {
   getIMEListFromOutput, isShowingLockscreen, isCurrentFocusOnKeyguard,
   getSurfaceOrientation, isScreenOnFully, extractMatchingPermissions,
+  escapeShellArg,
 } from '../helpers.js';
 import path from 'path';
 import _ from 'lodash';
@@ -1149,9 +1150,10 @@ methods.getPIDsByName = async function getPIDsByName (name) {
     if (this._isPgrepAvailable || this._isPidofAvailable) {
       const shellCommand = this._isPgrepAvailable
         ? (this._canPgrepUseFullCmdLineSearch
-          ? ['pgrep', '-f', _.escapeRegExp(`([[:blank:]]|^)${name}([[:blank:]]|$)`)]
+          ? ['pgrep', '-f', escapeShellArg(_.escapeRegExp(`([[:blank:]]|^)${name}([[:blank:]]|$)`))]
           // https://github.com/appium/appium/issues/13872
-          : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ || pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
+          : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ ` +
+              `|| pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
         : ['pidof', name];
       try {
         return (await this.shell(shellCommand))

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -2,7 +2,6 @@ import log from '../logger.js';
 import {
   getIMEListFromOutput, isShowingLockscreen, isCurrentFocusOnKeyguard,
   getSurfaceOrientation, isScreenOnFully, extractMatchingPermissions,
-  escapeShellArg,
 } from '../helpers.js';
 import path from 'path';
 import _ from 'lodash';
@@ -1150,10 +1149,10 @@ methods.getPIDsByName = async function getPIDsByName (name) {
     if (this._isPgrepAvailable || this._isPidofAvailable) {
       const shellCommand = this._isPgrepAvailable
         ? (this._canPgrepUseFullCmdLineSearch
-          ? ['pgrep', '-f', escapeShellArg(_.escapeRegExp(`([[:blank:]]|^)${name}([[:blank:]]|$)`))]
+          ? ['pgrep', '-f', _.escapeRegExp(`([[:blank:]]|^)${name}([[:blank:]]|$)`)]
           // https://github.com/appium/appium/issues/13872
-          : [`pgrep ${escapeShellArg('^' + _.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN)) + '$')} ` +
-              `|| pgrep ${escapeShellArg('^' + _.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN)) + '$')}`])
+          : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ ` +
+              `|| pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
         : ['pidof', name];
       try {
         return (await this.shell(shellCommand))

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1163,10 +1163,14 @@ methods.getPIDsByName = async function getPIDsByName (name) {
       } catch (e) {
         // error code 1 is returned if the utility did not find any processes
         // with the given name
-        if (e.code === 1) {
+        if (e.code !== 1) {
+          throw new Error(`Could not extract process ID of '${name}': ${e.message}`);
+        }
+        if (_.includes(e.stderr || e.stdout, 'syntax error')) {
+          log.warn(`Got an unexpected response from the shell interpreter: ${e.stderr || e.stdout}`);
+        } else {
           return [];
         }
-        throw new Error(`Could not extract process ID of '${name}': ${e.message}`);
       }
     }
   }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -2,7 +2,7 @@ import {
   buildStartCmd, APKS_EXTENSION, buildInstallArgs,
   APK_INSTALL_TIMEOUT, DEFAULT_ADB_EXEC_TIMEOUT,
   parseManifest, parseAaptStrings, parseAapt2Strings, formatConfigMarker,
-  escapeArg,
+  escapeShellArg,
 } from '../helpers.js';
 import { exec } from 'teen_process';
 import log from '../logger.js';
@@ -77,7 +77,7 @@ apkUtilsMethods.startUri = async function startUri (uri, pkg, opts = {}) {
     args.push('-W');
   }
   args.push('-a', 'android.intent.action.VIEW',
-    '-d', escapeArg(uri),
+    '-d', escapeShellArg(uri),
     pkg);
 
   try {

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -1,5 +1,5 @@
 import log from '../logger.js';
-import { parseJsonData, escapeArg } from '../helpers.js';
+import { parseJsonData, escapeShellArg } from '../helpers.js';
 import _ from 'lodash';
 import { util } from 'appium-support';
 import { waitForCondition } from 'asyncbox';
@@ -468,7 +468,7 @@ commands.typeUnicode = async function typeUnicode (text) {
     return false;
   }
   await this.runInImeContext(UNICODE_IME,
-    async () => await this.shell(['input', 'text', escapeArg(imap.encode(text))]));
+    async () => await this.shell(['input', 'text', escapeShellArg(imap.encode(text))]));
   return true;
 };
 


### PR DESCRIPTION
It looks like the system `spawn` call does not always handle command line arguments the way we want them to be handled in Windows. This patch fixes it.