### PR TITLE
Add support for adb devices -l

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -198,24 +198,36 @@ systemCallMethods.getBinaryFromPath = async function getBinaryFromPath (binaryNa
 };
 
 /**
+ * @typedef {Object} ConnectedDevicesOptions
+ * @property {?boolean} long [falsy] - Whether to get long output, which includes extra properties in each device.
+ * Akin to running `adb devices -l`.
+ */
+
+/**
  * @typedef {Object} Device
  * @property {string} udid - The device udid.
  * @property {string} state - Current device state, as it is visible in
  *                            _adb devices -l_ output.
+ * Will have additional properties if the `long` flag was set.
  */
 
 /**
  * Retrieve the list of devices visible to adb.
  *
+ * @param {?ConnectedDevicesOptions} opts [{}] - Additional options mapping.
  * @return {Array.<Device>} The list of devices or an empty list if
  *                          no devices are connected.
  * @throws {Error} If there was an error while listing devices.
  */
-systemCallMethods.getConnectedDevices = async function getConnectedDevices () {
+systemCallMethods.getConnectedDevices = async function getConnectedDevices (opts = {}) {
   log.debug('Getting connected devices');
   let stdout;
   try {
-    ({stdout} = await exec(this.executable.path, [...this.executable.defaultArgs, 'devices']));
+    const args = [...this.executable.defaultArgs, 'devices'];
+    if (opts.long) {
+      args.push('-l');
+    }
+    ({stdout} = await exec(this.executable.path, args));
   } catch (e) {
     throw new Error(`Error while getting connected devices. Original error: ${e.message}`);
   }
@@ -236,12 +248,19 @@ systemCallMethods.getConnectedDevices = async function getConnectedDevices () {
   const devices = stdout.split('\n')
     .map(_.trim)
     .filter((line) => line && !excludedLines.some((x) => line.includes(x)))
-    .reduce((acc, line) => {
+    .map((line) => {
       // state is "device", afaic
-      const [udid, state] = line.split(/\s+/);
-      acc.push({udid, state});
-      return acc;
-    }, []);
+      const [udid, state, ...description] = line.split(/\s+/);
+      const device = {udid, state};
+      if (opts.long) {
+        for (const entry of description) {
+          // each entry looks like key:value
+          const [key, value] = entry.split(':');
+          device[key] = value;
+        }
+      }
+      return device;
+    });
   if (_.isEmpty(devices)) {
     log.debug('No connected devices have been detected');
   } else {
@@ -577,12 +596,13 @@ systemCallMethods.getPortFromEmulatorString = function getPortFromEmulatorString
 /**
  * Retrieve the list of currently connected emulators.
  *
+ * @param {?ConnectedDevicesOptions} opts [{}] - Additional options mapping.
  * @return {Array.<Device>} The list of connected devices.
  */
-systemCallMethods.getConnectedEmulators = async function getConnectedEmulators () {
+systemCallMethods.getConnectedEmulators = async function getConnectedEmulators (opts) {
   log.debug('Getting connected emulators');
   try {
-    let devices = await this.getConnectedDevices();
+    let devices = await this.getConnectedDevices(opts);
     let emulators = [];
     for (let device of devices) {
       let port = this.getPortFromEmulatorString(device.udid);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -199,7 +199,7 @@ systemCallMethods.getBinaryFromPath = async function getBinaryFromPath (binaryNa
 
 /**
  * @typedef {Object} ConnectedDevicesOptions
- * @property {?boolean} verbose [falsy] - Whether to get long output, which includes extra properties in each device.
+ * @property {?boolean} verbose - Whether to get long output, which includes extra properties in each device.
  * Akin to running `adb devices -l`.
  */
 
@@ -212,11 +212,11 @@ systemCallMethods.getBinaryFromPath = async function getBinaryFromPath (binaryNa
 
 /**
  * @typedef {Device} VerboseDevice Additional properties returned when `verbose` is true.
- * @property {string} product
- * @property {string} model
- * @property {string} device
- * @property {?string} usb
- * @property {?transport_id}
+ * @property {string} product - The product codename of the device, such as "razor".
+ * @property {string} model - The model name of the device, such as "Nexus_7".
+ * @property {string} device - The device codename, such as "flow".
+ * @property {?string} usb - Represents the USB port the device is connected to, such as "1-1".
+ * @property {?string} transport_id - The Transport ID for the device, such as "1".
  */
 
 /**
@@ -263,9 +263,11 @@ systemCallMethods.getConnectedDevices = async function getConnectedDevices (opts
       const device = {udid, state};
       if (opts.verbose) {
         for (const entry of description) {
-          // each entry looks like key:value
-          const [key, value] = entry.split(':');
-          device[key] = value;
+          if (entry.includes(':')) {
+            // each entry looks like key:value
+            const [key, value] = entry.split(':');
+            device[key] = value;
+          }
         }
       }
       return device;

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -610,7 +610,7 @@ systemCallMethods.getPortFromEmulatorString = function getPortFromEmulatorString
  * @param {?ConnectedDevicesOptions} opts [{}] - Additional options mapping.
  * @return {Array.<Device>} The list of connected devices.
  */
-systemCallMethods.getConnectedEmulators = async function getConnectedEmulators (opts) {
+systemCallMethods.getConnectedEmulators = async function getConnectedEmulators (opts = {}) {
   log.debug('Getting connected emulators');
   try {
     let devices = await this.getConnectedDevices(opts);

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -199,7 +199,7 @@ systemCallMethods.getBinaryFromPath = async function getBinaryFromPath (binaryNa
 
 /**
  * @typedef {Object} ConnectedDevicesOptions
- * @property {?boolean} long [falsy] - Whether to get long output, which includes extra properties in each device.
+ * @property {?boolean} verbose [falsy] - Whether to get long output, which includes extra properties in each device.
  * Akin to running `adb devices -l`.
  */
 
@@ -208,7 +208,15 @@ systemCallMethods.getBinaryFromPath = async function getBinaryFromPath (binaryNa
  * @property {string} udid - The device udid.
  * @property {string} state - Current device state, as it is visible in
  *                            _adb devices -l_ output.
- * Will have additional properties if the `long` flag was set.
+ */
+
+/**
+ * @typedef {Device} VerboseDevice Additional properties returned when `verbose` is true.
+ * @property {string} product
+ * @property {string} model
+ * @property {string} device
+ * @property {?string} usb
+ * @property {?transport_id}
  */
 
 /**
@@ -221,12 +229,13 @@ systemCallMethods.getBinaryFromPath = async function getBinaryFromPath (binaryNa
  */
 systemCallMethods.getConnectedDevices = async function getConnectedDevices (opts = {}) {
   log.debug('Getting connected devices');
+  const args = [...this.executable.defaultArgs, 'devices'];
+  if (opts.verbose) {
+    args.push('-l');
+  }
+
   let stdout;
   try {
-    const args = [...this.executable.defaultArgs, 'devices'];
-    if (opts.long) {
-      args.push('-l');
-    }
     ({stdout} = await exec(this.executable.path, args));
   } catch (e) {
     throw new Error(`Error while getting connected devices. Original error: ${e.message}`);
@@ -252,7 +261,7 @@ systemCallMethods.getConnectedDevices = async function getConnectedDevices (opts
       // state is "device", afaic
       const [udid, state, ...description] = line.split(/\s+/);
       const device = {udid, state};
-      if (opts.long) {
+      if (opts.verbose) {
         for (const entry of description) {
           // each entry looks like key:value
           const [key, value] = entry.split(':');

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -23,6 +23,7 @@ describe('System calls', withMocks({teen_process}, function (mocks) {
         .returns({stdout: 'List of devices attached \n emulator-5554	device'});
       let devices = await adb.getConnectedDevices();
       devices.should.have.length.above(0);
+      devices.should.deep.equal([{udid: 'emulator-5554', state: 'device'}]);
     });
     it('should get all connected devices which have valid udid', async function () {
       let stdoutValue = 'List of devices attached \n' +
@@ -42,6 +43,17 @@ describe('System calls', withMocks({teen_process}, function (mocks) {
         .returns({stdout: 'foobar'});
       await adb.getConnectedDevices().should.eventually.be
                                      .rejectedWith('Unexpected output while trying to get devices');
+    });
+    it('should get all connected devices with long output', async function () {
+      mocks.teen_process.expects('exec')
+        .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices', '-l'])
+        .returns({stdout: 'List of devices attached \nemulator-5556 device product:sdk_google_phone_x86_64 model:Android_SDK_built_for_x86_64 device:generic_x86_64\n0a388e93      device usb:1-1 product:razor model:Nexus_7 device:flo'});
+      let devices = await adb.getConnectedDevices({long: true});
+      devices.should.have.length.above(0);
+      devices.should.deep.equal([
+        {udid: 'emulator-5556', state: 'device', product: 'sdk_google_phone_x86_64', model: 'Android_SDK_built_for_x86_64', device: 'generic_x86_64'},
+        {udid: '0a388e93', state: 'device', usb: '1-1', product: 'razor', model: 'Nexus_7', device: 'flo'},
+      ]);
     });
   });
   describe('getDevicesWithRetry', function () {

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -44,11 +44,11 @@ describe('System calls', withMocks({teen_process}, function (mocks) {
       await adb.getConnectedDevices().should.eventually.be
                                      .rejectedWith('Unexpected output while trying to get devices');
     });
-    it('should get all connected devices with long output', async function () {
+    it('should get all connected devices with verbose output', async function () {
       mocks.teen_process.expects('exec')
         .once().withExactArgs(adb.executable.path, ['-P', 5037, 'devices', '-l'])
         .returns({stdout: 'List of devices attached \nemulator-5556 device product:sdk_google_phone_x86_64 model:Android_SDK_built_for_x86_64 device:generic_x86_64\n0a388e93      device usb:1-1 product:razor model:Nexus_7 device:flo'});
-      let devices = await adb.getConnectedDevices({long: true});
+      let devices = await adb.getConnectedDevices({verbose: true});
       devices.should.have.length.above(0);
       devices.should.deep.equal([
         {udid: 'emulator-5556', state: 'device', product: 'sdk_google_phone_x86_64', model: 'Android_SDK_built_for_x86_64', device: 'generic_x86_64'},


### PR DESCRIPTION
This change adds the ability to use `adb devices -l` instead of plain `adb devices`. This lets addition information get read when obtaining connected devices.

The `-l` is short for "long" so I used the same naming when creating the options object.

https://developer.android.com/studio/command-line/adb#devicestatus