### PR TITLE
fix: Streamline parameters validation for emulator commands

### DIFF
--- a/lib/tools/adb-emu-commands.js
+++ b/lib/tools/adb-emu-commands.js
@@ -7,8 +7,6 @@ import B from 'bluebird';
 import path from 'path';
 import ini from 'ini';
 
-const PHONE_NUMBER_PATTERN = /^[+]?[(]?[0-9]*[)]?[-\s.]?[0-9]*[-\s.]?[0-9]{2,}$/im;
-
 const emuMethods = {};
 emuMethods.POWER_AC_STATES = Object.freeze({
   POWER_AC_ON: 'on',
@@ -165,7 +163,7 @@ emuMethods.rotate = async function rotate () {
 /**
  * Emulate power state change on the connected emulator.
  *
- * @param {string} state ['on'] - Either 'on' or 'off'.
+ * @param {on|off} state ['on'] - Either 'on' or 'off'.
  */
 emuMethods.powerAC = async function powerAC (state = 'on') {
   if (_.values(emuMethods.POWER_AC_STATES).indexOf(state) === -1) {
@@ -180,7 +178,7 @@ emuMethods.powerAC = async function powerAC (state = 'on') {
  *
  * @param {string} sensor - Sensor type declared in SENSORS items.
  * @param {number|string} value  - Number to set as the sensor value.
- * @throws {Error} - If sensor type or sensor value is not defined
+ * @throws {TypeError} - If sensor type or sensor value is not defined
  */
 emuMethods.sensorSet = async function sensorSet (sensor, value) {
   if (!_.includes(emuMethods.SENSORS, sensor)) {
@@ -203,7 +201,7 @@ emuMethods.sensorSet = async function sensorSet (sensor, value) {
 emuMethods.powerCapacity = async function powerCapacity (percent = 100) {
   percent = parseInt(percent, 10);
   if (isNaN(percent) || percent < 0 || percent > 100) {
-    throw new Error(`The percentage value should be valid integer between 0 and 100`);
+    throw new TypeError(`The percentage value should be valid integer between 0 and 100`);
   }
   await this.adbExecEmu(['power', 'capacity', percent]);
 };
@@ -221,16 +219,14 @@ emuMethods.powerOFF = async function powerOFF () {
  *
  * @param {string|number} phoneNumber - The phone number of message sender.
  * @param {string} message [''] - The message content.
- * @throws {error} If phone number has invalid format.
+ * @throws {TypeError} If phone number has invalid format.
  */
 emuMethods.sendSMS = async function sendSMS (phoneNumber, message = '') {
-  message = message.trim();
-  if (message === '') {
-    throw new Error('Sending an SMS requires a message');
+  if (_.isEmpty(message)) {
+    throw new TypeError('SMS message must not be empty');
   }
-  phoneNumber = `${phoneNumber}`.replace(/\s*/, '');
-  if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
-    throw new Error(`Invalid sendSMS phoneNumber param ${phoneNumber}`);
+  if (!_.isInteger(phoneNumber) && _.isEmpty(phoneNumber)) {
+    throw new TypeError('Phone number most not be empty');
   }
   await this.adbExecEmu(['sms', 'send', phoneNumber, message]);
 };
@@ -239,17 +235,18 @@ emuMethods.sendSMS = async function sendSMS (phoneNumber, message = '') {
  * Emulate GSM call event on the connected emulator.
  *
  * @param {string|number} phoneNumber - The phone number of the caller.
- * @param {string} action [''] - One of available GSM call actions.
- * @throws {error} If phone number has invalid format.
- * @throws {error} If _action_ value is invalid.
+ * @param {call|accept|cancel|hold} action - One of available GSM call actions.
+ * @throws {TypeError} If phone number has invalid format.
+ * @throws {TypeError} If _action_ value is invalid.
  */
-emuMethods.gsmCall = async function gsmCall (phoneNumber, action = '') {
-  if (_.values(emuMethods.GSM_CALL_ACTIONS).indexOf(action) === -1) {
-    throw new Error(`Invalid gsm action param ${action}. Supported values: ${_.values(emuMethods.GSM_CALL_ACTIONS)}`);
+emuMethods.gsmCall = async function gsmCall (phoneNumber, action) {
+  if (!_.values(emuMethods.GSM_CALL_ACTIONS).includes(action)) {
+    throw new TypeError(
+      `Invalid gsm action param ${action}. Supported values: ${_.values(emuMethods.GSM_CALL_ACTIONS)}`
+    );
   }
-  phoneNumber = `${phoneNumber}`.replace(/\s*/, '');
-  if (!PHONE_NUMBER_PATTERN.test(phoneNumber)) {
-    throw new Error(`Invalid gsmCall phoneNumber param ${phoneNumber}`);
+  if (!_.isInteger(phoneNumber) && _.isEmpty(phoneNumber)) {
+    throw new TypeError('Phone number most not be empty');
   }
   await this.adbExecEmu(['gsm', action, phoneNumber]);
 };
@@ -257,13 +254,15 @@ emuMethods.gsmCall = async function gsmCall (phoneNumber, action = '') {
 /**
  * Emulate GSM signal strength change event on the connected emulator.
  *
- * @param {string|number} strength [4] - A number in range [0, 4];
- * @throws {error} If _strength_ value is invalid.
+ * @param {0|1|2|3|4} strength [4] - A number in range [0, 4];
+ * @throws {TypeError} If _strength_ value is invalid.
  */
 emuMethods.gsmSignal = async function gsmSignal (strength = 4) {
   strength = parseInt(strength, 10);
-  if (emuMethods.GSM_SIGNAL_STRENGTHS.indexOf(strength) === -1) {
-    throw new Error(`Invalid signal strength param ${strength}. Supported values: ${_.values(emuMethods.GSM_SIGNAL_STRENGTHS)}`);
+  if (!emuMethods.GSM_SIGNAL_STRENGTHS.includes(strength)) {
+    throw new TypeError(
+      `Invalid signal strength param ${strength}. Supported values: ${_.values(emuMethods.GSM_SIGNAL_STRENGTHS)}`
+    );
   }
   log.info('gsm signal-profile <strength> changes the reported strength on next (15s) update.');
   await this.adbExecEmu(['gsm', 'signal-profile', strength]);
@@ -272,13 +271,15 @@ emuMethods.gsmSignal = async function gsmSignal (strength = 4) {
 /**
  * Emulate GSM voice event on the connected emulator.
  *
- * @param {string} state ['on'] - Either 'on' or 'off'.
- * @throws {error} If _state_ value is invalid.
+ * @param {unregistered|home|roaming|searching|denied|on|off} state ['on'] - Either 'on' or 'off'.
+ * @throws {TypeError} If _state_ value is invalid.
  */
 emuMethods.gsmVoice = async function gsmVoice (state = 'on') {
   // gsm voice <state> allows you to change the state of your GPRS connection
-  if (_.values(emuMethods.GSM_VOICE_STATES).indexOf(state) === -1) {
-    throw new Error(`Invalid gsm voice state param ${state}. Supported values: ${_.values(emuMethods.GSM_VOICE_STATES)}`);
+  if (!_.values(emuMethods.GSM_VOICE_STATES).includes(state)) {
+    throw new TypeError(
+      `Invalid gsm voice state param ${state}. Supported values: ${_.values(emuMethods.GSM_VOICE_STATES)}`
+    );
   }
   await this.adbExecEmu(['gsm', 'voice', state]);
 };
@@ -286,13 +287,15 @@ emuMethods.gsmVoice = async function gsmVoice (state = 'on') {
 /**
  * Emulate network speed change event on the connected emulator.
  *
- * @param {string} speed ['full'] - One of possible NETWORK_SPEED values.
- * @throws {error} If _speed_ value is invalid.
+ * @param {gsm|scsd|gprs|edge|umts|hspda|lte|evdo|full} speed ['full'] - One of possible NETWORK_SPEED values.
+ * @throws {TypeError} If _speed_ value is invalid.
  */
 emuMethods.networkSpeed = async function networkSpeed (speed = 'full') {
   // network speed <speed> allows you to set the network speed emulation.
-  if (_.values(emuMethods.NETWORK_SPEED).indexOf(speed) === -1) {
-    throw new Error(`Invalid network speed param ${speed}. Supported values: ${_.values(emuMethods.NETWORK_SPEED)}`);
+  if (!_.values(emuMethods.NETWORK_SPEED).includes(speed)) {
+    throw new Error(
+      `Invalid network speed param ${speed}. Supported values: ${_.values(emuMethods.NETWORK_SPEED)}`
+    );
   }
   await this.adbExecEmu(['network', 'speed', speed]);
 };

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -155,7 +155,7 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects('adbExec')
-          .once().withExactArgs(['emu', 'sms', 'send', phoneNumber, 'Hello Appium'])
+          .once().withExactArgs(['emu', 'sms', 'send', phoneNumber, message])
           .returns();
         await adb.sendSMS(phoneNumber, message);
       });

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -155,7 +155,7 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects('adbExec')
-          .once().withExactArgs(['emu', 'sms', 'send', '4509', 'Hello Appium'])
+          .once().withExactArgs(['emu', 'sms', 'send', phoneNumber, 'Hello Appium'])
           .returns();
         await adb.sendSMS(phoneNumber, message);
       });
@@ -194,7 +194,7 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects('adbExec')
-          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_CALL, '4509'])
+          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_CALL, phoneNumber])
           .returns();
         await adb.gsmCall(phoneNumber, 'call');
       });
@@ -207,7 +207,7 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects('adbExec')
-          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_ACCEPT, '4509'])
+          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_ACCEPT, phoneNumber])
           .returns();
         await adb.gsmCall(phoneNumber, 'accept');
       });
@@ -220,7 +220,7 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects('adbExec')
-          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_CANCEL, '4509'])
+          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_CANCEL, phoneNumber])
           .returns();
         await adb.gsmCall(phoneNumber, 'cancel');
       });
@@ -233,7 +233,7 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
           .once().withExactArgs()
           .returns();
         mocks.adb.expects('adbExec')
-          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_HOLD, '4509'])
+          .once().withExactArgs(['emu', 'gsm', adb.GSM_CALL_ACTIONS.GSM_HOLD, phoneNumber])
           .returns();
         await adb.gsmCall(phoneNumber, 'hold');
       });

--- a/test/unit/adb-emu-commands-specs.js
+++ b/test/unit/adb-emu-commands-specs.js
@@ -140,10 +140,10 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
     });
     describe('sendSMS', function () {
       it('should throw exception on invalid message', async function () {
-        await adb.sendSMS('+549341312345678').should.eventually.be.rejectedWith('Sending an SMS requires a message');
+        await adb.sendSMS('+549341312345678').should.be.rejected;
       });
       it('should throw exception on invalid phoneNumber', async function () {
-        await adb.sendSMS('00549341a312345678', 'Hello Appium').should.eventually.be.rejectedWith('Invalid sendSMS phoneNumber');
+        await adb.sendSMS('', 'Hello Appium').should.be.rejected;
       });
       it('should call adbExec with the correct args', async function () {
         let phoneNumber = 4509;
@@ -180,10 +180,10 @@ describe('adb emulator commands', withMocks({adb}, function (mocks) {
     });
     describe('gsm call methods', function () {
       it('should throw exception on invalid action', async function () {
-        await adb.gsmCall('+549341312345678').should.eventually.be.rejectedWith('Invalid gsm action');
+        await adb.gsmCall('+549341312345678').should.be.rejected;
       });
       it('should throw exception on invalid phoneNumber', async function () {
-        await adb.gsmCall('+5493413a12345678', 'call').should.eventually.be.rejectedWith('Invalid gsmCall phoneNumber');
+        await adb.gsmCall('', 'call').should.be.rejected;
       });
       it('should set the correct method for making gsm call', async function () {
         let phoneNumber = 4509;


### PR DESCRIPTION
Let adb itself validate parameters format. We only make sure if these are not empty