### PR TITLE
fix: adb pull default timeout will use adb exec timeout

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -895,8 +895,8 @@ methods.push = async function push (localPath, remotePath, opts) {
  *                        options.
  */
 methods.pull = async function pull (remotePath, localPath, opts = {}) {
-  // pull folder can take more time, increasing time out to 60 secs
-  await this.adbExec(['pull', remotePath, localPath], {...opts, timeout: opts.timeout ?? 60000});
+  // pull folder can take more time, increasing time out to 300 secs
+  await this.adbExec(['pull', remotePath, localPath], {...opts, timeout: opts.timeout ?? 300000});
 };
 
 /**


### PR DESCRIPTION
If appium:adbExecTimeout is set, use that timeout when timeout is not set in options.

For example RecordingFullHD video for over 30 minutes with media projection recording fails because pull has a default 60s timeout. Setting adbExecTimeout capability doesn't affect this because of pull setting a default timeout of 60s.

Fixes issue #18522