### PR TITLE
feat: Added support for applications with multiple processes

### DIFF
--- a/lib/tools/adb-commands.js
+++ b/lib/tools/adb-commands.js
@@ -1367,11 +1367,12 @@ methods.getPIDsByName = async function getPIDsByName (name) {
     if (this._isPgrepAvailable || this._isPidofAvailable) {
       const shellCommand = this._isPgrepAvailable
         ? (this._canPgrepUseFullCmdLineSearch
-          ? ['pgrep', '-f', _.escapeRegExp(`([[:blank:]]|^)${name}([[:blank:]]|$)`)]
+          ? ['pgrep', '-f', _.escapeRegExp(`([[:blank:]]|^)${name}(:[a-zA-Z0-9_-]+)?([[:blank:]]|$)`)]
           // https://github.com/appium/appium/issues/13872
           : [`pgrep ^${_.escapeRegExp(name.slice(-MAX_PGREP_PATTERN_LEN))}$ ` +
               `|| pgrep ^${_.escapeRegExp(name.slice(0, MAX_PGREP_PATTERN_LEN))}$`])
         : ['pidof', name];
+
       try {
         return (await this.shell(shellCommand))
           .split(/\s+/)

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -649,6 +649,14 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
           .returns('5078\n5079\n');
         (await adb.getPIDsByName(contactManagerPackage)).should.eql([5078, 5079]);
       });
+      it('should call shell and parse pids with pgrep correctly with package with proccess', async function () {
+        adb._isPidofAvailable = false;
+        adb._isPgrepAvailable = true;
+        adb._canPgrepUseFullCmdLineSearch = true;
+        const escapedProcessName = _.escapeRegExp(`([[:blank:]]|^)${contactManagerPackage}(:[a-zA-Z0-9_-]+)?([[:blank:]]|$)`);
+        mocks.adb.expects('shell').once().withExactArgs(['pgrep', '-f', escapedProcessName]).returns('5080\n5081\n');         
+        (await adb.getPIDsByName(contactManagerPackage)).should.eql([5080, 5081]);
+      });
       it('should call shell and return an empty list if no processes are running', async function () {
         adb._isPidofAvailable = true;
         adb._isPgrepAvailable = false;

--- a/test/unit/adb-commands-specs.js
+++ b/test/unit/adb-commands-specs.js
@@ -654,7 +654,7 @@ describe('adb commands', withMocks({adb, logcat, teen_process, net}, function (m
         adb._isPgrepAvailable = true;
         adb._canPgrepUseFullCmdLineSearch = true;
         const escapedProcessName = _.escapeRegExp(`([[:blank:]]|^)${contactManagerPackage}(:[a-zA-Z0-9_-]+)?([[:blank:]]|$)`);
-        mocks.adb.expects('shell').once().withExactArgs(['pgrep', '-f', escapedProcessName]).returns('5080\n5081\n');         
+        mocks.adb.expects('shell').once().withExactArgs(['pgrep', '-f', escapedProcessName]).returns('5080\n5081\n');
         (await adb.getPIDsByName(contactManagerPackage)).should.eql([5080, 5081]);
       });
       it('should call shell and return an empty list if no processes are running', async function () {


### PR DESCRIPTION
Added support for applications with multiple processes
Example: when running following command:
"adb shell ps | grep <package_name>"
the output looks like this:
u0_a262 22229 844 8667368 243348 0 0 S <package_name>:MainProcess