### PR TITLE
feat: add isSettingsAppServiceRunningInForeground to check the settings' service existence better

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1953,6 +1953,16 @@ methods.takeScreenshot = async function takeScreenshot (displayId) {
   return stdout;
 };
 
+/**
+ * Return the result of 'adb shell dumpsys activity services <packagename>'
+ *
+ * @this {import('../adb.js').ADB}
+ * @returns {Promise<string>} the result of 'adb shell dumpsys activity services <packagename>'
+ */
+methods.getActivityService = async function getActivityService (pkgName) {
+  return await this.shell(['dumpsys', 'activity', 'services', pkgName]);
+};
+
 export default methods;
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1953,16 +1953,6 @@ methods.takeScreenshot = async function takeScreenshot (displayId) {
   return stdout;
 };
 
-/**
- * Return the result of 'adb shell dumpsys activity services <packagename>'
- *
- * @this {import('../adb.js').ADB}
- * @returns {Promise<string>} the result of 'adb shell dumpsys activity services <packagename>'
- */
-methods.getActivityService = async function getActivityService (pkgName) {
-  return await this.shell(['dumpsys', 'activity', 'services', pkgName]);
-};
-
 export default methods;
 
 /**

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -59,7 +59,7 @@ commands.isSettingsAppServiceRunningInForeground = async function isSettingsAppS
 
   // The foreground service is available since api level 26,
   // thus this method works only for api level 26+.
-  const output = await this.getActivityService(SETTINGS_HELPER_ID);
+  const output = await this.shell(['dumpsys', 'activity', 'services', SETTINGS_HELPER_ID]);
   return output.includes(FOREGROUND_APP_KEYWORD);
 };
 

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -52,12 +52,12 @@ const commands = {};
 commands.hasRunningForegroundService = async function hasRunningForegroundService () {
   try {
     const output = await this.getActivityService(SETTINGS_HELPER_ID);
-    return (output.includes(FORE_GROUND_APP_KEYWORD))
+    return (output.includes(FORE_GROUND_APP_KEYWORD));
   } catch (e) {
     log.warn(`Got an error in getting the foreground service state: ${e.message}`);
   }
   return false;
-}
+};
 
 /**
  * @typedef {Object} SettingsAppStartupOptions
@@ -77,16 +77,15 @@ commands.hasRunningForegroundService = async function hasRunningForegroundServic
  * @returns {Promise<import('../adb.js').ADB>} self instance for chaining
  */
 commands.requireRunningSettingsApp = async function requireRunningSettingsApp (opts = {}) {
-  const {
-    timeout = 5000,
-    shouldRestoreCurrentApp = false
-  } = opts;
-
   if (await this.hasRunningForegroundService()) {
     return this;
   }
 
   log.debug('Starting Appium Settings app');
+  const {
+    timeout = 5000,
+    shouldRestoreCurrentApp = false
+  } = opts;
   let appPackage;
   if (shouldRestoreCurrentApp) {
     try {

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -59,6 +59,9 @@ commands.isSettingsAppServiceRunningInForeground = async function isSettingsAppS
 
   // The foreground service is available since api level 26,
   // thus this method works only for api level 26+.
+
+  // 'dumpsys activity services <package>' had slightly better performance
+  // than 'dumpsys activity services' and parsing the foreground apps.
   const output = await this.shell(['dumpsys', 'activity', 'services', SETTINGS_HELPER_ID]);
   return output.includes(FOREGROUND_APP_KEYWORD);
 };

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -49,7 +49,7 @@ const commands = {};
  * since it does not have the foreground service.
  *
  * @this {import('../adb.js').ADB}
-* @throws {Error} If the method gets an error in the adb shell execution.
+ * @throws {Error} If the method gets an error in the adb shell execution.
  * @returns {Promise<boolean>} Return true if the device has running settings app foreground service.
  */
 commands.isSettingsAppServiceRunningInForeground = async function isSettingsAppServiceRunningInForeground () {

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -39,7 +39,7 @@ const GPS_CACHE_REFRESHED_LOGS = [
 
 const GPS_COORDINATES_PATTERN = /data="(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)"/;
 
-const FORE_GROUND_APP_KEYWORD = 'isForeground=true';
+const FOREGROUND_APP_KEYWORD = 'isForeground=true';
 
 const commands = {};
 
@@ -49,22 +49,18 @@ const commands = {};
  * since it does not have the foreground service.
  *
  * @this {import('../adb.js').ADB}
+* @throws {Error} If the method gets an error in the adb shell execution.
  * @returns {Promise<boolean>} Return true if the device has running settings app foreground service.
  */
-commands.hasRunningSettingsAppForegroundService = async function hasRunningSettingsAppForegroundService () {
+commands.isSettingsAppServiceRunningInForeground = async function isSettingsAppServiceRunningInForeground () {
   if (await this.getApiLevel() < 26) {
     return await this.processExists(SETTINGS_HELPER_ID);
   }
 
   // The foreground service is available since api level 26,
   // thus this method works only for api level 26+.
-  try {
-    const output = await this.getActivityService(SETTINGS_HELPER_ID);
-    return (output.includes(FORE_GROUND_APP_KEYWORD));
-  } catch (e) {
-    log.warn(`Got an error in getting the foreground service state: ${e.message}`);
-  }
-  return false;
+  const output = await this.getActivityService(SETTINGS_HELPER_ID);
+  return output.includes(FOREGROUND_APP_KEYWORD);
 };
 
 /**
@@ -89,7 +85,7 @@ commands.hasRunningSettingsAppForegroundService = async function hasRunningSetti
  * @returns {Promise<import('../adb.js').ADB>} self instance for chaining
  */
 commands.requireRunningSettingsApp = async function requireRunningSettingsApp (opts = {}) {
-  if (await this.hasRunningSettingsAppForegroundService()) {
+  if (await this.isSettingsAppServiceRunningInForeground()) {
     return this;
   }
 
@@ -115,7 +111,7 @@ commands.requireRunningSettingsApp = async function requireRunningSettingsApp (o
     waitForLaunch: false,
   });
   try {
-    await waitForCondition(async () => await this.hasRunningSettingsAppForegroundService(), {
+    await waitForCondition(async () => await this.isSettingsAppServiceRunningInForeground(), {
       waitMs: timeout,
       intervalMs: 300,
     });

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -88,7 +88,7 @@ commands.requireRunningSettingsApp = async function requireRunningSettingsApp (o
   log.debug('Starting Appium Settings app');
   const {
     timeout = 5000,
-    shouldRestoreCurrentApp = false
+    shouldRestoreCurrentApp = false,
   } = opts;
   let appPackage;
   if (shouldRestoreCurrentApp) {

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -49,7 +49,7 @@ const commands = {};
  * @this {import('../adb.js').ADB}
  * @returns {Promise<boolean>} Return true if the device has running settings app foreground service.
  */
-commands.hasRunningForegroundService = async function hasRunningForegroundService () {
+commands.hasRunningSettingsAppForegroundService = async function hasRunningSettingsAppForegroundService () {
   try {
     const output = await this.getActivityService(SETTINGS_HELPER_ID);
     return (output.includes(FORE_GROUND_APP_KEYWORD));
@@ -69,7 +69,11 @@ commands.hasRunningForegroundService = async function hasRunningForegroundServic
 
 /**
  * Ensures that Appium Settings helper application is running
- * and starts it if necessary
+ * and starts it if necessary.
+ *
+ * The settings app process could keep working by 'android.service.notification.NotificationListenerService cmp=io.appium.settings/.NLService'
+ * while the app process was killed, or forcefully stopped, or the app was just installed.
+ * In the case, the io.appium.settings process exists but the foreground service hasn't been started yet.
  *
  * @this {import('../adb.js').ADB}
  * @param {SettingsAppStartupOptions} [opts={}]
@@ -77,7 +81,7 @@ commands.hasRunningForegroundService = async function hasRunningForegroundServic
  * @returns {Promise<import('../adb.js').ADB>} self instance for chaining
  */
 commands.requireRunningSettingsApp = async function requireRunningSettingsApp (opts = {}) {
-  if (await this.hasRunningForegroundService()) {
+  if (await this.hasRunningSettingsAppForegroundService()) {
     return this;
   }
 
@@ -103,7 +107,7 @@ commands.requireRunningSettingsApp = async function requireRunningSettingsApp (o
     waitForLaunch: false,
   });
   try {
-    await waitForCondition(async () => await this.hasRunningForegroundService(), {
+    await waitForCondition(async () => await this.hasRunningSettingsAppForegroundService(), {
       waitMs: timeout,
       intervalMs: 300,
     });

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -39,7 +39,25 @@ const GPS_CACHE_REFRESHED_LOGS = [
 
 const GPS_COORDINATES_PATTERN = /data="(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)"/;
 
+const FORE_GROUND_APP_KEYWORD = 'isForeground=true';
+
 const commands = {};
+
+/**
+ * If the io.appium.settings package has running foreground service.
+ *
+ * @this {import('../adb.js').ADB}
+ * @returns {Promise<boolean>} Return true if the device has running settings app foreground service.
+ */
+commands.hasRunningForegroundService = async function hasRunningForegroundService () {
+  try {
+    const output = await this.getActivityService(SETTINGS_HELPER_ID);
+    return (output.includes(FORE_GROUND_APP_KEYWORD))
+  } catch (e) {
+    log.warn(`Got an error in getting the foreground service state: ${e.message}`);
+  }
+  return false;
+}
 
 /**
  * @typedef {Object} SettingsAppStartupOptions
@@ -47,8 +65,6 @@ const commands = {};
  * to wait until the app has started
  * @property {boolean} [shouldRestoreCurrentApp=false] Whether to restore
  * the activity which was the current one before Settings startup
- * @property {boolean} [forceStartSettingsApp=false] Whether to start
- * the Settings app forcefully regardless of the current app process status.
  */
 
 /**
@@ -63,11 +79,10 @@ const commands = {};
 commands.requireRunningSettingsApp = async function requireRunningSettingsApp (opts = {}) {
   const {
     timeout = 5000,
-    shouldRestoreCurrentApp = false,
-    forceStartSettingsApp = false
+    shouldRestoreCurrentApp = false
   } = opts;
 
-  if (forceStartSettingsApp === false && await this.processExists(SETTINGS_HELPER_ID)) {
+  if (await this.hasRunningForegroundService()) {
     return this;
   }
 
@@ -89,7 +104,7 @@ commands.requireRunningSettingsApp = async function requireRunningSettingsApp (o
     waitForLaunch: false,
   });
   try {
-    await waitForCondition(async () => await this.processExists(SETTINGS_HELPER_ID), {
+    await waitForCondition(async () => await this.hasRunningForegroundService(), {
       waitMs: timeout,
       intervalMs: 300,
     });

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -47,6 +47,8 @@ const commands = {};
  * to wait until the app has started
  * @property {boolean} [shouldRestoreCurrentApp=false] Whether to restore
  * the activity which was the current one before Settings startup
+ * @property {boolean} [forceStartSettingsApp=false] Whether to start
+ * the Settings app forcefully regardless of the current app process status.
  */
 
 /**
@@ -59,15 +61,17 @@ const commands = {};
  * @returns {Promise<import('../adb.js').ADB>} self instance for chaining
  */
 commands.requireRunningSettingsApp = async function requireRunningSettingsApp (opts = {}) {
-  if (await this.processExists(SETTINGS_HELPER_ID)) {
+  const {
+    timeout = 5000,
+    shouldRestoreCurrentApp = false,
+    forceStartSettingsApp = false
+  } = opts;
+
+  if (forceStartSettingsApp === false && await this.processExists(SETTINGS_HELPER_ID)) {
     return this;
   }
 
   log.debug('Starting Appium Settings app');
-  const {
-    timeout = 5000,
-    shouldRestoreCurrentApp = false,
-  } = opts;
   let appPackage;
   if (shouldRestoreCurrentApp) {
     try {

--- a/lib/tools/settings-client-commands.js
+++ b/lib/tools/settings-client-commands.js
@@ -45,11 +45,19 @@ const commands = {};
 
 /**
  * If the io.appium.settings package has running foreground service.
+ * It returns the io.appium.settings's process existence for api level 25 and lower
+ * since it does not have the foreground service.
  *
  * @this {import('../adb.js').ADB}
  * @returns {Promise<boolean>} Return true if the device has running settings app foreground service.
  */
 commands.hasRunningSettingsAppForegroundService = async function hasRunningSettingsAppForegroundService () {
+  if (await this.getApiLevel() < 26) {
+    return await this.processExists(SETTINGS_HELPER_ID);
+  }
+
+  // The foreground service is available since api level 26,
+  // thus this method works only for api level 26+.
   try {
     const output = await this.getActivityService(SETTINGS_HELPER_ID);
     return (output.includes(FORE_GROUND_APP_KEYWORD));

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -1244,4 +1244,107 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       await adb.setDefaultHiddenApiPolicy();
     });
   });
+
+  describe('hasRunningSettingsAppForegroundService', function () {
+    it('should return true if the output includes isForeground=true', async function () {
+      // this case is when 'io.appium.settings/.NLService' was started AND
+      // the settings app is running as a foreground service.
+      // This case could happen when only 'shell cmd notification allow_listener io.appium.settings/.NLService' is
+      // called but the process hasn't been started from io.appium.settings/.ForegroundService,
+      // or the app process was stopped by "Force Stop" via the system settings app.
+      const getActivityServiceOutput = `
+          ACTIVITY MANAGER SERVICES (dumpsys activity services)
+            User 0 active services:
+            * ServiceRecord{f0ad90b u0 io.appium.settings/.NLService}
+              intent={act=android.service.notification.NotificationListenerService cmp=io.appium.settings/.NLService}
+              packageName=io.appium.settings
+              processName=io.appium.settings
+              permission=android.permission.BIND_NOTIFICATION_LISTENER_SERVICE
+              baseDir=/data/app/~~fHuRc6u9ehtAcXvuXy-fiw==/io.appium.settings-wJRwd1HrrbVG5ZINWuHi5Q==/base.apk
+              dataDir=/data/user/0/io.appium.settings
+              app=ProcessRecord{1d61746 18302:io.appium.settings/u0a320}
+              whitelistManager=true
+              allowWhileInUsePermissionInFgs=true
+              startForegroundCount=0
+              recentCallingPackage=android
+              createTime=-6m21s859ms startingBgTimeout=--
+              lastActivity=-6m21s783ms restartTime=-6m21s783ms createdFromFg=true
+              Bindings:
+              * IntentBindRecord{a5d675f CREATE}:
+                intent={act=android.service.notification.NotificationListenerService cmp=io.appium.settings/.NLService}
+                binder=android.os.BinderProxy@1be25ac
+                requested=true received=true hasBound=true doRebind=false
+                * Client AppBindRecord{c78a275 ProcessRecord{3f853b1 1847:system/1000}}
+                  Per-process Connections:
+                    ConnectionRecord{fbf1188 u0 CR FGS !PRCP io.appium.settings/.NLService:@339692b}
+              All Connections:
+                ConnectionRecord{fbf1188 u0 CR FGS !PRCP io.appium.settings/.NLService:@339692b}
+
+            * ServiceRecord{e7a180b u0 io.appium.settings/.ForegroundService}
+              intent={act=start cmp=io.appium.settings/.ForegroundService}
+              packageName=io.appium.settings
+              processName=io.appium.settings
+              permission=android.permission.FOREGROUND_SERVICE
+              baseDir=/data/app/~~fHuRc6u9ehtAcXvuXy-fiw==/io.appium.settings-wJRwd1HrrbVG5ZINWuHi5Q==/base.apk
+              dataDir=/data/user/0/io.appium.settings
+              app=ProcessRecord{1d61746 18302:io.appium.settings/u0a320}
+              allowWhileInUsePermissionInFgs=true
+              startForegroundCount=1
+              recentCallingPackage=io.appium.settings
+              isForeground=true foregroundId=1 foregroundNoti=Notification(channel=main_channel shortcut=null contentView=null vibrate=null sound=null defaults=0x0 flags=0x62 color=0x00000000 vis=PRIVATE)
+              createTime=-5m1s703ms startingBgTimeout=--
+              lastActivity=-5m1s702ms restartTime=-5m1s702ms createdFromFg=true
+              startRequested=true delayedStop=false stopIfKilled=false callStart=true lastStartId=1
+
+            Connection bindings to services:
+            * ConnectionRecord{fbf1188 u0 CR FGS !PRCP io.appium.settings/.NLService:@339692b}
+              binding=AppBindRecord{c78a275 io.appium.settings/.NLService:system}
+              conn=android.app.LoadedApk$ServiceDispatcher$InnerConnection@339692b flags=0x5000101`;
+      mocks.adb.expects('shell').once().returns(getActivityServiceOutput);
+      await adb.hasRunningSettingsAppForegroundService().should.eventually.true;
+    });
+    it('should return false if the output does not include isForeground=true', async function () {
+      // this case is when 'io.appium.settings/.NLService' was started but
+      // the settings app hasn't been started as a foreground service yet.
+      const getActivityServiceOutput = `
+        ACTIVITY MANAGER SERVICES (dumpsys activity services)
+          User 0 active services:
+          * ServiceRecord{41dde04 u0 io.appium.settings/.NLService}
+            intent={act=android.service.notification.NotificationListenerService cmp=io.appium.settings/.NLService}
+            packageName=io.appium.settings
+            processName=io.appium.settings
+            permission=android.permission.BIND_NOTIFICATION_LISTENER_SERVICE
+            baseDir=/data/app/~~fHuRc6u9ehtAcXvuXy-fiw==/io.appium.settings-wJRwd1HrrbVG5ZINWuHi5Q==/base.apk
+            dataDir=/data/user/0/io.appium.settings
+            app=ProcessRecord{d3b2ed1 18588:io.appium.settings/u0a320}
+            whitelistManager=true
+            allowWhileInUsePermissionInFgs=true
+            startForegroundCount=0
+            recentCallingPackage=android
+            createTime=-2s362ms startingBgTimeout=--
+            lastActivity=-2s283ms restartTime=-2s283ms createdFromFg=true
+            Bindings:
+            * IntentBindRecord{26ce8cd CREATE}:
+              intent={act=android.service.notification.NotificationListenerService cmp=io.appium.settings/.NLService}
+              binder=android.os.BinderProxy@2dbc582
+              requested=true received=true hasBound=true doRebind=false
+              * Client AppBindRecord{24ce493 ProcessRecord{3f853b1 1847:system/1000}}
+                Per-process Connections:
+                  ConnectionRecord{8f3e709 u0 CR FGS !PRCP io.appium.settings/.NLService:@d481010}
+                  ConnectionRecord{bd3f9f8 u0 CR FGS !PRCP io.appium.settings/.NLService:@1c7ed5b}
+            All Connections:
+              ConnectionRecord{bd3f9f8 u0 CR FGS !PRCP io.appium.settings/.NLService:@1c7ed5b}
+              ConnectionRecord{8f3e709 u0 CR FGS !PRCP io.appium.settings/.NLService:@d481010}
+
+          Connection bindings to services:
+          * ConnectionRecord{bd3f9f8 u0 CR FGS !PRCP io.appium.settings/.NLService:@1c7ed5b}
+            binding=AppBindRecord{24ce493 io.appium.settings/.NLService:system}
+            conn=android.app.LoadedApk$ServiceDispatcher$InnerConnection@1c7ed5b flags=0x5000101
+          * ConnectionRecord{8f3e709 u0 CR FGS !PRCP io.appium.settings/.NLService:@d481010}
+            binding=AppBindRecord{24ce493 io.appium.settings/.NLService:system}
+            conn=android.app.LoadedApk$ServiceDispatcher$InnerConnection@d481010 flags=0x5000101`;
+      mocks.adb.expects('shell').once().returns(getActivityServiceOutput);
+      await adb.hasRunningSettingsAppForegroundService().should.eventually.false;
+    });
+  });
 }));

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -1300,7 +1300,9 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
             * ConnectionRecord{fbf1188 u0 CR FGS !PRCP io.appium.settings/.NLService:@339692b}
               binding=AppBindRecord{c78a275 io.appium.settings/.NLService:system}
               conn=android.app.LoadedApk$ServiceDispatcher$InnerConnection@339692b flags=0x5000101`;
-      mocks.adb.expects('shell').once().returns(getActivityServiceOutput);
+      mocks.adb.expects('getApiLevel').once().returns(26);
+      mocks.adb.expects('processExists').never();
+      mocks.adb.expects('getActivityService').once().returns(getActivityServiceOutput);
       await adb.hasRunningSettingsAppForegroundService().should.eventually.true;
     });
     it('should return false if the output does not include isForeground=true', async function () {
@@ -1343,8 +1345,18 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
           * ConnectionRecord{8f3e709 u0 CR FGS !PRCP io.appium.settings/.NLService:@d481010}
             binding=AppBindRecord{24ce493 io.appium.settings/.NLService:system}
             conn=android.app.LoadedApk$ServiceDispatcher$InnerConnection@d481010 flags=0x5000101`;
-      mocks.adb.expects('shell').once().returns(getActivityServiceOutput);
+
+      mocks.adb.expects('getApiLevel').once().returns(26);
+      mocks.adb.expects('processExists').never();
+      mocks.adb.expects('getActivityService').once().returns(getActivityServiceOutput);
       await adb.hasRunningSettingsAppForegroundService().should.eventually.false;
     });
+    it('should rely on processExists for api level 25 and lower', async function () {
+      mocks.adb.expects('getApiLevel').once().returns(25);
+      mocks.adb.expects('processExists').once().returns(1000);
+      mocks.adb.expects('getActivityService').never();
+      await adb.hasRunningSettingsAppForegroundService().should.eventually.eql(1000);
+    });
+
   });
 }));

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -1302,7 +1302,7 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
               conn=android.app.LoadedApk$ServiceDispatcher$InnerConnection@339692b flags=0x5000101`;
       mocks.adb.expects('getApiLevel').once().returns(26);
       mocks.adb.expects('processExists').never();
-      mocks.adb.expects('getActivityService').once().returns(getActivityServiceOutput);
+      mocks.adb.expects('shell').once().withArgs(['dumpsys', 'activity', 'services', 'io.appium.settings']).returns(getActivityServiceOutput);
       await adb.isSettingsAppServiceRunningInForeground().should.eventually.true;
     });
     it('should return false if the output does not include isForeground=true', async function () {
@@ -1348,13 +1348,13 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
 
       mocks.adb.expects('getApiLevel').once().returns(26);
       mocks.adb.expects('processExists').never();
-      mocks.adb.expects('getActivityService').once().returns(getActivityServiceOutput);
+      mocks.adb.expects('shell').once().withArgs(['dumpsys', 'activity', 'services', 'io.appium.settings']).returns(getActivityServiceOutput);
       await adb.isSettingsAppServiceRunningInForeground().should.eventually.false;
     });
     it('should rely on processExists for api level 25 and lower', async function () {
       mocks.adb.expects('getApiLevel').once().returns(25);
       mocks.adb.expects('processExists').once().returns(1000);
-      mocks.adb.expects('getActivityService').never();
+      mocks.adb.expects('shell').never().withArgs(['dumpsys', 'activity', 'services', 'io.appium.settings']);
       await adb.isSettingsAppServiceRunningInForeground().should.eventually.eql(1000);
     });
 

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -1245,7 +1245,7 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
     });
   });
 
-  describe('hasRunningSettingsAppForegroundService', function () {
+  describe('isSettingsAppServiceRunningInForeground', function () {
     it('should return true if the output includes isForeground=true', async function () {
       // this case is when 'io.appium.settings/.NLService' was started AND
       // the settings app is running as a foreground service.
@@ -1303,7 +1303,7 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       mocks.adb.expects('getApiLevel').once().returns(26);
       mocks.adb.expects('processExists').never();
       mocks.adb.expects('getActivityService').once().returns(getActivityServiceOutput);
-      await adb.hasRunningSettingsAppForegroundService().should.eventually.true;
+      await adb.isSettingsAppServiceRunningInForeground().should.eventually.true;
     });
     it('should return false if the output does not include isForeground=true', async function () {
       // this case is when 'io.appium.settings/.NLService' was started but
@@ -1349,13 +1349,13 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
       mocks.adb.expects('getApiLevel').once().returns(26);
       mocks.adb.expects('processExists').never();
       mocks.adb.expects('getActivityService').once().returns(getActivityServiceOutput);
-      await adb.hasRunningSettingsAppForegroundService().should.eventually.false;
+      await adb.isSettingsAppServiceRunningInForeground().should.eventually.false;
     });
     it('should rely on processExists for api level 25 and lower', async function () {
       mocks.adb.expects('getApiLevel').once().returns(25);
       mocks.adb.expects('processExists').once().returns(1000);
       mocks.adb.expects('getActivityService').never();
-      await adb.hasRunningSettingsAppForegroundService().should.eventually.eql(1000);
+      await adb.isSettingsAppServiceRunningInForeground().should.eventually.eql(1000);
     });
 
   });


### PR DESCRIPTION
It looks like a command below launches `io.appium.settings` process, which can be found by `[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell pgrep -f \(\[\[:blank:\]\]\|\^\)io\.appium\.settings\(\[\[:blank:\]\]\|\$\)'`, but the app was not started in the background properly (no the app in the notification). It causes io.appium.settings process did not start properly situation, thus for example `driver.location` to get the location/set location causes an error because the `io.appium.settings` was not started properly with `this.startApp`.


We must start the settings app forcefully once with `this.startApp` to start the settings app process properly.

```
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell cmd notification allow_listener io.appium.settings/.NLService'
```

```
  await this.startApp({
    pkg: SETTINGS_HELPER_ID,
    activity: SETTINGS_HELPER_MAIN_ACTIVITY,
    action: 'android.intent.action.MAIN',
    category: 'android.intent.category.LAUNCHER',
    stopApp: false,
    waitForLaunch: false,
  });
```

I also found `-g` option could launch the io.appium.settings app process on Android 11. I saw the behavior was not always, but actually occurred. Then, `await this.processExists(SETTINGS_HELPER_ID)` skipped the io.appium.settings process with `this.startApp` while uia2 driver must have started the settings app with `this.startApp` to make the get location etc work properly


https://github.com/appium/appium-android-driver/pull/895 is this PR's usage