### PR TITLE
fix: Move utf7 encoding primitives to the module codebase

### DIFF
--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -3,7 +3,7 @@ import { parseJsonData } from '../helpers.js';
 import _ from 'lodash';
 import { util, timing } from '@appium/support';
 import { waitForCondition } from 'asyncbox';
-import { imap } from 'utf7';
+import { imap } from './utf7';
 import { SubProcess } from 'teen_process';
 import B from 'bluebird';
 

--- a/lib/tools/utf7.js
+++ b/lib/tools/utf7.js
@@ -1,0 +1,153 @@
+/*
+ * The code below has been adopted from https://www.npmjs.com/package/utf7
+ */
+
+/**
+ * @param {number} length
+ * @returns {Buffer}
+ */
+function allocateAsciiBuffer(length) {
+  return Buffer.alloc(length, 'ascii');
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function _encode(str) {
+  const b = allocateAsciiBuffer(str.length * 2);
+  for (let i = 0, bi = 0; i < str.length; i++) {
+    // Note that we can't simply convert a UTF-8 string to Base64 because
+    // UTF-8 uses a different encoding. In modified UTF-7, all characters
+    // are represented by their two byte Unicode ID.
+    const c = str.charCodeAt(i);
+    // Upper 8 bits shifted into lower 8 bits so that they fit into 1 byte.
+    b[bi++] = c >> 8;
+    // Lower 8 bits. Cut off the upper 8 bits so that they fit into 1 byte.
+    b[bi++] = c & 0xFF;
+  }
+  // Modified Base64 uses , instead of / and omits trailing =.
+  return b.toString('base64').replace(/=+$/, '');
+}
+
+/**
+ * @param {string} str
+ * @returns {Buffer}
+ */
+function allocateBase64Buffer(str) {
+  return Buffer.from(str, 'base64');
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function _decode(str) {
+  const b = allocateBase64Buffer(str);
+  const r = [];
+  for (let i = 0; i < b.length;) {
+    // Calculate charcode from two adjacent bytes.
+    r.push(String.fromCharCode(b[i++] << 8 | b[i++]));
+  }
+  return r.join('');
+}
+
+/**
+ * Escape RegEx from http://simonwillison.net/2006/Jan/20/escape/
+ *
+ * @param {string} chars
+ * @returns {string}
+ */
+function escape(chars) {
+  return chars.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+// Character classes defined by RFC 2152.
+const setD = 'A-Za-z0-9' + escape(`'(),-./:?`);
+const setO = escape(`!"#$%&*;<=>@[]^_'{|}`);
+const setW = escape(` \r\n\t`);
+
+// Stores compiled regexes for various replacement pattern.
+const regexes = {};
+const regexAll = new RegExp(`[^${setW}${setD}${setO}]+`, 'g');
+
+export const imap = {};
+
+/**
+ * RFC 2152 UTF-7 encoding.
+ *
+ * @param {string} str
+ * @param {string?} mask
+ * @returns {string}
+ */
+export const encode = function encode(str, mask = null) {
+  // Generate a RegExp object from the string of mask characters.
+  if (!mask) {
+    mask = '';
+  }
+  if (!regexes[mask]) {
+    regexes[mask] = new RegExp(`[^${setD}${escape(mask)}]+`, 'g');
+  }
+
+  // We replace subsequent disallowed chars with their escape sequence.
+  return str.replace(regexes[mask], (chunk) =>
+    // + is represented by an empty sequence +-, otherwise call encode().
+    `+${chunk === '+' ? '' : _encode(chunk)}-`
+  );
+};
+
+/**
+ * RFC 2152 UTF-7 encoding with all optionals.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+exports.encodeAll = function encodeAll(str) {
+  // We replace subsequent disallowed chars with their escape sequence.
+  return str.replace(regexAll, (chunk) =>
+    // + is represented by an empty sequence +-, otherwise call encode().
+    `+${chunk === '+' ? '' : _encode(chunk)}-`
+  );
+};
+
+/**
+ * RFC 3501, section 5.1.3 UTF-7 encoding.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+imap.encode = function encode(str) {
+  // All printable ASCII chars except for & must be represented by themselves.
+  // We replace subsequent non-representable chars with their escape sequence.
+  return str.replace(/&/g, '&-').replace(/[^\x20-\x7e]+/g, (chunk) => {
+    // & is represented by an empty sequence &-, otherwise call encode().
+    chunk = (chunk === '&' ? '' : _encode(chunk)).replace(/\//g, ',');
+    return `&${chunk}-`;
+  });
+};
+
+/**
+ * RFC 2152 UTF-7 decoding.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export const decode = function decode(str) {
+  return str.replace(/\+([A-Za-z0-9/]*)-?/gi, (_, chunk) =>
+    // &- represents &.
+    chunk === '' ? '+' : _decode(chunk)
+  );
+};
+
+/**
+ * RFC 3501, section 5.1.3 UTF-7 decoding.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+imap.decode = function decode(str) {
+  return str.replace(/&([^-]*)-/g, (_, chunk) =>
+    // &- represents &.
+    chunk === '' ? '&' : _decode(chunk.replace(/,/g, '/'))
+  );
+};

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "lru-cache": "^10.0.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.0.1",
-    "utf7": "^1.0.2"
+    "teen_process": "^2.0.1"
   },
   "devDependencies": {
     "@appium/eslint-config-appium": "^6.0.0",


### PR DESCRIPTION
The https://www.npmjs.com/package/utf7 package has been released 7 years ago for the last time and thus has vulnerable dependencies:
```
node_modules/@babel/core/node_modules/semver
node_modules/@babel/helper-compilation-targets/node_modules/semver
node_modules/istanbul-lib-instrument/node_modules/semver
node_modules/make-dir/node_modules/semver
node_modules/npm-run-all/node_modules/semver
node_modules/read-pkg-up/node_modules/semver
node_modules/read-pkg/node_modules/semver
node_modules/utf7/node_modules/semver
  utf7  >=1.0.2
  Depends on vulnerable versions of semver
  node_modules/utf7
    appium-adb  >=7.20.0
    Depends on vulnerable versions of utf7
    node_modules/appium-adb

vm2  *
Severity: critical
vm2 Sandbox Escape vulnerability - https://github.com/advisories/GHSA-cchq-frgv-rjh5
vm2 Sandbox Escape vulnerability - https://github.com/advisories/GHSA-g644-9gfx-q4q4
No fix available
```

I have ported the actual code from the original module (there's not much) to a local helper file to get rid of vulnerable dependencies