### PR TITLE
feat: Add a helper to create a universal apk from an .aab bundle

### DIFF
--- a/lib/tools/aab-utils.js
+++ b/lib/tools/aab-utils.js
@@ -1,0 +1,101 @@
+import log from '../logger.js';
+import path from 'path';
+import { fs, tempDir, util } from '@appium/support';
+import LRU from 'lru-cache';
+import { unzipFile } from '../helpers.js';
+import AsyncLock from 'async-lock';
+import B from 'bluebird';
+
+const AAB_CACHE = new LRU({
+  max: 10,
+  dispose: (aabHash, extractedFilesRoot) => fs.rimraf(extractedFilesRoot),
+});
+const AAB_CACHE_GUARD = new AsyncLock();
+const UNIVERSAL_APK = 'universal.apk';
+
+const aabUtilsMethods = {};
+
+process.on('exit', () => {
+  if (!AAB_CACHE.size) {
+    return;
+  }
+
+  const paths = [...AAB_CACHE.values()];
+  log.debug(`Performing cleanup of ${paths.length} cached .aab ` +
+    util.pluralize('package', paths.length));
+  for (const appPath of paths) {
+    try {
+      // Asynchronous calls are not supported in onExit handler
+      fs.rimrafSync(appPath);
+    } catch (e) {
+      log.warn(e.message);
+    }
+  }
+});
+
+aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPath) {
+  if (!await fs.exists(aabPath)) {
+    throw new Error(`The file at '${aabPath}' either does not exist or is not accessible`);
+  }
+
+  const aabName = path.basename(aabPath);
+  const apkName = aabName.substring(0, aabName.length - path.extname(aabName)) + '.apk';
+  const tmpRoot = await tempDir.openDir();
+  const tmpApksPath = path.join(tmpRoot, `${aabName}.apks`);
+  try {
+    return await AAB_CACHE_GUARD.acquire(aabPath, async () => {
+      const aabHash = await fs.hash(aabPath);
+      log.debug(`Calculated '${aabPath}' hash: ${aabHash}`);
+      if (AAB_CACHE.has(aabHash)) {
+        const resultPath = path.resolve(AAB_CACHE.get(aabHash), apkName);
+        if (await fs.exists(resultPath)) {
+          return resultPath;
+        }
+        AAB_CACHE.del(aabHash);
+      }
+
+      await this.initAapt2();
+      const args = [
+        'build-apks',
+        '--aapt2', this.binaries.aapt2,
+        '--bundle', aabPath,
+        '--output', tmpApksPath,
+        '--mode=universal'
+      ];
+      log.debug(`Preparing universal .apks bundle from '${aabPath}'`);
+      await this.execBundletool(args, `Cannot build a universal .apks bundle from '${aabPath}'`);
+
+      log.debug(`Unpacking universal application bundle at '${tmpApksPath}' to '${tmpRoot}'`);
+      await unzipFile(tmpApksPath, tmpRoot);
+      let universalApkPath;
+      const fileDeletionPromises = [];
+      const allFileNames = await fs.readdir(tmpRoot);
+      for (const fileName of allFileNames) {
+        const fullPath = path.join(tmpRoot, fileName);
+        if (fileName === UNIVERSAL_APK) {
+          universalApkPath = fullPath;
+        } else {
+          fileDeletionPromises.push(fs.rimraf(fullPath));
+        }
+      }
+      try {
+        await B.all(fileDeletionPromises);
+      } catch (ign) {}
+      if (!universalApkPath) {
+        log.debug(`The following items ae present in the .aab bundle: ${allFileNames}`);
+        throw new Error(`${UNIVERSAL_APK} cannot be found in '${aabPath}' bundle. ` +
+          `Does the archive contain a valid application bundle?`);
+      }
+      const resultPath = path.join(tmpRoot, apkName);
+      log.debug(`Found ${UNIVERSAL_APK} at '${universalApkPath}'. Caching it to '${resultPath}'`);
+      await fs.mv(universalApkPath, resultPath);
+      AAB_CACHE.set(aabHash, tmpRoot);
+      return resultPath;
+    });
+  } catch (e) {
+    await fs.rimraf(tmpRoot);
+    throw e;
+  }
+};
+
+export default aabUtilsMethods;

--- a/lib/tools/aab-utils.js
+++ b/lib/tools/aab-utils.js
@@ -5,10 +5,11 @@ import LRU from 'lru-cache';
 import { unzipFile } from '../helpers.js';
 import AsyncLock from 'async-lock';
 import B from 'bluebird';
+import crypto from 'crypto';
 
 const AAB_CACHE = new LRU({
   max: 10,
-  dispose: (aabHash, extractedFilesRoot) => fs.rimraf(extractedFilesRoot),
+  dispose: (hash, extractedFilesRoot) => fs.rimraf(extractedFilesRoot),
 });
 const AAB_CACHE_GUARD = new AsyncLock();
 const UNIVERSAL_APK = 'universal.apk';
@@ -33,7 +34,36 @@ process.on('exit', () => {
   }
 });
 
-aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPath) {
+/**
+ * @typedef {Object} ApkCreationOptions
+ * @property {string} keystore Specifies the path to the deployment keystore used
+ * to sign the APKs. This flag is optional. If you don't include it,
+ * bundletool attempts to sign your APKs with a debug signing key.
+ * If the .apk has been already signed and cached then it is not going to be resigned
+ * unless a different keystore or key alias is used.
+ * @property {string} keystorePassword Specifies your keystore’s password.
+ * It is mandatory to provide this value if `keystore` one is assigned
+ * otherwise it is going to be ignored.
+ * @property {string} keyAlias Specifies the alias of the signing key you want to use.
+ * It is mandatory to provide this value if `keystore` one is assigned
+ * otherwise it is going to be ignored.
+ * @property {string} keyPassword Specifies the password for the signing key.
+ * It is mandatory to provide this value if `keystore` one is assigned
+ * otherwise it is going to be ignored.
+ */
+
+/**
+ * Builds a universal .apk from the given .aab package. See
+ * https://developer.android.com/studio/command-line/bundletool#generate_apks
+ * for more details.
+ *
+ * @param {string} aabPath Full path to the source .aab package
+ * @param {ApkCreationOptions} opts
+ * @returns The path to the resulting universal .apk. The .apk is stored in the internal cache
+ * by default.
+ * @throws {Error} If there was an error while creating the universal .apk
+ */
+aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPath, opts = {}) {
   if (!await fs.exists(aabPath)) {
     throw new Error(`The file at '${aabPath}' either does not exist or is not accessible`);
   }
@@ -45,13 +75,34 @@ aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPat
   try {
     return await AAB_CACHE_GUARD.acquire(aabPath, async () => {
       const aabHash = await fs.hash(aabPath);
-      log.debug(`Calculated '${aabPath}' hash: ${aabHash}`);
-      if (AAB_CACHE.has(aabHash)) {
-        const resultPath = path.resolve(AAB_CACHE.get(aabHash), apkName);
+      const {
+        keystore,
+        keystorePassword,
+        keyAlias,
+        keyPassword,
+      } = opts;
+      let cacheHash = aabHash;
+      if (keystore) {
+        if (!await fs.exists(keystore)) {
+          throw new Error(`The keystore file at '${keystore}' either does not exist ` +
+            `or is not accessible`);
+        }
+        if (!keystorePassword || !keyAlias || !keyPassword) {
+          throw new Error('It is mandatory to also provide keystore password, key alias, ' +
+            'and key password if the keystore path is set');
+        }
+        const keystoreHash = await fs.hash(keystore);
+        const keyAliasHash = crypto.createHash('sha1');
+        keyAliasHash.update(keyAlias);
+        cacheHash = [cacheHash, keystoreHash, keyAliasHash.digest('hex')].join(':');
+      }
+      log.debug(`Calculated the cache key for '${aabPath}': ${cacheHash}`);
+      if (AAB_CACHE.has(cacheHash)) {
+        const resultPath = path.resolve(AAB_CACHE.get(cacheHash), apkName);
         if (await fs.exists(resultPath)) {
           return resultPath;
         }
-        AAB_CACHE.del(aabHash);
+        AAB_CACHE.del(cacheHash);
       }
 
       await this.initAapt2();
@@ -60,6 +111,12 @@ aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPat
         '--aapt2', this.binaries.aapt2,
         '--bundle', aabPath,
         '--output', tmpApksPath,
+        ...(keystore ? [
+          '--ks', keystore,
+          '--ks-pass', `pass:${keystorePassword}`,
+          '--ks-key-alias', keyAlias,
+          '--key-pass', `pass:${keyPassword}`,
+        ] : []),
         '--mode=universal'
       ];
       log.debug(`Preparing universal .apks bundle from '${aabPath}'`);
@@ -89,7 +146,7 @@ aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPat
       const resultPath = path.join(tmpRoot, apkName);
       log.debug(`Found ${UNIVERSAL_APK} at '${universalApkPath}'. Caching it to '${resultPath}'`);
       await fs.mv(universalApkPath, resultPath);
-      AAB_CACHE.set(aabHash, tmpRoot);
+      AAB_CACHE.set(cacheHash, tmpRoot);
       return resultPath;
     });
   } catch (e) {

--- a/lib/tools/aab-utils.js
+++ b/lib/tools/aab-utils.js
@@ -69,7 +69,7 @@ aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPat
   }
 
   const aabName = path.basename(aabPath);
-  const apkName = aabName.substring(0, aabName.length - path.extname(aabName)) + '.apk';
+  const apkName = aabName.substring(0, aabName.length - path.extname(aabName).length) + '.apk';
   const tmpRoot = await tempDir.openDir();
   const tmpApksPath = path.join(tmpRoot, `${aabName}.apks`);
   try {

--- a/lib/tools/aab-utils.js
+++ b/lib/tools/aab-utils.js
@@ -82,7 +82,7 @@ aabUtilsMethods.extractUniversalApk = async function extractUniversalApk (aabPat
         await B.all(fileDeletionPromises);
       } catch (ign) {}
       if (!universalApkPath) {
-        log.debug(`The following items ae present in the .aab bundle: ${allFileNames}`);
+        log.debug(`The following items were extracted from the .aab bundle: ${allFileNames}`);
         throw new Error(`${UNIVERSAL_APK} cannot be found in '${aabPath}' bundle. ` +
           `Does the archive contain a valid application bundle?`);
       }

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -15,8 +15,7 @@ import os from 'os';
 import LRU from 'lru-cache';
 import ApkReader from 'adbkit-apkreader';
 
-
-let apkUtilsMethods = {};
+const apkUtilsMethods = {};
 
 const ACTIVITIES_TROUBLESHOOTING_LINK =
   'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/android/activity-startup.md';
@@ -460,8 +459,8 @@ apkUtilsMethods.cacheApk = async function cacheApk (apkPath, options = {}) {
     log.info(`The application at '${apkPath}' is already cached to '${remotePath}'`);
     // Update the application timestamp asynchronously in order to bump its position
     // in the sorted ls output
-    this.shell(['touch', '-am', remotePath])
-      .catch(() => {});
+    // eslint-disable-next-line promise/prefer-await-to-then
+    this.shell(['touch', '-am', remotePath]).catch(() => {});
   } else {
     log.info(`Caching the application at '${apkPath}' to '${remotePath}'`);
     const timer = new timing.Timer().start();

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -19,8 +19,10 @@ const APKS_CACHE = new LRU({
 const APKS_CACHE_GUARD = new AsyncLock();
 const BUNDLETOOL_TIMEOUT_MS = 4 * 60 * 1000;
 
+const apksUtilsMethods = {};
+
 process.on('exit', () => {
-  if (APKS_CACHE.itemCount === 0) {
+  if (!APKS_CACHE.size) {
     return;
   }
 
@@ -82,8 +84,6 @@ async function extractFromApks (apks, dstPath) {
     return resultPath;
   });
 }
-
-let apksUtilsMethods = {};
 
 /**
  * Executes bundletool utility with given arguments and returns the actual stdout
@@ -271,7 +271,7 @@ apksUtilsMethods.extractLanguageApk = async function extractLanguageApk (apks, l
   return await this.extractBaseApk(apks);
 };
 
-apksUtilsMethods.isTestPackageOnlyError = function (output) {
+apksUtilsMethods.isTestPackageOnlyError = function isTestPackageOnlyError (output) {
   return /\[INSTALL_FAILED_TEST_ONLY\]/.test(output);
 };
 

--- a/lib/tools/index.js
+++ b/lib/tools/index.js
@@ -4,6 +4,7 @@ import systemCallMethods, { getAndroidBinaryPath } from './system-calls.js';
 import apkSigningMethods from './apk-signing.js';
 import apkUtilsMethods from './apk-utils.js';
 import apksUtilsMethods from './apks-utils.js';
+import aabUtilsMethods from './aab-utils.js';
 import emuMethods from './adb-emu-commands.js';
 import settingsClientCommands from './settings-client-commands';
 import lockManagementCommands from './lockmgmt';
@@ -17,6 +18,7 @@ Object.assign(
     apkSigningMethods,
     apkUtilsMethods,
     apksUtilsMethods,
+    aabUtilsMethods,
     settingsClientCommands,
     lockManagementCommands,
     keyboardCommands,


### PR DESCRIPTION
I don't think we can easily add .apks support into Espresso driver, but we can still transform .aab files into .apk directly