### PR TITLE
docs: Update README so the example works verbatim

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm run e2e-test
 example:
 
 ```js
-import ADB from 'appium-adb';
+import { ADB } from 'appium-adb';
 
 const adb = await ADB.createADB();
 console.log(await adb.getPIDsByName('com.android.phone'));


### PR DESCRIPTION
The import was missing curly braces, and it was importing the wrong thing which led to the example failing, as also described in https://github.com/appium/appium-adb/issues/649 that was closed by the author without sending a PR.

I thought the library code might have changed and/or the README had got out of sync, but after looking at the source I realised what was happening.

This little change helps people get started with the lib. Hope it helps!