### PR TITLE
feat: let pass user for isAppInstalled

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -52,7 +52,12 @@ apkUtilsMethods.isAppInstalled = async function isAppInstalled (pkg, opts = {}) 
   let isInstalled;
   if (await this.getApiLevel() < 26) {
     try {
-      const stdout = await this.shell(['pm', 'path', pkg]);
+      const cmd = ['pm', 'path'];
+      if (util.hasValue(user)) {
+        cmd.push('--user', user);
+      }
+      cmd.push(pkg);
+      const stdout = await this.shell(cmd);
       isInstalled = /^package:/m.test(stdout);
     } catch (ign) {
       isInstalled = false;

--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -31,13 +31,23 @@ const RESOLVER_ACTIVITY_NAME = 'android/com.android.internal.app.ResolverActivit
 
 
 /**
+ * @typedef {Object} IsAppInstalledOptions
+ * @property {string} [user] - The user id
+ */
+
+/**
  * Check whether the particular package is present on the device under test.
  *
  * @this {import('../adb.js').ADB}
  * @param {string} pkg - The name of the package to check.
+ * @param {IsAppInstalledOptions} [opts={}]
  * @return {Promise<boolean>} True if the package is installed.
  */
-apkUtilsMethods.isAppInstalled = async function isAppInstalled (pkg) {
+apkUtilsMethods.isAppInstalled = async function isAppInstalled (pkg, opts = {}) {
+  const {
+    user
+  } = opts;
+
   log.debug(`Getting install status for ${pkg}`);
   let isInstalled;
   if (await this.getApiLevel() < 26) {
@@ -48,7 +58,11 @@ apkUtilsMethods.isAppInstalled = async function isAppInstalled (pkg) {
       isInstalled = false;
     }
   } else {
-    const stdout = await this.shell(['cmd', 'package', 'list', 'packages']);
+    const cmd = ['cmd', 'package', 'list', 'packages'];
+    if (util.hasValue(user)) {
+      cmd.push('--user', user);
+    }
+    const stdout = await this.shell(cmd);
     isInstalled = new RegExp(`^package:${_.escapeRegExp(pkg)}$`, 'm').test(stdout);
   }
   log.debug(`'${pkg}' is${!isInstalled ? ' not' : ''} installed`);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -83,6 +83,24 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .returns(`package:dummy.package1`);
       (await adb.isAppInstalled(pkg)).should.be.false;
     });
+    it('should parse correctly and return true for newer versions with user', async function () {
+      const pkg = 'dummy.package';
+      mocks.adb.expects('getApiLevel')
+        .returns(26);
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['cmd', 'package', 'list', 'packages', '--user', '1'])
+        .returns(`package:dummy.package\npackage:other.package\n`);
+      (await adb.isAppInstalled(pkg, {user: '1'})).should.be.true;
+    });
+    it('should parse correctly and return false for newer versions with user', async function () {
+      const pkg = 'dummy.package';
+      mocks.adb.expects('getApiLevel')
+        .returns(26);
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['cmd', 'package', 'list', 'packages', '--user', '1'])
+        .returns(`package:dummy.package1`);
+      (await adb.isAppInstalled(pkg, {user: '1'})).should.be.false;
+    });
   });
 
   describe('getFocusedPackageAndActivity', function () {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -83,6 +83,25 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
         .returns(`package:dummy.package1`);
       (await adb.isAppInstalled(pkg)).should.be.false;
     });
+    it('should parse correctly and return true for older versions with user', async function () {
+      const pkg = 'dummy.package';
+      mocks.adb.expects('getApiLevel')
+        .returns(25);
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['pm', 'path', '--user', '1', pkg])
+        .returns(`package:/system/priv-app/TeleService/TeleService.apk with user`);
+      (await adb.isAppInstalled(pkg, {user: '1'})).should.be.true;
+    });
+    it('should parse correctly and return false for older versions', async function () {
+      const pkg = 'dummy.package';
+      mocks.adb.expects('getApiLevel')
+        .returns(25);
+      mocks.adb.expects('shell')
+        .once().withExactArgs(['pm', 'path', '--user', '1', pkg])
+        .throws();
+      (await adb.isAppInstalled(pkg, {user: '1'})).should.be.false;
+    });
+
     it('should parse correctly and return true for newer versions with user', async function () {
       const pkg = 'dummy.package';
       mocks.adb.expects('getApiLevel')


### PR DESCRIPTION
closes https://github.com/appium/appium-adb/issues/738

Then, eventually `mobile: isAppInstalled` will have `user` like startActivity.
https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#mobile-isappinstalled`


```
$ adb -s emulator-5556 shell pm -h
Package manager (package) commands:
  help
    Print this help text.

  path [--user USER_ID] PACKAGE
    Print the path to the .apk of the given PACKAGE.
```




```
  list packages [-f] [-d] [-e] [-s] [-3] [-i] [-l] [-u] [-U]
      [--show-versioncode] [--apex-only] [--factory-only]
      [--uid UID] [--user USER_ID] [FILTER]
    Prints all packages; optionally only those whose name contains
    the text in FILTER.  Options are:
      -f: see their associated file
      -a: all known packages (but excluding APEXes)
      -d: filter to only show disabled packages
      -e: filter to only show enabled packages
      -s: filter to only show system packages
      -3: filter to only show third party packages
      -i: see the installer for the packages
      -l: ignored (used for compatibility with older releases)
      -U: also show the package UID
      -u: also include uninstalled packages
      --show-versioncode: also show the version code
      --apex-only: only show APEX packages
      --factory-only: only show system packages excluding updates
      --uid UID: filter to only show packages with the given UID
      --user USER_ID: only list packages belonging to the given user
      --match-libraries: include packages that declare static shared and SDK libraries
```