### PR TITLE
Add cloneADB function

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -61,7 +61,8 @@ class ADB {
     const originalOptions = _.cloneDeep(_.pick(this, Object.keys(DEFAULT_OPTS)));
     const cloneOptions = _.defaultsDeep(opts, originalOptions);
 
-    // Reset default arguments created in the constructor
+    // Reset default arguments created in the constructor.
+    // Without this code, -H and -P can be injected into defaultArgs multiple times.
     const defaultArgs = cloneOptions.executable.defaultArgs;
     if (cloneOptions.remoteAdbHost && defaultArgs.includes('-H')) {
       defaultArgs.splice(defaultArgs.indexOf('-H'), 2);

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -57,9 +57,19 @@ class ADB {
    * @param {object} opts - Additional options mapping to pass to the `ADB` constructor.
    * @returns {ADB} The resulting class instance.
    */
-  clone (opts) {
-    const adb = new ADB(opts);
-    _.defaultsDeep(adb, _.cloneDeep(this));
+  clone (opts = {}) {
+    const cloneOptions = _.defaultsDeep(opts, _.cloneDeep(this));
+
+    // Reset default arguments created in the constructor
+    const defaultArgs = cloneOptions.executable.defaultArgs;
+    if (cloneOptions.remoteAdbHost && defaultArgs.includes('-H')) {
+      defaultArgs.splice(defaultArgs.indexOf('-H'), 2);
+    }
+    if (defaultArgs.includes('-P')) {
+      defaultArgs.splice(defaultArgs.indexOf('-P'), 2);
+    }
+
+    const adb = new ADB(cloneOptions);
     return adb;
   }
 }

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -50,6 +50,19 @@ class ADB {
     }
     this.executable.defaultArgs.push('-P', this.adbPort);
   }
+
+  /**
+   * Create a new instance of `ADB` that inherits configuration from this `ADB` instance.
+   * This avoids the need to call `ADB.createADB()` multiple times.
+   * @param {object} opts - Additional options mapping to pass to the `ADB` constructor.
+   * @returns {ADB} The resulting class instance.
+   */
+  cloneADB (opts) {
+    const adb = new ADB(opts);
+    adb.sdkRoot = this.sdkRoot;
+    adb.executable.path = this.executable.path;
+    return adb;
+  }
 }
 
 ADB.createADB = async function createADB (opts) {

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -58,7 +58,8 @@ class ADB {
    * @returns {ADB} The resulting class instance.
    */
   clone (opts = {}) {
-    const cloneOptions = _.defaultsDeep(opts, _.cloneDeep(this));
+    const originalOptions = _.cloneDeep(_.pick(this, Object.keys(DEFAULT_OPTS)));
+    const cloneOptions = _.defaultsDeep(opts, originalOptions);
 
     // Reset default arguments created in the constructor
     const defaultArgs = cloneOptions.executable.defaultArgs;
@@ -69,8 +70,7 @@ class ADB {
       defaultArgs.splice(defaultArgs.indexOf('-P'), 2);
     }
 
-    const adb = new ADB(cloneOptions);
-    return adb;
+    return new ADB(cloneOptions);
   }
 }
 

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -57,7 +57,7 @@ class ADB {
    * @param {object} opts - Additional options mapping to pass to the `ADB` constructor.
    * @returns {ADB} The resulting class instance.
    */
-  cloneADB (opts) {
+  clone (opts) {
     const adb = new ADB(opts);
     adb.sdkRoot = this.sdkRoot;
     adb.executable.path = this.executable.path;

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -59,8 +59,7 @@ class ADB {
    */
   clone (opts) {
     const adb = new ADB(opts);
-    adb.sdkRoot = this.sdkRoot;
-    adb.executable.path = this.executable.path;
+    _.defaultsDeep(adb, _.cloneDeep(this));
     return adb;
   }
 }

--- a/test/functional/adb-e2e-specs.js
+++ b/test/functional/adb-e2e-specs.js
@@ -37,4 +37,11 @@ describe('ADB', function () {
     await adb.initZipAlign();
     adb.binaries.zipalign.should.contain('zipalign');
   });
+  it('should correctly initialize adb from parent', async function () {
+    let adb = await ADB.createADB();
+    should.exist(adb.executable.path);
+    let clone = adb.cloneADB();
+    should.exist(clone.executable.path);
+    should.be.equal(adb.executable.path, clone.executable.path);
+  });
 });

--- a/test/functional/adb-e2e-specs.js
+++ b/test/functional/adb-e2e-specs.js
@@ -40,8 +40,8 @@ describe('ADB', function () {
   it('should correctly initialize adb from parent', async function () {
     let adb = await ADB.createADB();
     should.exist(adb.executable.path);
-    let clone = adb.cloneADB();
+    let clone = adb.clone();
     should.exist(clone.executable.path);
-    should.be.equal(adb.executable.path, clone.executable.path);
+    adb.executable.path.should.equal(clone.executable.path);
   });
 });

--- a/test/unit/adb-specs.js
+++ b/test/unit/adb-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import { ADB, DEFAULT_ADB_PORT } from '../..';
 
 
 chai.use(chaiAsPromised);
@@ -15,6 +15,20 @@ describe('ADB', function () {
 
       clone.executable.path.should.equal(original.executable.path);
       clone.executable.defaultArgs.should.deep.equal(original.executable.defaultArgs);
+    });
+
+    it('should replace specified options', function () {
+      const original = new ADB({
+        executable: {path: 'adb', defaultArgs: ['-a']},
+      });
+      const clone = original.clone({
+        remoteAdbHost: 'example.com',
+      });
+
+      clone.executable.path.should.equal(original.executable.path);
+      clone.executable.defaultArgs.should.deep.equal(['-a', '-H', 'example.com', '-P', DEFAULT_ADB_PORT]);
+      clone.remoteAdbHost.should.equal('example.com');
+      clone.adbHost.should.not.equal(original.adbHost);
     });
   });
 });

--- a/test/unit/adb-specs.js
+++ b/test/unit/adb-specs.js
@@ -1,0 +1,20 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import ADB from '../..';
+
+
+chai.use(chaiAsPromised);
+
+describe('ADB', function () {
+  describe('clone', function () {
+    it('should copy all options', function () {
+      const original = new ADB({
+        executable: {path: 'var/adb', defaultArgs: ['-a']},
+      });
+      const clone = original.clone();
+
+      clone.executable.path.should.equal(original.executable.path);
+      clone.executable.defaultArgs.should.deep.equal(original.executable.defaultArgs);
+    });
+  });
+});


### PR DESCRIPTION
Closes appium/appium#16932

Adds a `cloneADB` function that copies already initialized properties created in `ADB.createADB()`.

This was added in the top-level class since it uses the class constructor. It was attached directly to the class to avoid the prototype assignment warning.