### PR TITLE
feat: Add an option to enforce dumpsys usage for launchable activity name detection

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -212,16 +212,30 @@ methods.isValidClass = function isValidClass (classString) {
 };
 
 /**
+ * @typedef {Object} ResolveActivityOptions
+ * @property {boolean?} preferCmd [true] Whether to prefer `cmd` tool usage for
+ * launchable activity name detection. It might be useful to disable it if
+ * `cmd package resolve-activity` returns 'android/com.android.internal.app.ResolverActivity',
+ * which means the app has no default handler set in system settings.
+ * See https://github.com/appium/appium/issues/17128 for more details.
+ * This option has no effect if the target Android version is below 24 as there
+ * the corresponding `cmd` subcommand is not implemented and dumpsys usage is the only
+ * possible way to detect the launchable activity name.
+ */
+
+/**
  * Fetches the fully qualified name of the launchable activity for the
  * given package. It is expected the package is already installed on
  * the device under test.
  *
  * @param {string} pkg - The target package identifier
+ * @param {ResolveActivityOptions?} opts
  * @return {string} Fully qualified name of the launchable activity
  * @throws {Error} If there was an error while resolving the activity name
  */
-methods.resolveLaunchableActivity = async function resolveLaunchableActivity (pkg) {
-  if (await this.getApiLevel() < 24) {
+methods.resolveLaunchableActivity = async function resolveLaunchableActivity (pkg, opts = {}) {
+  const { preferCmd = true } = opts;
+  if (!preferCmd || await this.getApiLevel() < 24) {
     const stdout = await this.shell(['dumpsys', 'package', pkg]);
     const names = parseLaunchableActivityNames(stdout);
     if (_.isEmpty(names)) {


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/17128