### PR TITLE
feat: add hint of signature scheme

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -625,9 +625,13 @@ apkUtilsMethods.install = async function install (appPath, options = {}) {
     const truncatedOutput = (!_.isString(output) || output.length <= 300) ?
       output : `${output.substr(0, 150)}...${output.substr(output.length - 150)}`;
     log.debug(`Install command stdout: ${truncatedOutput}`);
-    if (/\[INSTALL[A-Z_]+FAILED[A-Z_]+\]/.test(output)) {
+    if (this.isInstallFailed(output)) {
       if (this.isTestPackageOnlyError(output)) {
         const msg = `Set 'allowTestPackages' capability to true in order to allow test packages installation.`;
+        log.warn(msg);
+        throw new Error(`${output}\n${msg}`);
+      } else if (this.isInsufficientSignatureScheme(output)) {
+        const msg = `Please make sure if the apk has expected signature scheme version https://developer.android.com/tools/apksigner#options-sign.`;
         log.warn(msg);
         throw new Error(`${output}\n${msg}`);
       }

--- a/lib/tools/apks-utils.js
+++ b/lib/tools/apks-utils.js
@@ -275,6 +275,32 @@ apksUtilsMethods.isTestPackageOnlyError = function isTestPackageOnlyError (outpu
   return /\[INSTALL_FAILED_TEST_ONLY\]/.test(output);
 };
 
+
+/**
+ * Returns true if the given output had INSTALL_PARSE_FAILED_NO_CERTIFICATES word.
+ * Usually the apk does not have proper signature scheme. It needs to be signed properly,
+ * or the apk needs to be updated.
+ * https://developer.android.com/tools/apksigner#options-sign
+ *
+ * @param {string} output - The adb command output
+ * @returns {boolean} If the output includes INSTALL_PARSE_FAILED_NO_CERTIFICATES
+ */
+apksUtilsMethods.isInsufficientSignatureScheme = function isInsufficientSignatureScheme (output) {
+  return /\[INSTALL_PARSE_FAILED_NO_CERTIFICATES\]/.test(output);
+};
+
+
+/**
+ * Returns true if the given output includes INSTALL and FAILED words.
+ *
+ * @param {string} output - The adb command output
+ * @returns {boolean} If the output includes both INSTALL and FAILED
+ */
+apksUtilsMethods.isInstallFailed = function isInstallFailed (output) {
+  return /\[INSTALL[A-Z_]+FAILED[A-Z_]+\]/.test(output);
+};
+
+
 export default apksUtilsMethods;
 
 

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -983,12 +983,30 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     });
   });
   describe('isTestPackageOnly', function () {
-    it('should return true on INSTALL_FAILED_TEST_ONLY meesage found in adb install output', function () {
+    it('should return true on INSTALL_FAILED_TEST_ONLY message found in adb install output', function () {
       apksUtilsMethods.isTestPackageOnlyError('[INSTALL_FAILED_TEST_ONLY]').should.equal(true);
       apksUtilsMethods.isTestPackageOnlyError(' [INSTALL_FAILED_TEST_ONLY] ').should.equal(true);
     });
-    it('should return false on INSTALL_FAILED_TEST_ONLY meesage not found in adb install output', function () {
+    it('should return false on INSTALL_FAILED_TEST_ONLY message not found in adb install output', function () {
       apksUtilsMethods.isTestPackageOnlyError('[INSTALL_FAILED_OTHER]').should.equal(false);
+    });
+  });
+  describe('isInstallFailed', function () {
+    it('should return true on INSTALL and FAILED words found in adb install output', function () {
+      apksUtilsMethods.isInstallFailed('[INSTALL_PARSE_FAILED_NO_CERTIFICATES]').should.equal(true);
+      apksUtilsMethods.isInstallFailed(' [INSTALL_FAILED_TEST_ONLY] ').should.equal(true);
+    });
+    it('should return false on INSTALL and FAILED words found in adb install output', function () {
+      apksUtilsMethods.isInstallFailed('[INSTALL_PARSE_NO_CERTIFICATE]').should.equal(false);
+    });
+  });
+  describe('isInsufficientSignatureScheme', function () {
+    it('should return true on INSTALL_PARSE_FAILED_NO_CERTIFICATES message found in adb install output', function () {
+      apksUtilsMethods.isInsufficientSignatureScheme('[INSTALL_PARSE_FAILED_NO_CERTIFICATES]').should.equal(true);
+      apksUtilsMethods.isInsufficientSignatureScheme(' [INSTALL_PARSE_FAILED_NO_CERTIFICATES] ').should.equal(true);
+    });
+    it('should return false on INSTALL_PARSE_FAILED_NO_CERTIFICATES message not found in adb install output', function () {
+      apksUtilsMethods.isInsufficientSignatureScheme('[INSTALL_PARSE_FAILED_NO_CERTIFICATE]').should.equal(false);
     });
   });
   describe('installMultipleApks', function () {


### PR DESCRIPTION
Adds a guide to check the signature scheme if the installation command got INSTALL_PARSE_FAILED_NO_CERTIFICATES

closes https://github.com/appium/appium/issues/18878