### PR TITLE
fix: Fix recent entry retrieval

### DIFF
--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -159,21 +159,17 @@ class Logcat extends EventEmitter {
           resolve();
         }
       });
-      this.proc.on('lines-stderr', (lines) => {
-        for (const line of lines) {
-          if (!started && EXECVP_ERR_PATTERN.test(line)) {
-            log.error('Logcat process failed to start');
-            return reject(new Error(`Logcat process failed to start. stderr: ${line}`));
-          }
-          this.outputHandler(line, 'STDERR: ');
+      this.proc.on('line-stderr', (line) => {
+        if (!started && EXECVP_ERR_PATTERN.test(line)) {
+          log.error('Logcat process failed to start');
+          return reject(new Error(`Logcat process failed to start. stderr: ${line}`));
         }
+        this.outputHandler(line, 'STDERR: ');
         resolve();
       });
-      this.proc.on('lines-stdout', (lines) => {
+      this.proc.on('line-stdout', (line) => {
+        this.outputHandler(line);
         resolve();
-        for (const line of lines) {
-          this.outputHandler(line);
-        }
       });
       await this.proc.start(0);
       // resolve after a timeout, even if no output was recorded
@@ -191,7 +187,7 @@ class Logcat extends EventEmitter {
     const timestamp = Date.now();
     /** @type {number} */
     let recentIndex = -1;
-    for (const key of this.logs.rkeys()) {
+    for (const key of this.logs.keys()) {
       recentIndex = key;
       break;
     }

--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -223,7 +223,7 @@ class Logcat extends EventEmitter {
     const result = [];
     /** @type {number?} */
     let recentLogIndex = null;
-    for (const [index, [message, timestamp]] of this.logs.entries()) {
+    for (const [index, [message, timestamp]] of /** @type {Generator} */ (this.logs.rentries())) {
       if (this.logIndexSinceLastRequest && index > this.logIndexSinceLastRequest
           || !this.logIndexSinceLastRequest) {
         recentLogIndex = index;
@@ -242,7 +242,7 @@ class Logcat extends EventEmitter {
   getAllLogs () {
     /** @type {LogEntry[]} */
     const result = [];
-    for (const [message, timestamp] of this.logs.values()) {
+    for (const [message, timestamp] of /** @type {Generator} */ (this.logs.rvalues())) {
       result.push(toLogEntry(message, timestamp));
     }
     return result;

--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -185,7 +185,6 @@ class Logcat extends EventEmitter {
    */
   outputHandler (logLine, prefix = '') {
     const timestamp = Date.now();
-    /** @type {number} */
     let recentIndex = -1;
     for (const key of this.logs.keys()) {
       recentIndex = key;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lru-cache": "^10.0.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.1.10"
+    "teen_process": "^2.2.0"
   },
   "devDependencies": {
     "@appium/eslint-config-appium-ts": "^0.x",

--- a/test/unit/logcat-specs.js
+++ b/test/unit/logcat-specs.js
@@ -29,7 +29,7 @@ describe('logcat', withMocks({teen_process}, function (mocks) {
         .onFirstCall()
         .returns(conn);
       setTimeout(function () {
-        conn.emit('lines-stdout', ['- beginning of system\r']);
+        conn.emit('line-stdout', '- beginning of system\r');
       }, 0);
       await logcat.startCapture({
         format: 'brief',
@@ -46,7 +46,7 @@ describe('logcat', withMocks({teen_process}, function (mocks) {
         .onFirstCall()
         .returns(conn);
       setTimeout(function () {
-        conn.emit('lines-stderr', ['execvp()']);
+        conn.emit('line-stderr', 'execvp()');
       }, 0);
       await logcat.startCapture().should.eventually.be.rejectedWith('Logcat');
     });
@@ -58,7 +58,7 @@ describe('logcat', withMocks({teen_process}, function (mocks) {
         .onFirstCall()
         .returns(conn);
       setTimeout(function () {
-        conn.emit('lines-stderr', ['something']);
+        conn.emit('line-stderr', 'something');
       }, 0);
       await logcat.startCapture().should.eventually.not.be.rejectedWith('Logcat');
     });


### PR DESCRIPTION
It turns out the keys() method of LRUCache returns items ordered from most recently used to least used and the order for rkeys() is inverted.