### PR TITLE
chore: Tune error output of adbExec

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -450,7 +450,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
           `Try to increase the ${opts.timeout}ms adb execution timeout represented by '${opts.timeoutCapName}' capability`;
       } else {
         e.message = `Error executing adbExec. Original error: '${e.message}'; ` +
-          `Command output: ${e.stderr || e.stdout || ''}`;
+          `Command output: ${e.stderr || e.stdout || 'None'}`;
       }
       throw e;
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -450,7 +450,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
           `Try to increase the ${opts.timeout}ms adb execution timeout represented by '${opts.timeoutCapName}' capability`;
       } else {
         e.message = `Error executing adbExec. Original error: '${e.message}'; ` +
-          `Command output: ${e.stderr || e.stdout || 'None'}`;
+          `Command output: ${e.stderr || e.stdout || '<empty>'}`;
       }
       throw e;
     }

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -450,7 +450,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
           `Try to increase the ${opts.timeout}ms adb execution timeout represented by '${opts.timeoutCapName}' capability`;
       } else {
         e.message = `Error executing adbExec. Original error: '${e.message}'; ` +
-          `Stderr: '${(e.stderr || '').trim()}'; Code: '${e.code}'`;
+          `Command output: ${e.stderr || e.stdout || ''}`;
       }
       throw e;
     }


### PR DESCRIPTION
Sometimes adb prints error messages to stdout and keeps stderr empty. I don't know the reason of such behaviour (perhaps some legacy stuff)