### PR TITLE
fix: Prefer indexes over timestamps as logcat keys

### DIFF
--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -115,12 +115,12 @@ class Logcat extends EventEmitter {
     this.debug = opts.debug;
     this.debugTrace = opts.debugTrace;
     this.maxBufferSize = opts.maxBufferSize || MAX_BUFFER_SIZE;
-    /** @type {LRUCache<bigint, [string, number]>} */
+    /** @type {LRUCache<number, [string, number]>} */
     this.logs = new LRUCache({
       max: this.maxBufferSize,
     });
-    /** @type {bigint?} */
-    this.logHrTimeSinceLastRequest = null;
+    /** @type {number?} */
+    this.logIndexSinceLastRequest = null;
   }
 
   async startCapture (opts = {}) {
@@ -188,9 +188,14 @@ class Logcat extends EventEmitter {
    * @returns {void}
    */
   outputHandler (logLine, prefix = '') {
-    const hrTime = process.hrtime.bigint();
     const timestamp = Date.now();
-    this.logs.set(hrTime, [logLine, timestamp]);
+    /** @type {number} */
+    let recentIndex = -1;
+    for (const key of this.logs.rkeys()) {
+      recentIndex = key;
+      break;
+    }
+    this.logs.set(++recentIndex, [logLine, timestamp]);
     if (this.listenerCount('output')) {
       this.emit('output', toLogEntry(logLine, timestamp));
     }
@@ -219,23 +224,19 @@ class Logcat extends EventEmitter {
    * @returns {LogEntry[]}
    */
   getLogs () {
-    if (!this.logs.size) {
-      return [];
-    }
-
     /** @type {LogEntry[]} */
     const result = [];
-    /** @type {bigint?} */
-    let recentLogHrTime = null;
-    for (const [hrTime, [message, timestamp]] of this.logs.entries()) {
-      if (this.logHrTimeSinceLastRequest && hrTime > this.logHrTimeSinceLastRequest
-          || !this.logHrTimeSinceLastRequest) {
-        recentLogHrTime = hrTime;
+    /** @type {number?} */
+    let recentLogIndex = null;
+    for (const [index, [message, timestamp]] of this.logs.entries()) {
+      if (this.logIndexSinceLastRequest && index > this.logIndexSinceLastRequest
+          || !this.logIndexSinceLastRequest) {
+        recentLogIndex = index;
         result.push(toLogEntry(message, timestamp));
       }
     }
-    if (recentLogHrTime) {
-      this.logHrTimeSinceLastRequest = recentLogHrTime;
+    if (_.isInteger(recentLogIndex)) {
+      this.logIndexSinceLastRequest = recentLogIndex;
     }
     return result;
   }
@@ -244,10 +245,6 @@ class Logcat extends EventEmitter {
    * @returns {LogEntry[]}
    */
   getAllLogs () {
-    if (!this.logs.size) {
-      return [];
-    }
-
     /** @type {LogEntry[]} */
     const result = [];
     for (const [message, timestamp] of this.logs.values()) {


### PR DESCRIPTION
Now it might not be a thing to use nanosecond timestamps as keys, but in the future, when CPUs are fast enough it might create issues that are hard to detect.