### PR TITLE
chore: Add a troubleshooting link to the WRITE_SECURE_SETTINGS error message

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -491,6 +491,20 @@ methods.toggleGPSLocationProvider = async function toggleGPSLocationProvider (en
 };
 
 /**
+ * Decorates an exception message with a solution link
+ *
+ * @param {Error} e The error object to be decorated
+ * @returns {Error} Either the same error or the decorated one
+ */
+function decorateWriteSecureSettingsException (e) {
+  if (_.includes(e.message, 'requires:android.permission.WRITE_SECURE_SETTINGS')) {
+    e.message = `Check https://forum.xda-developers.com/t/i-cant-enable-write_secure_settings-for-an-app-over-adb.3855596/ ` +
+      `for throubleshooting. ${e.message}`;
+  }
+  return e;
+}
+
+/**
  * Set hidden api policy to manage access to non-SDK APIs.
  * https://developer.android.com/preview/restrictions-non-sdk-interfaces
  *
@@ -521,7 +535,7 @@ methods.setHiddenApiPolicy = async function setHiddenApiPolicy (value, ignoreErr
     await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings put global ${k} ${value}`).join(';'));
   } catch (e) {
     if (!ignoreError) {
-      throw e;
+      throw decorateWriteSecureSettingsException(e);
     }
     log.info(`Failed to set setting keys '${HIDDEN_API_POLICY_KEYS}' to '${value}'. Original error: ${e.message}`);
   }
@@ -540,7 +554,7 @@ methods.setDefaultHiddenApiPolicy = async function setDefaultHiddenApiPolicy (ig
     await this.shell(HIDDEN_API_POLICY_KEYS.map((k) => `settings delete global ${k}`).join(';'));
   } catch (e) {
     if (!ignoreError) {
-      throw e;
+      throw decorateWriteSecureSettingsException(e);
     }
     log.info(`Failed to delete keys '${HIDDEN_API_POLICY_KEYS}'. Original error: ${e.message}`);
   }


### PR DESCRIPTION
Maybe it could help to people that get stuck with a cryptic error message while using Chinese phones to run their tests