### PR TITLE
feat: Start setting mock locations as a foreground service

### DIFF
--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -247,7 +247,7 @@ commands.setGeoLocation = async function setGeoLocation (location, isEmulator = 
     await this.adbExec(['emu', 'geo', 'fix', ...(args.map((arg) => arg.replace('.', ',')))]);
   } else {
     const args = [
-      'am', await this.getApiLevel() >= 26 ? 'start-foreground-service' : 'startservice',
+      'am', (await this.getApiLevel() >= 26) ? 'start-foreground-service' : 'startservice',
       '-e', 'longitude', longitude,
       '-e', 'latitude', latitude,
     ];

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -247,7 +247,7 @@ commands.setGeoLocation = async function setGeoLocation (location, isEmulator = 
     await this.adbExec(['emu', 'geo', 'fix', ...(args.map((arg) => arg.replace('.', ',')))]);
   } else {
     const args = [
-      'am', 'startservice',
+      'am', await this.getApiLevel() >= 26 ? 'start-foreground-service' : 'startservice',
       '-e', 'longitude', longitude,
       '-e', 'latitude', latitude,
     ];

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -531,7 +531,22 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         longitude: '50.5',
         latitude: '50.1'
       };
-      it('should call shell with correct args for real device', async function () {
+      it('should call shell with correct args for real device with Oreo preview device', async function () {
+        mocks.adb.expects('getApiLevel')
+          .once().returns(26);
+        mocks.adb.expects('shell')
+          .once().withExactArgs([
+            'am', 'start-foreground-service',
+            '-e', 'longitude', location.longitude,
+            '-e', 'latitude', location.latitude,
+            `io.appium.settings/.LocationService`
+          ])
+          .returns('');
+        await adb.setGeoLocation(location);
+      });
+      it('should call shell with correct args for real device with Nougat preview device', async function () {
+        mocks.adb.expects('getApiLevel')
+          .once().returns(25);
         mocks.adb.expects('shell')
           .once().withExactArgs([
             'am', 'startservice',


### PR DESCRIPTION
This commit changes to start setting mock locations as a foreground service for API versions 26+, according to [the README of io.appium.settings](https://github.com/appium/io.appium.settings/blob/master/README.md#setting-mock-locations).