### PR TITLE
feat: Add outputFormat option to shell command

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -386,7 +386,10 @@ let isExecLocked = false;
  *                        You can also set the additional `exclusive` param
  *                        to `true` that assures no other parallel adb commands
  *                        are going to be executed while the current one is running
- * @return {string} - Command's stdout.
+ *                        You can set the `outputFormat` param to `stdout` to receive just the stdout
+ *                        output (default) or `full` to receive the entire stdout, stderr, and code
+ *                        response from a command with a zero exit code
+ * @return {string|Object} - Command's stdout or an object containing stdout, stderr, and code.
  * @throws {Error} If the command returned non-zero exit code.
  */
 systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
@@ -398,6 +401,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
   // setting default timeout for each command to prevent infinite wait.
   opts.timeout = opts.timeout || this.adbExecTimeout || DEFAULT_ADB_EXEC_TIMEOUT;
   opts.timeoutCapName = opts.timeoutCapName || 'adbExecTimeout'; // For error message
+  opts.outputFormat = opts.outputFormat || 'stdout';
 
   cmd = _.isArray(cmd) ? cmd : [cmd];
   let adbRetried = false;
@@ -406,11 +410,11 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
       const args = [...this.executable.defaultArgs, ...cmd];
       log.debug(`Running '${this.executable.path} ` +
         (args.find((arg) => /\s+/.test(arg)) ? util.quote(args) : args.join(' ')) + `'`);
-      let {stdout} = await exec(this.executable.path, args, opts);
+      let {stdout, stderr, code} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out
       stdout = stdout.replace(LINKER_WARNING_REGEXP, '').trim();
-      return stdout;
+      return opts.outputFormat === 'full' ? {stdout, stderr, code} : stdout;
     } catch (e) {
       const errText = `${e.message}, ${e.stdout}, ${e.stderr}`;
       if (ADB_RETRY_ERROR_PATTERNS.some((p) => p.test(errText))) {
@@ -466,6 +470,8 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
  * (used in the error messages).
  * @property {?number} timeout [adbExecTimeout] - command execution timeout.
  * @property {?boolean} privileged [falsy] - Whether to run the given command as root.
+ * @property {?string} outputFormat - Whether response should include full exec output or just stdout.
+ *                                    Potential values are full or stdout; defaults to stdout.
  *
  * All other properties are the same as for `exec` call from {@link https://github.com/appium/node-teen_process}
  * module

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -375,6 +375,11 @@ systemCallMethods.adbExecEmu = async function adbExecEmu (cmd) {
 
 let isExecLocked = false;
 
+systemCallMethods.EXEC_OUTPUT_FORMAT = Object.freeze({
+  STDOUT: 'stdout',
+  FULL: 'full',
+});
+
 /**
  * @typedef {Object} ExecResult
  * @property {string} stdout The stdout received from exec
@@ -393,8 +398,8 @@ let isExecLocked = false;
  *                        to `true` that assures no other parallel adb commands
  *                        are going to be executed while the current one is running
  *                        You can set the `outputFormat` param to `stdout` to receive just the stdout
- *                        output (default) or `full` to receive the entire stdout, stderr, and code
- *                        response from a command with a zero exit code
+ *                        output (default) or `full` to receive the stdout and stderr response from a
+ *                        command with a zero exit code
  * @return {string|ExecResult} - Command's stdout or an object containing stdout and stderr.
  * @throws {Error} If the command returned non-zero exit code.
  */
@@ -408,9 +413,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
   opts.timeout = opts.timeout || this.adbExecTimeout || DEFAULT_ADB_EXEC_TIMEOUT;
   opts.timeoutCapName = opts.timeoutCapName || 'adbExecTimeout'; // For error message
 
-  const outputFormatStdout = 'stdout';
-  const outputFormatFull = 'full';
-  let outputFormat = opts.outputFormat || outputFormatStdout;
+  const {outputFormat = systemCallMethods.EXEC_OUTPUT_FORMAT.STDOUT} = opts;
 
   cmd = _.isArray(cmd) ? cmd : [cmd];
   let adbRetried = false;
@@ -423,7 +426,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out
       stdout = stdout.replace(LINKER_WARNING_REGEXP, '').trim();
-      return outputFormat === outputFormatFull ? {stdout, stderr} : stdout;
+      return outputFormat === systemCallMethods.EXEC_OUTPUT_FORMAT.FULL ? {stdout, stderr} : stdout;
     } catch (e) {
       const errText = `${e.message}, ${e.stdout}, ${e.stderr}`;
       if (ADB_RETRY_ERROR_PATTERNS.some((p) => p.test(errText))) {

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -376,6 +376,12 @@ systemCallMethods.adbExecEmu = async function adbExecEmu (cmd) {
 let isExecLocked = false;
 
 /**
+ * @typedef {Object} ExecResult
+ * @property {string} stdout The stdout received from exec
+ * @property {string} stderr The stderr received from exec
+ */
+
+/**
  * Execute the given adb command.
  *
  * @param {Array.<string>} cmd - The array of rest command line parameters
@@ -389,7 +395,7 @@ let isExecLocked = false;
  *                        You can set the `outputFormat` param to `stdout` to receive just the stdout
  *                        output (default) or `full` to receive the entire stdout, stderr, and code
  *                        response from a command with a zero exit code
- * @return {string|Object} - Command's stdout or an object containing stdout, stderr, and code.
+ * @return {string|ExecResult} - Command's stdout or an object containing stdout and stderr.
  * @throws {Error} If the command returned non-zero exit code.
  */
 systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
@@ -401,7 +407,10 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
   // setting default timeout for each command to prevent infinite wait.
   opts.timeout = opts.timeout || this.adbExecTimeout || DEFAULT_ADB_EXEC_TIMEOUT;
   opts.timeoutCapName = opts.timeoutCapName || 'adbExecTimeout'; // For error message
-  opts.outputFormat = opts.outputFormat || 'stdout';
+
+  const outputFormatStdout = 'stdout';
+  const outputFormatFull = 'full';
+  let outputFormat = opts.outputFormat || outputFormatStdout;
 
   cmd = _.isArray(cmd) ? cmd : [cmd];
   let adbRetried = false;
@@ -410,11 +419,11 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
       const args = [...this.executable.defaultArgs, ...cmd];
       log.debug(`Running '${this.executable.path} ` +
         (args.find((arg) => /\s+/.test(arg)) ? util.quote(args) : args.join(' ')) + `'`);
-      let {stdout, stderr, code} = await exec(this.executable.path, args, opts);
+      let {stdout, stderr} = await exec(this.executable.path, args, opts);
       // sometimes ADB prints out weird stdout warnings that we don't want
       // to include in any of the response data, so let's strip it out
       stdout = stdout.replace(LINKER_WARNING_REGEXP, '').trim();
-      return opts.outputFormat === 'full' ? {stdout, stderr, code} : stdout;
+      return outputFormat === outputFormatFull ? {stdout, stderr} : stdout;
     } catch (e) {
       const errText = `${e.message}, ${e.stdout}, ${e.stderr}`;
       if (ADB_RETRY_ERROR_PATTERNS.some((p) => p.test(errText))) {
@@ -470,8 +479,8 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
  * (used in the error messages).
  * @property {?number} timeout [adbExecTimeout] - command execution timeout.
  * @property {?boolean} privileged [falsy] - Whether to run the given command as root.
- * @property {?string} outputFormat - Whether response should include full exec output or just stdout.
- *                                    Potential values are full or stdout; defaults to stdout.
+ * @property {?string} outputFormat [stdout] - Whether response should include full exec output or just stdout.
+ *                                             Potential values are full or stdout.
  *
  * All other properties are the same as for `exec` call from {@link https://github.com/appium/node-teen_process}
  * module

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -35,13 +35,13 @@ describe('System calls', function () {
   it('shell should execute command in adb shell ', async function () {
     (await adb.shell(['getprop', 'ro.build.version.sdk'])).should.equal(`${apiLevel}`);
   });
-  it('shell should output stderr from adb shell with full output', async function () {
+  it('shell should return stderr from adb with full output', async function () {
     let fullShellOutput = await adb.shell(['content', 'read', '--uri', 'content://doesnotexist'], {outputFormat: 'full'});
+    let outputWithError = apiLevel <= 23 ? fullShellOutput.stdout : fullShellOutput.stderr;
     fullShellOutput.code.should.equal(0);
-    fullShellOutput.stderr.should.contain('Error while accessing provider');
-    fullShellOutput.stdout.should.equal('');
+    outputWithError.should.contain('Error while accessing provider');
   });
-  it('shell should output stdout from adb shell with full output', async function () {
+  it('shell should return stdout from adb shell with full output', async function () {
     let fullShellOutput = await adb.shell(['getprop', 'ro.build.version.sdk'], {outputFormat: 'full'});
     fullShellOutput.code.should.equal(0);
     fullShellOutput.stderr.should.equal('');

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -35,6 +35,18 @@ describe('System calls', function () {
   it('shell should execute command in adb shell ', async function () {
     (await adb.shell(['getprop', 'ro.build.version.sdk'])).should.equal(`${apiLevel}`);
   });
+  it('shell should output stderr from adb shell with full output', async function () {
+    let fullShellOutput = await adb.shell(['content', 'read', '--uri', 'content://doesnotexist'], {outputFormat: 'full'});
+    fullShellOutput.code.should.equal(0);
+    fullShellOutput.stderr.should.contain('Error while accessing provider');
+    fullShellOutput.stdout.should.equal('');
+  });
+  it('shell should output stdout from adb shell with full output', async function () {
+    let fullShellOutput = await adb.shell(['getprop', 'ro.build.version.sdk'], {outputFormat: 'full'});
+    fullShellOutput.code.should.equal(0);
+    fullShellOutput.stderr.should.equal('');
+    fullShellOutput.stdout.should.equal(`${apiLevel}`);
+  });
   it('getConnectedEmulators should get all connected emulators', async function () {
     (await adb.getConnectedEmulators()).length.should.be.above(0);
   });

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -37,12 +37,12 @@ describe('System calls', function () {
   });
   it('shell should return stderr from adb with full output', async function () {
     const minStderrApiLevel = 24;
-    let fullShellOutput = await adb.shell(['content', 'read', '--uri', 'content://doesnotexist'], {outputFormat: 'full'});
+    let fullShellOutput = await adb.shell(['content', 'read', '--uri', 'content://doesnotexist'], {outputFormat: adb.EXEC_OUTPUT_FORMAT.FULL});
     let outputWithError = apiLevel < minStderrApiLevel ? fullShellOutput.stdout : fullShellOutput.stderr;
     outputWithError.should.contain('Error while accessing provider');
   });
   it('shell should return stdout from adb shell with full output', async function () {
-    let fullShellOutput = await adb.shell(['getprop', 'ro.build.version.sdk'], {outputFormat: 'full'});
+    let fullShellOutput = await adb.shell(['getprop', 'ro.build.version.sdk'], {outputFormat: adb.EXEC_OUTPUT_FORMAT.FULL});
     fullShellOutput.stderr.should.equal('');
     fullShellOutput.stdout.should.equal(`${apiLevel}`);
   });

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -36,14 +36,13 @@ describe('System calls', function () {
     (await adb.shell(['getprop', 'ro.build.version.sdk'])).should.equal(`${apiLevel}`);
   });
   it('shell should return stderr from adb with full output', async function () {
+    const minStderrApiLevel = 24;
     let fullShellOutput = await adb.shell(['content', 'read', '--uri', 'content://doesnotexist'], {outputFormat: 'full'});
-    let outputWithError = apiLevel <= 23 ? fullShellOutput.stdout : fullShellOutput.stderr;
-    fullShellOutput.code.should.equal(0);
+    let outputWithError = apiLevel < minStderrApiLevel ? fullShellOutput.stdout : fullShellOutput.stderr;
     outputWithError.should.contain('Error while accessing provider');
   });
   it('shell should return stdout from adb shell with full output', async function () {
     let fullShellOutput = await adb.shell(['getprop', 'ro.build.version.sdk'], {outputFormat: 'full'});
-    fullShellOutput.code.should.equal(0);
     fullShellOutput.stderr.should.equal('');
     fullShellOutput.stdout.should.equal(`${apiLevel}`);
   });

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -167,7 +167,7 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
     });
     it('should return full output when set', async function () {
       let output = await adb.shell(['command'], {outputFormat: 'full'});
-      output.should.deep.equal({stdout: 'a value', stderr: 'an error', code: 0});
+      output.should.deep.equal({stdout: 'a value', stderr: 'an error'});
     });
   });
   describe('reboot', function () {

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -158,7 +158,6 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       .returns({stdout: 'a value', stderr: 'an error', code: 0});
     });
     it('should default to stdout', async function () {
-
       let output = await adb.shell(['command']);
       output.should.equal('a value');
     });

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -162,11 +162,11 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       output.should.equal('a value');
     });
     it('should output only stdout when set', async function () {
-      let output = await adb.shell(['command'], {outputFormat: 'stdout'});
+      let output = await adb.shell(['command'], {outputFormat: adb.EXEC_OUTPUT_FORMAT.STDOUT});
       output.should.equal('a value');
     });
     it('should return full output when set', async function () {
-      let output = await adb.shell(['command'], {outputFormat: 'full'});
+      let output = await adb.shell(['command'], {outputFormat: adb.EXEC_OUTPUT_FORMAT.FULL});
       output.should.deep.equal({stdout: 'a value', stderr: 'an error'});
     });
   });

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -151,6 +151,28 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
     let size = await adb.fileSize(remotePath);
     size.should.eql(39571);
   });
+  describe('shell outputFormat option', function () {
+    beforeEach(function () {
+      mocks.teen_process.expects('exec')
+      .once()
+      .returns({stdout: 'a value', stderr: 'an error', code: 0});
+    });
+    it('should default to stdout', async function () {
+      mocks.teen_process.expects('exec')
+        .once()
+        .returns({stdout: 'a value', stderr: 'an error', code: 0});
+      let output = await adb.shell(['command']);
+      output.should.equal('a value');
+    });
+    it('should output only stdout when set', async function () {
+      let output = await adb.shell(['command'], {outputFormat: 'stdout'});
+      output.should.equal('a value');
+    });
+    it('should return full output when set', async function () {
+      let output = await adb.shell(['command'], {outputFormat: 'full'});
+      output.should.deep.equal({stdout: 'a value', stderr: 'an error', code: 0});
+    });
+  });
   describe('reboot', function () {
     it('should call stop and start using shell', async function () {
       mocks.adb.expects('shell')

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -158,9 +158,7 @@ describe('System calls', withMocks({adb, B, teen_process}, function (mocks) {
       .returns({stdout: 'a value', stderr: 'an error', code: 0});
     });
     it('should default to stdout', async function () {
-      mocks.teen_process.expects('exec')
-        .once()
-        .returns({stdout: 'a value', stderr: 'an error', code: 0});
+
       let output = await adb.shell(['command']);
       output.should.equal('a value');
     });


### PR DESCRIPTION
[Issue 15696- appium-adb: no way to read stderr from shell commands that exit with code 0](https://github.com/appium/appium/issues/15696) describes a scenario in which appium-adb's `shell` command throws away `stderr` when a command exits with code 0. To add support for this scenario, this PR implements the following approach (as described by @dbjorge in the issue):

> A new `outputFormat` option to `shell`/`adbExec` that: 
> * accepts either `stdout` or `full`
> * defaults to `stdout`
> * is checked during the `adbExec` success path; if `stdout`, `adbExec` matches the existing behavior and returns `stdout`, and if `full`, `adbExec` instead returns the full original output from `await teen_process.exec(...)` (ie, an object with `stdout`, `stderr`, and `code` properties)

Comments on the issue indicated that this is the preferred implementation approach, so I went with it.

### Additional details
- As implemented, this PR does not enforce that `outputFormat` be set to `stdout` to maintain the current behavior--any value other than `full` will result in the default `stdout` return value. I would be happy to update this to instead validate the value and throw and error if it isn't `undefined`, `stdout`, or `full` if that is preferable. 
- I updated documentation relating to the `opts` paramenters for `shell` and `adbExec`. If there is anywhere else I should update documentation, please let me know!
- I attempted to follow the "make your code look like the surrounding code" principle from the [style guide](https://github.com/appium/appium/blob/master/docs/en/contributing-to-appium/style-guide.md) for both the production and test code