### PR TITLE
fix: escape doesn't work due to misuse of regex

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -27,8 +27,6 @@ const HIDDEN_API_POLICY_KEYS = [
 const PID_COLUMN_TITLE = 'PID';
 const PROCESS_NAME_COLUMN_TITLE = 'NAME';
 const PS_TITLE_PATTERN = new RegExp(`^(.*\\b${PID_COLUMN_TITLE}\\b.*\\b${PROCESS_NAME_COLUMN_TITLE}\\b.*)$`, 'm');
-// https://stackoverflow.com/questions/25791423/adb-shell-input-text-does-not-take-ampersand-character/25791498
-const ADB_INPUT_ESCAPE_PATTERN = /[()<>|;&*\\~^"']/g;
 
 const methods = {};
 
@@ -638,7 +636,9 @@ methods.inputText = async function inputText (text) {
   const originalStr = `${text}`;
   const escapedText = originalStr.replace(/\$/g, '\\$').replace(/ /g, '%s');
   let args = ['input', 'text', originalStr];
-  if (escapedText !== originalStr || ADB_INPUT_ESCAPE_PATTERN.test(originalStr)) {
+  // https://stackoverflow.com/questions/25791423/adb-shell-input-text-does-not-take-ampersand-character/25791498
+  const adbInputEscapePattern = /[()<>|;&*\\~^"']/g;
+  if (escapedText !== originalStr || adbInputEscapePattern.test(originalStr)) {
     if (_.every(['"', `'`], (c) => originalStr.includes(c))) {
       throw new Error(
         `Did not know how to escape a string that contains both types of quotes (" and ')`

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -249,6 +249,14 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
           .returns('');
         await adb.inputText(text);
       });
+      it('should call shell with correct args if special chars are present but spaces are not in the text', async function () {
+        const text = '&something';
+        const expectedText = `"&something"`;
+        mocks.adb.expects('shell')
+          .once().withExactArgs([`input text ${expectedText}`])
+          .returns('');
+        await adb.inputText(text);
+      });
       it('should call shell with correct args and select appropriate quotes', async function () {
         const text = 'some text & with quote$"';
         const expectedText = `'some%stext%s&%swith%squote\\$"'`;


### PR DESCRIPTION
I ran into an interesting behavior. Passing a non-ascii character to the mobile:type command always succeeds the first time but fails the second time. The reason is that the regex object is stateful.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
> JavaScript [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) objects are stateful when they have the [global](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global) or [sticky](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) flags set

This PR fixes the problem by changing it to a local variable.