### PR TITLE
fix: insert a missing await keyword

### DIFF
--- a/lib/adb.ts
+++ b/lib/adb.ts
@@ -106,7 +106,7 @@ export class ADB {
   static async createADB(opts: Partial<ADBOptions>) {
     const adb = new ADB(opts);
     adb.sdkRoot = await requireSdkRoot(adb.sdkRoot);
-    adb.getAdbWithCorrectAdbPath();
+    await adb.getAdbWithCorrectAdbPath();
     try {
       await adb.adbExec(['start-server']);
     } catch (e) {


### PR DESCRIPTION
if my understanding is correct, I think we need a `await` keyword, which is somehow dropped since https://github.com/appium/appium-adb/pull/661/