### PR TITLE
tests: Fix ADB instance import

### DIFF
--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import path from 'path';
 import { apiLevel, platformVersion, MOCHA_TIMEOUT } from './setup';
 import { fs, mkdirp } from '@appium/support';

--- a/test/functional/adb-e2e-specs.js
+++ b/test/functional/adb-e2e-specs.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import { fs } from '@appium/support';
 import path from 'path';
 

--- a/test/functional/adb-emu-commands-e2e-specs.js
+++ b/test/functional/adb-emu-commands-e2e-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 
 chai.use(chaiAsPromised);
 chai.should();

--- a/test/functional/android-manifest-e2e-specs.js
+++ b/test/functional/android-manifest-e2e-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import path from 'path';
 import { fs, util } from '@appium/support';
 

--- a/test/functional/apk-utils-e2e-specs.js
+++ b/test/functional/apk-utils-e2e-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import path from 'path';
 import { retryInterval } from 'asyncbox';
 import { MOCHA_TIMEOUT, MOCHA_LONG_TIMEOUT, apiLevel } from './setup';

--- a/test/functional/syscalls-e2e-specs.js
+++ b/test/functional/syscalls-e2e-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import { apiLevel, avdName, MOCHA_TIMEOUT, MOCHA_LONG_TIMEOUT } from './setup';
 import path from 'path';
 import { getModuleRoot } from '../../lib/helpers.js';

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import net from 'net';
 import events from 'events';
 import Logcat from '../../lib/logcat.js';

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import { withMocks } from '@appium/test-support';
 import _ from 'lodash';
 

--- a/test/unit/adb-specs.js
+++ b/test/unit/adb-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { ADB, DEFAULT_ADB_PORT } from '../..';
+import { ADB, DEFAULT_ADB_PORT } from '../../lib/adb';
 
 
 chai.use(chaiAsPromised);

--- a/test/unit/apk-signing-specs.js
+++ b/test/unit/apk-signing-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import * as helpers from '../../lib/helpers.js';
 import path from 'path';
 import * as teen_process from 'teen_process';

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as teen_process from 'teen_process';
 import { fs } from '@appium/support';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import { withMocks } from '@appium/test-support';
 import _ from 'lodash';
 import B from 'bluebird';

--- a/test/unit/syscalls-specs.js
+++ b/test/unit/syscalls-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import ADB from '../..';
+import ADB from '../../lib/adb';
 import * as teen_process from 'teen_process';
 import { withMocks } from '@appium/test-support';
 import B from 'bluebird';


### PR DESCRIPTION
We should never import from index.js in tests, but rather directly from corresponding source modules.