### PR TITLE
chore: Memoize constant system properties

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1474,7 +1474,7 @@ methods.androidCoverage = async function androidCoverage (instrumentClass, waitP
  */
 methods.getDeviceProperty = async function getDeviceProperty (property, memoize = false) {
   if (memoize) {
-    if (!_.isPlainObject(this._memoizedDeviceProperties)) {
+    if (_.isUndefined(this._memoizedDeviceProperties)) {
       this._memoizedDeviceProperties = new LRU({
         max: 20,
       });


### PR DESCRIPTION
Some device properties cannot get changed during the session, so it makes sense to memoize their values in order to speed up the test execution