### PR TITLE
fix: Make package argument of startUri optional

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -96,16 +96,16 @@ apkUtilsMethods.isAppInstalled = async function isAppInstalled (pkg, opts = {}) 
  *
  * @this {import('../adb.js').ADB}
  * @param {string} uri - The name of URI to start.
- * @param {string} pkg - The name of the package to start the URI with.
+ * @param {string?} [pkg=null] - The name of the package to start the URI with.
  * @param {StartUriOptions} [opts={}]
  */
-apkUtilsMethods.startUri = async function startUri (uri, pkg, opts = {}) {
+apkUtilsMethods.startUri = async function startUri (uri, pkg = null, opts = {}) {
   const {
     waitForLaunch = true,
   } = opts;
 
-  if (!uri || !pkg) {
-    throw new Error('URI and package arguments are required');
+  if (!uri) {
+    throw new Error('URI argument is required');
   }
 
   const args = ['am', 'start'];
@@ -113,8 +113,10 @@ apkUtilsMethods.startUri = async function startUri (uri, pkg, opts = {}) {
     args.push('-W');
   }
   args.push('-a', 'android.intent.action.VIEW',
-    '-d', escapeShellArg(uri),
-    pkg);
+    '-d', escapeShellArg(uri));
+  if (pkg) {
+    args.push(pkg);
+  }
 
   try {
     const res = await this.shell(args);

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -517,9 +517,8 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
     });
   });
   describe('startUri', function () {
-    it('should fail if uri or pkg are not provided', async function () {
-      await adb.startUri().should.eventually.be.rejectedWith(/arguments are required/);
-      await adb.startUri('foo').should.eventually.be.rejectedWith(/arguments are required/);
+    it('should fail if uri is not provided', async function () {
+      await adb.startUri().should.eventually.be.rejectedWith(/argument is required/);
     });
     it('should fail if "unable to resolve intent" appears in shell command result', async function () {
       mocks.adb.expects('shell')
@@ -532,6 +531,16 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       await adb.startUri(uri, pkg).should.eventually.be.rejectedWith(/Unable to resolve intent/);
     });
     it('should build a call to a VIEW intent with the uri', async function () {
+      mocks.adb.expects('shell')
+        .once().withExactArgs([
+          'am', 'start', '-W', '-a',
+          'android.intent.action.VIEW', '-d', uri
+        ])
+        .returns('Passable result');
+
+      await adb.startUri(uri);
+    });
+    it('should build a call to a VIEW intent with the uri and package', async function () {
       mocks.adb.expects('shell')
         .once().withExactArgs([
           'am', 'start', '-W', '-a',


### PR DESCRIPTION
`startUri()` requires `pkg` argument as app package name but app package can be omitted on executing `am start`.

It may show disambiguation popup in some cases (e.g. when there are multiple apps which handle the given URI and the default app is not configured.)