### PR TITLE
feat(types): export more types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,12 +5,13 @@
  */
 
 import {install} from 'source-map-support';
-import {ADB} from './lib/adb';
-
 install();
+
+import {ADB} from './lib/adb';
 
 export * from './lib/adb';
 export type * from './lib/mixins';
 export type * from './lib/tools';
 export type * from './lib/logcat';
+export type * from './lib/options';
 export default ADB;

--- a/lib/adb.ts
+++ b/lib/adb.ts
@@ -3,8 +3,7 @@ import os from 'node:os';
 import methods, {getAndroidBinaryPath} from './tools';
 import {DEFAULT_ADB_EXEC_TIMEOUT, requireSdkRoot, getSdkRootFromEnv} from './helpers';
 import log from './logger';
-import {StringRecord} from '@appium/types';
-import type Logcat from './logcat';
+import type {ADBOptions, ADBExecutable} from './options';
 
 const DEFAULT_ADB_PORT = 5037;
 export const DEFAULT_OPTS = {
@@ -19,42 +18,6 @@ export const DEFAULT_OPTS = {
   allowOfflineDevices: false,
   allowDelayAdb: true,
 } as const;
-
-export interface ADBOptions {
-  sdkRoot?: string;
-  udid?: string;
-  appDeviceReadyTimeout?: number;
-  useKeystore?: boolean;
-  keystorePath?: string;
-  keystorePassword?: string;
-  keyAlias?: string;
-  keyPassword?: string;
-  executable: ADBExecutable;
-  tmpDir?: string;
-  curDeviceId?: string;
-  emulatorPort?: number;
-  logcat?: Logcat;
-  binaries?: StringRecord;
-  instrumentProc?: string;
-  suppressKillServer?: boolean;
-  jars?: StringRecord;
-  adbPort?: number;
-  adbHost?: string;
-  adbExecTimeout?: number;
-  remoteAppsCacheLimit?: number;
-  buildToolsVersion?: string;
-  allowOfflineDevices?: boolean;
-  allowDelayAdb?: boolean;
-  remoteAdbHost?: string;
-  remoteAdbPort?: number;
-  clearDeviceLogsOnStart?: boolean;
-  emPort?: number;
-}
-
-export interface ADBExecutable {
-  path: string;
-  defaultArgs: string[];
-}
 
 export class ADB {
   adbHost?: string;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -246,7 +246,7 @@ const getOpenSslForOs = async function () {
  * Get the absolute path to apksigner tool
  *
  * @param {Object} sysHelpers - An instance containing systemCallMethods helper methods
- * @returns {string} An absolute path to apksigner tool.
+ * @returns {Promise<string>} An absolute path to apksigner tool.
  * @throws {Error} If the tool is not present on the local file system.
  */
 async function getApksignerForOs (sysHelpers) {

--- a/lib/mixins.ts
+++ b/lib/mixins.ts
@@ -5,24 +5,32 @@
  * @module
  */
 
-import {SystemCalls} from './tools/system-calls';
-import {ApkUtils} from './tools/apk-utils';
-import {ADBCommands} from './tools/adb-commands';
-import {SettingsClientCommands} from './tools/settings-client-commands';
-import {ADBEmuCommands} from './tools/adb-emu-commands';
-import {LockManagementCommands} from './tools/lockmgmt';
-import {ManifestMethods} from './tools/android-manifest';
-import {KeyboardCommands} from './tools/keyboard-commands';
+import {
+  SystemCalls,
+  ApkUtils,
+  ADBCommands,
+  SettingsClientCommands,
+  ADBEmuCommands,
+  LockManagementCommands,
+  ManifestMethods,
+  KeyboardCommands,
+  ApkSigningCommands,
+  ApksUtils,
+} from './tools';
+import {ADBOptions} from './options';
+
 declare module './adb' {
   // note that ADBOptions is the options object, but it's mixed directly in to the instance in the constructor.
   interface ADB
     extends ADBCommands,
       ApkUtils,
+      ApksUtils,
       SystemCalls,
       ADBOptions,
       SettingsClientCommands,
       ADBEmuCommands,
       LockManagementCommands,
       ManifestMethods,
-      KeyboardCommands {}
+      KeyboardCommands,
+      ApkSigningCommands {}
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,0 +1,38 @@
+import type Logcat from './logcat';
+import type {StringRecord} from '@appium/types';
+
+export interface ADBOptions {
+  sdkRoot?: string;
+  udid?: string;
+  appDeviceReadyTimeout?: number;
+  useKeystore?: boolean;
+  keystorePath?: string;
+  keystorePassword?: string;
+  keyAlias?: string;
+  keyPassword?: string;
+  executable: ADBExecutable;
+  tmpDir?: string;
+  curDeviceId?: string;
+  emulatorPort?: number;
+  logcat?: Logcat;
+  binaries?: StringRecord;
+  instrumentProc?: string;
+  suppressKillServer?: boolean;
+  jars?: StringRecord;
+  adbPort?: number;
+  adbHost?: string;
+  adbExecTimeout?: number;
+  remoteAppsCacheLimit?: number;
+  buildToolsVersion?: string;
+  allowOfflineDevices?: boolean;
+  allowDelayAdb?: boolean;
+  remoteAdbHost?: string;
+  remoteAdbPort?: number;
+  clearDeviceLogsOnStart?: boolean;
+  emPort?: number;
+}
+
+export interface ADBExecutable {
+  path: string;
+  defaultArgs: string[];
+}

--- a/lib/tools/apk-signing.js
+++ b/lib/tools/apk-signing.js
@@ -31,8 +31,8 @@ const apkSigningMethods = {};
 /**
  * Execute apksigner utility with given arguments.
  *
- * @param {?Array<String>} args - The list of tool arguments.
- * @return {string} - Command stdout
+ * @param {string[]} args - The list of tool arguments.
+ * @return {Promise<string>} - Command stdout
  * @throws {Error} If apksigner binary is not present on the local file system
  *                 or the return code is not equal to zero.
  */
@@ -176,7 +176,7 @@ apkSigningMethods.sign = async function sign (appPath) {
  * Perform zip-aligning to the given local apk file.
  *
  * @param {string} apk - The full path to the local apk file.
- * @returns {boolean} True if the apk has been successfully aligned
+ * @returns {Promise<boolean>} True if the apk has been successfully aligned
  * or false if the apk has been already aligned.
  * @throws {Error} If zip-align fails.
  */
@@ -212,7 +212,7 @@ apkSigningMethods.zipAlignApk = async function zipAlignApk (apk) {
 
 /**
  * @typedef {Object} CertCheckOptions
- * @property {boolean} requireDefaultCert [true] Whether to require that the destination APK
+ * @property {boolean} [requireDefaultCert=true] Whether to require that the destination APK
  * is signed with the default Appium certificate or any valid certificate. This option
  * only has effect if `useKeystore` property is unset.
  */
@@ -223,7 +223,7 @@ apkSigningMethods.zipAlignApk = async function zipAlignApk (apk) {
  * @param {string} appPath - The full path to the local .apk(s) file.
  * @param {string} pgk - The name of application package.
  * @param {CertCheckOptions} opts - Certificate checking options
- * @return {boolean} True if given application is already signed.
+ * @return {Promise<boolean>} True if given application is already signed.
  */
 apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts = {}) {
   log.debug(`Checking app cert for ${appPath}`);
@@ -309,16 +309,16 @@ apkSigningMethods.checkApkCert = async function checkApkCert (appPath, pkg, opts
 
 /**
  * @typedef {Object} KeystoreHash
- * @property {?string} md5 the md5 hash value of the keystore
- * @property {?string} sha1 the sha1 hash value of the keystore
- * @property {?string} sha256 the sha256 hash value of the keystore
- * @property {?string} sha512 the sha512 hash value of the keystore
+ * @property {string} [md5] the md5 hash value of the keystore
+ * @property {string} [sha1] the sha1 hash value of the keystore
+ * @property {string} [sha256] the sha256 hash value of the keystore
+ * @property {string} [sha512] the sha512 hash value of the keystore
  */
 
 /**
  * Retrieve the the hash of the given keystore.
  *
- * @return {KeystoreHash}
+ * @return {Promise<KeystoreHash>}
  * @throws {Error} If getting keystore hash fails.
  */
 apkSigningMethods.getKeystoreHash = async function getKeystoreHash () {
@@ -359,3 +359,7 @@ apkSigningMethods.getKeystoreHash = async function getKeystoreHash () {
 };
 
 export default apkSigningMethods;
+
+/**
+ * @typedef {typeof apkSigningMethods} ApkSigningCommands
+ */

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -48,7 +48,7 @@ process.on('exit', () => {
  * @param {string} apks - The full path to the .apks file
  * @param {string|Array<String>} dstPath - The relative path to the destination file,
  * which is going to be extracted, where each path component is an array item
- * @returns {string} Full path to the extracted file
+ * @returns {Promise<string>} Full path to the extracted file
  * @throws {Error} If the requested item does not exist in the extracted archive or the provides
  * apks file is not a valid bundle
  */
@@ -90,7 +90,7 @@ async function extractFromApks (apks, dstPath) {
  *
  * @param {Array<String>} args - the list of bundletool arguments
  * @param {string} errorMsg - The customized error message string
- * @returns {string} the actual command stdout
+ * @returns {Promise<string>} the actual command stdout
  * @throws {Error} If bundletool jar does not exist in PATH or there was an error while
  * executing it
  */
@@ -129,7 +129,7 @@ apksUtilsMethods.execBundletool = async function execBundletool (args, errorMsg)
 
 /**
  * @param {string} specLocation - The full path to the generated device spec location
- * @returns {string} The same `specLocation` value
+ * @returns {Promise<string>} The same `specLocation` value
  * @throws {Error} If it is not possible to retrieve the spec for the current device
  */
 apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
@@ -146,18 +146,18 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
 
 /**
  * @typedef {Object} InstallMultipleApksOptions
- * @property {?number|string} timeout [20000] - The number of milliseconds to wait until
+ * @property {?number|string} [timeout=20000] - The number of milliseconds to wait until
  * the installation is completed
- * @property {string} timeoutCapName [androidInstallTimeout] - The timeout option name
+ * @property {string} [timeoutCapName=androidInstallTimeout] - The timeout option name
  * users can increase the timeout.
- * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
+ * @property {boolean} [allowTestPackages=false] - Set to true in order to allow test
  * packages installation.
- * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
+ * @property {boolean} [useSdcard=false] - Set to true to install the app on sdcard
  * instead of the device memory.
- * @property {boolean} grantPermissions [false] - Set to true in order to grant all the
+ * @property {boolean} [grantPermissions=false] - Set to true in order to grant all the
  * permissions requested in the application's manifest automatically after the installation
  * is completed under Android 6+.
- * @property {boolean} partialInstall [false] - Install apks partially. It is used for 'install-multiple'.
+ * @property {boolean} [partialInstall=false] - Install apks partially. It is used for 'install-multiple'.
  * https://android.stackexchange.com/questions/111064/what-is-a-partial-application-install-via-adb
  */
 
@@ -165,7 +165,7 @@ apksUtilsMethods.getDeviceSpec = async function getDeviceSpec (specLocation) {
  * Installs the given apks into the device under test
  *
  * @param {Array<string>} apkPathsToInstall - The full paths to install apks
- * @param {?installMultipleApksOptions} options - Installation options
+ * @param {?InstallMultipleApksOptions} options - Installation options
  */
 apksUtilsMethods.installMultipleApks = async function installMultipleApks (apkPathsToInstall, options = {}) {
   const installArgs = buildInstallArgs(await this.getApiLevel(), options);
@@ -229,7 +229,7 @@ apksUtilsMethods.installApks = async function installApks (apks, options = {}) {
  * Extracts and returns the full path to the master .apk file inside the bundle.
  *
  * @param {string} apks - The full path to the .apks file
- * @returns {string} The full path to the master bundle .apk
+ * @returns {Promise<string>} The full path to the master bundle .apk
  * @throws {Error} If there was an error while extracting/finding the file
  */
 apksUtilsMethods.extractBaseApk = async function extractBaseApk (apks) {
@@ -243,7 +243,7 @@ apksUtilsMethods.extractBaseApk = async function extractBaseApk (apks) {
  * @param {string} apks - The full path to the .apks file
  * @param {?string} language - The language abbreviation. The default language is
  * going to be selected if it is not set.
- * @returns {string} The full path to the corresponding language .apk or the master .apk
+ * @returns {Promise<string>} The full path to the corresponding language .apk or the master .apk
  * if language split is not enabled for the bundle.
  * @throws {Error} If there was an error while extracting/finding the file
  */
@@ -276,3 +276,8 @@ apksUtilsMethods.isTestPackageOnlyError = function isTestPackageOnlyError (outpu
 };
 
 export default apksUtilsMethods;
+
+
+/**
+ * @typedef {typeof apksUtilsMethods} ApksUtils
+ */

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -624,7 +624,7 @@ commands.getSmsList = async function getSmsList (opts = {}) {
  * to the destination input field before this method is called.
  *
  * @param {string} text The string to type
- * @returns {boolean} `true` if the input text has been successfully sent to adb
+ * @returns {Promise<boolean>} `true` if the input text has been successfully sent to adb
  */
 commands.typeUnicode = async function typeUnicode (text) {
   if (_.isNil(text)) {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "sinon": "^15.0.0",
     "temp": "^0.x",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.3"
+    "typescript": "~5.0.4"
   },
   "types": "./build/index.d.ts"
 }


### PR DESCRIPTION
- fix `getApksignerForOs` return type
- move options interface into its own file
- export `ApkSigningCommands` interface and attach to `ADB`
- export everything in `apks-utils` module; fix return values
- fix types in `tools/apk-signing`
- use TS v5.0.x