### PR TITLE
fix: Properly handle the situation where reboot_readiness check returns a non-zero exit code

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -34,6 +34,7 @@ const SDK_BINARY_ROOTS = [
 ];
 const MIN_DELAY_ADB_API_LEVEL = 28;
 const REQUIRED_SERVICES = ['activity', 'package', 'mount'];
+const SUBSYSTEM_STATE_OK = 'Subsystem state: true';
 
 /**
  * Retrieve full path to the given binary.
@@ -526,7 +527,7 @@ systemCallMethods.adbExec = async function adbExec (cmd, opts = {}) {
  * @param {!Array.<string>|string} cmd - The array of rest command line parameters or a single
  *                                      string parameter.
  * @param {?ShellExecOptions} opts [{}] - Additional options mapping.
- * @return {string} - Command's stdout.
+ * @return {Promise<string>} - Command's stdout.
  * @throws {Error} If the command returned non-zero exit code.
  */
 systemCallMethods.shell = async function shell (cmd, opts = {}) {
@@ -958,11 +959,14 @@ systemCallMethods.waitForEmulatorReady = async function waitForEmulatorReady (ti
       await waitForCondition(async () => {
         try {
           reason = await this.shell(['cmd', 'reboot_readiness', 'check-subsystems-state', '--list-blocking']);
-          return _.includes(reason, 'Subsystem state: true');
         } catch (err) {
-          log.debug(`Waiting for emulator startup. Intermediate error: ${err.message}`);
-          return false;
+          // https://github.com/appium/appium/issues/18717
+          reason = err.stdout || err.stderr;
+          if (!_.includes(reason, SUBSYSTEM_STATE_OK)) {
+            log.debug(`Waiting for emulator startup. Intermediate error: ${err.message}`);
+          }
         }
+        return _.includes(reason, SUBSYSTEM_STATE_OK);
       }, {
         waitMs: timeoutMs,
         intervalMs: 1000,


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/18717