### PR TITLE
feat: enable window animation via settings

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -985,14 +985,9 @@ methods.isAnimationOn = async function isAnimationOn () {
  *   - window_animation_scale
  *
  * @this {import('../adb.js').ADB}
- * @param {number} value Animation scale value (int or floating) to set.
- *                       The animation scale in Android code seems Java float,
- *                       but acceptable values as the settings command could be overr the Java float max/min.
- *                       The animation behaves as same as zero animation scale for negative number scale value.
- *                       For example, when the scale value is large number like 100,
- *                       the window animation of the Android GUI behaves very slow.
- *                       You may need to restart the device after setting the value with small number like 1
- *                       to avoid long waiting time to complete the animation.
+ * @param {number} value Animation scale value (int or float) to set.
+ *                       The minimum value of zero disables animations.
+ *                       By increasing the value animations become (slower/faster).
  * @return {Promise<void>}
  * @throws {Error} If the adb setting command raises an exception.
  */

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -976,15 +976,19 @@ methods.isAnimationOn = async function isAnimationOn () {
 };
 
 /**
- * Set window animation scale with the given velue via adb shell settings command.
+ * Set animation scale with the given velue via adb shell settings command.
+ *   - animator_duration_scale
+ *   - transition_animation_scale
+ *   - window_animation_scale
  *
  * @this {import('../adb.js').ADB}
  * @param {number} value Animation scale value (int or floating) to set.
- *                       The window animation scale in Android code seems Java float,
+ *                       The animation scale in Android code seems Java float,
  *                       but acceptable values as the settings command could be overr the Java float max/min.
- *                       When the scale value is large number like 100, the window animation of the Abdriud GUI
- *                       behaves very slow. You may need to restart the device after setting the value
- *                       with small number like 1 to avoid long animation completing waiting time.
+ *                       For example, when the scale value is large number like 100,
+ *                       the window animation of the Android GUI behaves very slow.
+ *                       You may need to restart the device after setting the value with small number like 1
+ *                       to avoid long animation completing waiting time.
  *                       Negative number is also acceptable as this settings command.
  *                       Then the animation behaves as same as set with zero.
  * @return {Promise<void>}

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -988,12 +988,11 @@ methods.isAnimationOn = async function isAnimationOn () {
  * @param {number} value Animation scale value (int or floating) to set.
  *                       The animation scale in Android code seems Java float,
  *                       but acceptable values as the settings command could be overr the Java float max/min.
+ *                       The animation behaves as same as zero animation scale for negative number scale value.
  *                       For example, when the scale value is large number like 100,
  *                       the window animation of the Android GUI behaves very slow.
  *                       You may need to restart the device after setting the value with small number like 1
- *                       to avoid long animation completing waiting time.
- *                       Negative number is also acceptable as this settings command.
- *                       Then the animation behaves as same as set with zero.
+ *                       to avoid long waiting time to complete the animation.
  * @return {Promise<void>}
  * @throws {Error} If the adb setting command raises an exception.
  */

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -979,17 +979,18 @@ methods.isAnimationOn = async function isAnimationOn () {
  * Set animation scale with the given velue.
  *
  * @this {import('../adb.js').ADB}
- * @param {number} value Animation value (int or floating) to set. Negative value sets zero.
- *                       It could be large value such as 1000000000 but the animation could be very slow.
+ * @param {number} value Animation scale value (int or floating) to set.
+ *                       The acceptable value depends on the `settings` command like
+ *                       `adb shell settings put global transition_animation_scale`.
+ *                       The animation scale in Android code seems Java float, but the acceptable value
+ *                       as the settings could be overr the Java float max.
+ *                       Negative number is also acceptable. Then the animation works as off.
  * @return {Promise<void>}
  * @throws {Error} If the adb setting command raises an exception.
  */
 methods.setAnimationScale = async function setAnimation (value) {
-  const animations = [];
-  for (const k of ANIMATION_SCALE_KEYS) {
-    animations.push(this.setSetting('global', k, value));
-  }
-  await B.all(animations);
+  await B.all( ANIMATION_SCALE_KEYS.map((k) => this.setSetting('global', k, value)) );
+
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -981,6 +981,9 @@ methods.isAnimationOn = async function isAnimationOn () {
  * It raises an error if adb commands gets an error.
  */
 methods.setAnimation = async function setAnimation (value) {
+  if (value < 0) {
+    value = 0;
+  }
   for (const k of [
     'animator_duration_scale',
     'transition_animation_scale',

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -24,6 +24,11 @@ const HIDDEN_API_POLICY_KEYS = [
   'hidden_api_policy_p_apps',
   'hidden_api_policy'
 ];
+const ANIMATION_SCALE_KEYS = [
+  'animator_duration_scale',
+  'transition_animation_scale',
+  'window_animation_scale'
+];
 const PID_COLUMN_TITLE = 'PID';
 const PROCESS_NAME_COLUMN_TITLE = 'NAME';
 const PS_TITLE_PATTERN = new RegExp(`^(.*\\b${PID_COLUMN_TITLE}\\b.*\\b${PROCESS_NAME_COLUMN_TITLE}\\b.*)$`, 'm');
@@ -984,11 +989,7 @@ methods.setAnimation = async function setAnimation (value) {
   if (value < 0) {
     value = 0;
   }
-  for (const k of [
-    'animator_duration_scale',
-    'transition_animation_scale',
-    'window_animation_scale'
-  ]) {
+  for (const k of ANIMATION_SCALE_KEYS) {
     await this.setSetting('global', k, value);
   }
   return true;

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -976,15 +976,17 @@ methods.isAnimationOn = async function isAnimationOn () {
 };
 
 /**
- * Set animation scale with the given velue.
+ * Set window animation scale with the given velue via adb shell settings command.
  *
  * @this {import('../adb.js').ADB}
  * @param {number} value Animation scale value (int or floating) to set.
- *                       The acceptable value depends on the `settings` command like
- *                       `adb shell settings put global transition_animation_scale`.
- *                       The animation scale in Android code seems Java float, but the acceptable value
- *                       as the settings could be overr the Java float max.
- *                       Negative number is also acceptable. Then the animation works as off.
+ *                       The window animation scale in Android code seems Java float,
+ *                       but acceptable values as the settings command could be overr the Java float max/min.
+ *                       When the scale value is large number like 100, the window animation of the Abdriud GUI
+ *                       behaves very slow. You may need to restart the device after setting the value
+ *                       with small number like 1 to avoid long animation completing waiting time.
+ *                       Negative number is also acceptable as this settings command.
+ *                       Then the animation behaves as same as set with zero.
  * @return {Promise<void>}
  * @throws {Error} If the adb setting command raises an exception.
  */

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -963,7 +963,10 @@ methods.isDataOn = async function isDataOn () {
 };
 
 /**
- * Check the state of animation on the device under test.
+ * Check the state of animation on the device under test below:
+ *   - animator_duration_scale
+ *   - transition_animation_scale
+ *   - window_animation_scale
  *
  * @this {import('../adb.js').ADB}
  * @return {Promise<boolean>} True if at least one of animation scale settings

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -973,6 +973,25 @@ methods.isAnimationOn = async function isAnimationOn () {
 };
 
 /**
+ * Set animations
+ *
+ * @this {import('../adb.js').ADB}
+ * @param {number} value Animation value to set
+ * @return {Promise<boolean>} True if all set animation command succeeded.
+ * It raises an error if adb commands gets an error.
+ */
+methods.setAnimation = async function setAnimation (value) {
+  for (const k of [
+    'animator_duration_scale',
+    'transition_animation_scale',
+    'window_animation_scale'
+  ]) {
+    await this.setSetting('global', k, value);
+  }
+  return true;
+};
+
+/**
  * Forcefully recursively remove a path on the device under test.
  * Be careful while calling this method.
  *

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -970,11 +970,9 @@ methods.isDataOn = async function isDataOn () {
  *                   is not equal to '0.0'.
  */
 methods.isAnimationOn = async function isAnimationOn () {
-  let animator_duration_scale = await this.getSetting('global', 'animator_duration_scale');
-  let transition_animation_scale = await this.getSetting('global', 'transition_animation_scale');
-  let window_animation_scale = await this.getSetting('global', 'window_animation_scale');
-  return _.some([animator_duration_scale, transition_animation_scale, window_animation_scale],
-                (setting) => setting !== '0.0');
+  return (await B.all(ANIMATION_SCALE_KEYS.map(
+    async (k) => (await this.getSetting('global', k)) !== '0.0'))
+  ).includes(true);
 };
 
 /**

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -987,7 +987,7 @@ methods.isAnimationOn = async function isAnimationOn () {
  * @this {import('../adb.js').ADB}
  * @param {number} value Animation scale value (int or float) to set.
  *                       The minimum value of zero disables animations.
- *                       By increasing the value animations become (slower/faster).
+ *                       By increasing the value, animations become slower.
  * @return {Promise<void>}
  * @throws {Error} If the adb setting command raises an exception.
  */

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -979,15 +979,19 @@ methods.isAnimationOn = async function isAnimationOn () {
 };
 
 /**
- * Set animation scale with the given velue via adb shell settings command.
+ * Set animation scale with the given value via adb shell settings command.
  *   - animator_duration_scale
  *   - transition_animation_scale
  *   - window_animation_scale
+ * API level 24 and newer OS versions may change the animation, at least emulators are so.
+ * API level 28+ real devices checked this worked, but we haven't checked older ones
+ * with real devices.
  *
  * @this {import('../adb.js').ADB}
  * @param {number} value Animation scale value (int or float) to set.
  *                       The minimum value of zero disables animations.
  *                       By increasing the value, animations become slower.
+ *                       '1' is the system default animation scale.
  * @return {Promise<void>}
  * @throws {Error} If the adb setting command raises an exception.
  */

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -989,7 +989,7 @@ methods.isAnimationOn = async function isAnimationOn () {
  * @throws {Error} If the adb setting command raises an exception.
  */
 methods.setAnimationScale = async function setAnimation (value) {
-  await B.all( ANIMATION_SCALE_KEYS.map((k) => this.setSetting('global', k, value)) );
+  await B.all(ANIMATION_SCALE_KEYS.map((k) => this.setSetting('global', k, value)));
 
 };
 

--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -976,21 +976,20 @@ methods.isAnimationOn = async function isAnimationOn () {
 };
 
 /**
- * Set animations
+ * Set animation scale with the given velue.
  *
  * @this {import('../adb.js').ADB}
- * @param {number} value Animation value to set
- * @return {Promise<boolean>} True if all set animation command succeeded.
- * It raises an error if adb commands gets an error.
+ * @param {number} value Animation value (int or floating) to set. Negative value sets zero.
+ *                       It could be large value such as 1000000000 but the animation could be very slow.
+ * @return {Promise<void>}
+ * @throws {Error} If the adb setting command raises an exception.
  */
-methods.setAnimation = async function setAnimation (value) {
-  if (value < 0) {
-    value = 0;
-  }
+methods.setAnimationScale = async function setAnimation (value) {
+  const animations = [];
   for (const k of ANIMATION_SCALE_KEYS) {
-    await this.setSetting('global', k, value);
+    animations.push(this.setSetting('global', k, value));
   }
-  return true;
+  await B.all(animations);
 };
 
 /**

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -469,6 +469,32 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         (await adb.isAnimationOn()).should.be.true;
       });
     });
+    describe('setAnimation', function () {
+      it('should set 1/5 for 11/5', async function () {
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 1.5);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 1.5);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 1.5);
+        (await adb.setAnimation(1.5)).should.be.true;
+      });
+      it('should set 1 for 1', async function () {
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 1);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 1);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 1);
+        (await adb.setAnimation(1)).should.be.true;
+      });
+      it('should set 0 for 0', async function () {
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 0);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 0);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 0);
+        (await adb.setAnimation(0)).should.be.true;
+      });
+      it('should set 0 for negative values', async function () {
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 0);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 0);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 0);
+        (await adb.setAnimation(-1)).should.be.true;
+      });
+    });
     describe('processExists', function () {
       it('should call shell with correct args and should find process', async function () {
         mocks.adb.expects('getPIDsByName')

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -11,6 +11,7 @@ import { EOL } from 'os';
 
 
 chai.use(chaiAsPromised);
+const expect = chai.expect;
 const should = chai.should();
 const apiLevel = 21,
       platformVersion = '4.4.4',
@@ -474,25 +475,25 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 1.5);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 1.5);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 1.5);
-        (await adb.setAnimationScale(1.5)).should.be.true;
+        expect(await adb.setAnimationScale(1.5)).not.throws;
       });
       it('should set 1 for 1', async function () {
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 1);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 1);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 1);
-        (await adb.setAnimationScale(1)).should.be.true;
+        expect(await adb.setAnimationScale(1)).not.throws;
       });
       it('should set 0 for 0', async function () {
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 0);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 0);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 0);
-        (await adb.setAnimationScale(0)).should.be.true;
+        expect(await adb.setAnimationScale(0)).not.throws;
       });
       it('should set 0 for negative values', async function () {
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', -1);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', -1);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', -1);
-        (await adb.setAnimationScale(-1)).should.be.true;
+        expect(await adb.setAnimationScale(-1)).not.throws;
       });
     });
     describe('processExists', function () {

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -474,25 +474,25 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 1.5);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 1.5);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 1.5);
-        (await adb.setAnimation(1.5)).should.be.true;
+        (await adb.setAnimationScale(1.5)).should.be.true;
       });
       it('should set 1 for 1', async function () {
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 1);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 1);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 1);
-        (await adb.setAnimation(1)).should.be.true;
+        (await adb.setAnimationScale(1)).should.be.true;
       });
       it('should set 0 for 0', async function () {
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 0);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 0);
         mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 0);
-        (await adb.setAnimation(0)).should.be.true;
+        (await adb.setAnimationScale(0)).should.be.true;
       });
       it('should set 0 for negative values', async function () {
-        mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', 0);
-        mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', 0);
-        mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', 0);
-        (await adb.setAnimation(-1)).should.be.true;
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'animator_duration_scale', -1);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'transition_animation_scale', -1);
+        mocks.adb.expects('setSetting').once().withExactArgs('global', 'window_animation_scale', -1);
+        (await adb.setAnimationScale(-1)).should.be.true;
       });
     });
     describe('processExists', function () {


### PR DESCRIPTION
This settings command worked on Android 9, 10, 11, 12, 13 and 14 real devices, so I think at least this can be alternative of existing animation one. I haven't tested for older than API level 26. So for now, we could use this as https://github.com/appium/appium-espresso-driver/pull/1007
