### PR TITLE
feat: Add opts to pull command

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -840,7 +840,7 @@ methods.push = async function push (localPath, remotePath, opts) {
  *                        _exec_ method options, for more information about available
  *                        options.
  */
-methods.pull = async function pull (remotePath, localPath, opts) {
+methods.pull = async function pull (remotePath, localPath, opts = {}) {
   // pull folder can take more time, increasing time out to 60 secs
   if (opts.timeout === null) {
     opts.timeout = 60000; // Default timeout

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -835,10 +835,15 @@ methods.push = async function push (localPath, remotePath, opts) {
  *
  * @param {string} remotePath - The source path on the remote device.
  * @param {string} localPath - The destination path to the file on the local file system.
+ * @param {object} opts - Additional options mapping. See
+ *                        https://github.com/appium/node-teen_process,
+ *                        _exec_ method options, for more information about available
+ *                        options.
  */
-methods.pull = async function pull (remotePath, localPath) {
+methods.pull = async function pull (remotePath, localPath, opts) {
   // pull folder can take more time, increasing time out to 60 secs
-  await this.adbExec(['pull', remotePath, localPath], {timeout: 60000});
+  if (opts.timeout === null) opts.timeout = 60000 // Default timeout
+  await this.adbExec(['pull', remotePath, localPath], opts);
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -842,7 +842,9 @@ methods.push = async function push (localPath, remotePath, opts) {
  */
 methods.pull = async function pull (remotePath, localPath, opts) {
   // pull folder can take more time, increasing time out to 60 secs
-  if (opts.timeout === null) opts.timeout = 60000 // Default timeout
+  if (opts.timeout === null) {
+    opts.timeout = 60000; // Default timeout
+  }
   await this.adbExec(['pull', remotePath, localPath], opts);
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -842,10 +842,7 @@ methods.push = async function push (localPath, remotePath, opts) {
  */
 methods.pull = async function pull (remotePath, localPath, opts = {}) {
   // pull folder can take more time, increasing time out to 60 secs
-  if (opts.timeout === null) {
-    opts.timeout = 60000; // Default timeout
-  }
-  await this.adbExec(['pull', remotePath, localPath], opts);
+  await this.adbExec(['pull', remotePath, localPath], {...opts, timeout: opts.timeout ?? 60000});
 };
 
 /**


### PR DESCRIPTION
Refactor pull command to accept options object while still keeping default timeout set to 60 seconds to ensure backwards compatibility.

Fixes issue [#15787](https://github.com/appium/appium/issues/15787)