### PR TITLE
chore: Assume cert validation succeeds if java vm error is thrown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage-e2e
 package-lock.json*
 .DS_Store
 bugreport-*
+.vscode

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -20,6 +20,7 @@ const MD5 = 'md5';
 const DEFAULT_CERT_HASH = {
   [SHA256]: 'a40da80a59d170caa950cf15c18c454d47a39b26989d8b640ecd745ba71bf5dc'
 };
+const JAVA_PROPS_INIT_ERROR = 'java.lang.Error: Properties init';
 
 
 const apkSigningMethods = {};
@@ -267,8 +268,22 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
       log.info(`'${appPath}' is not signed`);
       return false;
     }
+    const errMsg = err.stderr || err.stdout || err.message;
+    if (_.includes(errMsg, JAVA_PROPS_INIT_ERROR)) {
+      // This error pops up randomly and we are not quite sure why.
+      // My guess - a race condition in java vm initialization.
+      // Nevertheless, lets make Appium to believe the file is already signed,
+      // because it would be true for 99% of UIAutomator2-based
+      // tests, where we presign server binaries while publishing their NPM module.
+      // If these are not signed, e.g. in case of Espresso, then the next step(s)
+      // would anyway fail.
+      // See https://github.com/appium/appium/issues/14724 for more details.
+      log.warn(errMsg);
+      log.warn(`Assuming '${appPath}' is already signed and continuing anyway`);
+      return true;
+    }
     throw new Error(`Cannot verify the signature of '${appPath}'. ` +
-      `Original error: ${err.stderr || err.stdout || err.message}`);
+      `Original error: ${errMsg}`);
   }
 };
 

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -246,6 +246,7 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
     }
     return false;
   };
+
   const {
     requireDefaultCert = true,
   } = opts;
@@ -262,7 +263,6 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
   const expected = this.useKeystore
     ? await this.getKeystoreHash(appPath, pkg)
     : DEFAULT_CERT_HASH;
-
   try {
     await getApksignerForOs(this);
     const output = await this.executeApksigner(['verify', '--print-certs', appPath]);

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -4,6 +4,7 @@ import { exec } from 'teen_process';
 import path from 'path';
 import log from '../logger.js';
 import { tempDir, system, mkdirp, fs, util } from 'appium-support';
+import LRU from 'lru-cache';
 import {
   getJavaForOs, getApksignerForOs, getJavaHome,
   rootDir, APKS_EXTENSION, unsignApk,
@@ -21,6 +22,9 @@ const DEFAULT_CERT_HASH = {
   [SHA256]: 'a40da80a59d170caa950cf15c18c454d47a39b26989d8b640ecd745ba71bf5dc'
 };
 const JAVA_PROPS_INIT_ERROR = 'java.lang.Error: Properties init';
+const SIGNED_APPS_CACHE = new LRU({
+  max: 30,
+});
 
 
 const apkSigningMethods = {};
@@ -233,12 +237,8 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
     appPath = await this.extractBaseApk(appPath);
   }
 
-  const expectedHash = this.useKeystore
-    ? await this.getKeystoreHash(appPath, pkg)
-    : DEFAULT_CERT_HASH;
-
-  const hashMatches = (apksignerOutput) => {
-    for (const [name, value] of _.toPairs(expectedHash)) {
+  const hashMatches = (apksignerOutput, expectedHashes) => {
+    for (const [name, value] of _.toPairs(expectedHashes)) {
       if (new RegExp(`digest:\\s+${value}\\b`, 'i').test(apksignerOutput)) {
         log.debug(`${name} hash did match for '${path.basename(appPath)}'`);
         return true;
@@ -246,14 +246,27 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
     }
     return false;
   };
-
   const {
     requireDefaultCert = true,
   } = opts;
+
+  const appHash = await fs.hash(appPath);
+  if (SIGNED_APPS_CACHE.has(appHash)) {
+    log.debug(`Using the previously cached signature entry for '${path.basename(appPath)}'`);
+    const {keystorePath, output, expected} = SIGNED_APPS_CACHE.get(appHash);
+    if (this.useKeystore && this.keystorePath === keystorePath || !this.useKeystore) {
+      return (!this.useKeystore && !requireDefaultCert) || hashMatches(output, expected);
+    }
+  }
+
+  const expected = this.useKeystore
+    ? await this.getKeystoreHash(appPath, pkg)
+    : DEFAULT_CERT_HASH;
+
   try {
     await getApksignerForOs(this);
     const output = await this.executeApksigner(['verify', '--print-certs', appPath]);
-    const hasMatch = hashMatches(output);
+    const hasMatch = hashMatches(output, expected);
     if (hasMatch) {
       log.info(`'${appPath}' is signed with the ` +
         `${this.useKeystore ? 'keystore' : 'default'} certificate`);
@@ -261,7 +274,15 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
       log.info(`'${appPath}' is signed with a ` +
         `non-${this.useKeystore ? 'keystore' : 'default'} certificate`);
     }
-    return (!this.useKeystore && !requireDefaultCert) || hasMatch;
+    const isSigned = (!this.useKeystore && !requireDefaultCert) || hasMatch;
+    if (isSigned) {
+      SIGNED_APPS_CACHE.set(appHash, {
+        output,
+        expected,
+        keystorePath: this.keystorePath,
+      });
+    }
+    return isSigned;
   } catch (err) {
     // check if there is no signature
     if (_.includes(err.stderr, APKSIGNER_VERIFY_FAIL)) {

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -143,6 +143,11 @@ describe('signing', withMocks({teen_process, helpers, adb, appiumSupport, fs, te
   });
 
   describe('checkApkCert', function () {
+    beforeEach(function () {
+      mocks.fs.expects('hash')
+        .returns(Math.random().toString(36));
+    });
+
     it('should return false for apk not present', async function () {
       (await adb.checkApkCert('dummyPath', 'dummyPackage')).should.be.false;
     });


### PR DESCRIPTION
The `java.lang.Error: Properties init: Could not determine current working directory` error pops up randomly while checking app signature with apksigner and we are not quite sure why.  My guess - a race condition in java vm initialization. Nevertheless, lets make Appium to believe the file is already signed, because it would be true for 99% of UIAutomator2-based tests, where we presign server binaries while publishing their NPM module. If these are not signed, e.g. in case of Espresso, then the next step(s) would anyway fail.
See https://github.com/appium/appium/issues/14724 for more details.