### PR TITLE
chore: Always use reboot_readiness service to detect emulator startup  for API 31+

### DIFF
--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -35,7 +35,6 @@ const SDK_BINARY_ROOTS = [
 const MIN_DELAY_ADB_API_LEVEL = 28;
 const REQUIRED_SERVICES = ['activity', 'package', 'mount'];
 const SUBSYSTEM_STATE_OK = 'Subsystem state: true';
-const NO_READINESS_SERVICE_ERROR = `Can't find service: reboot_readiness`;
 
 /**
  * Retrieve full path to the given binary.
@@ -960,7 +959,7 @@ systemCallMethods.launchAVD = async function launchAVD (avdName, opts = {}) {
       throw new Error(`'${avdName}' Emulator has failed to boot: ${e.stderr || e.message}`);
     }
   }
-  await this.waitForEmulatorReady(readyTimeout - timer.getDuration().asMilliSeconds);
+  await this.waitForEmulatorReady(Math.trunc(readyTimeout - timer.getDuration().asMilliSeconds));
   return proc;
 };
 
@@ -1023,38 +1022,34 @@ systemCallMethods.getVersion = _.memoize(async function getVersion () {
  * @throws {Error} If the emulator is not ready within the given timeout.
  */
 systemCallMethods.waitForEmulatorReady = async function waitForEmulatorReady (timeoutMs = 20000) {
+  log.debug(`Waiting up to ${timeoutMs}ms for the emulator to be ready`);
   if (await this.getApiLevel() >= 31) {
-    let reason;
+    /** @type {string|undefined} */
+    let state;
     try {
-      let hasReadinessService = true;
       await waitForCondition(async () => {
         try {
-          reason = await this.shell(['cmd', 'reboot_readiness', 'check-subsystems-state', '--list-blocking']);
+          state = await this.shell([
+            'cmd', 'reboot_readiness', 'check-subsystems-state', '--list-blocking'
+          ]);
         } catch (err) {
           // https://github.com/appium/appium/issues/18717
-          reason = err.stdout || err.stderr;
-          if (_.includes(reason, NO_READINESS_SERVICE_ERROR)) {
-            hasReadinessService = false;
-            return true;
-          } else if (!_.includes(reason, SUBSYSTEM_STATE_OK)) {
-            log.debug(`Waiting for emulator startup. Intermediate error: ${err.message}`);
-          }
+          state = err.stdout || err.stderr;
         }
-        return _.includes(reason, SUBSYSTEM_STATE_OK);
+        if (_.includes(state, SUBSYSTEM_STATE_OK)) {
+          return true;
+        }
+
+        log.debug(`Waiting for emulator startup. Intermediate state: ${state}`);
+        return false;
       }, {
         waitMs: timeoutMs,
         intervalMs: 1000,
       });
-      if (hasReadinessService) {
-        return;
-      }
     } catch (e) {
-      throw new Error(`Emulator is not ready within ${timeoutMs}ms${reason ? ('. Reason: ' + reason) : ''}`);
+      throw new Error(`Emulator is not ready within ${timeoutMs}ms${state ? ('. Reason: ' + state) : ''}`);
     }
-    log.info(
-      `The device under test does not have reboot_readiness service. ` +
-      `Falling back to the alternative boot detection method.`
-    );
+    return;
   }
 
   /** @type {RegExp[]} */


### PR DESCRIPTION
This service is always present on API 31+ emulators