### PR TITLE
test: Update ports integration test

### DIFF
--- a/test/functional/adb-commands-e2e-specs.js
+++ b/test/functional/adb-commands-e2e-specs.js
@@ -285,11 +285,8 @@ describe('adb commands', function () {
   });
 
   describe('listPorts', function () {
-    it('should list IPv4 ports', async function () {
-      _.isEmpty(await adb.listPorts()).should.be.false;
-    });
-    it('should list IPv6 ports', async function () {
-      _.isEmpty(await adb.listPorts('6')).should.be.false;
+    it('should list opened ports', async function () {
+      (_.isEmpty(await adb.listPorts()) && _.isEmpty(await adb.listPorts('6'))).should.be.false;
     });
   });
 });


### PR DESCRIPTION
Some GH emulators only have ipv6 ports opened