### PR TITLE
feat: add screenState=SCREEN_STATE_OFF as the screen locked

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -272,6 +272,17 @@ export async function getApkanalyzerForOs (sysHelpers) {
 }
 
 /**
+ * Checks screenState has SCREEN_STATE_OFF in dumpsys output to determine
+ * possible lock screen.
+ *
+ * @param {string} dumpsys - The output of dumpsys window command.
+ * @return {boolean} True if lock screen is showing.
+ */
+export function isScreenOff(dumpsys) {
+  return /\s+screenState=SCREEN_STATE_OFF/i.test(dumpsys);
+}
+
+/**
  * Checks mShowingLockscreen or mDreamingLockscreen in dumpsys output to determine
  * if lock screen is showing
  *

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -278,7 +278,7 @@ export async function getApkanalyzerForOs (sysHelpers) {
  * @param {string} dumpsys - The output of dumpsys window command.
  * @return {boolean} True if lock screen is showing.
  */
-export function isScreenOff(dumpsys) {
+export function isScreenStateOff(dumpsys) {
   return /\s+screenState=SCREEN_STATE_OFF/i.test(dumpsys);
 }
 
@@ -334,7 +334,8 @@ export function getSurfaceOrientation (dumpsys) {
 
 /*
  * Checks mScreenOnFully in dumpsys output to determine if screen is showing
- * Default is true
+ * Default is true.
+ * Note: this key
  */
 export function isScreenOnFully (dumpsys) {
   let m = /mScreenOnFully=\w+/gi.exec(dumpsys);

--- a/lib/tools/lockmgmt.js
+++ b/lib/tools/lockmgmt.js
@@ -2,7 +2,7 @@ import { log } from '../logger.js';
 import _ from 'lodash';
 import {
   isShowingLockscreen, isCurrentFocusOnKeyguard, isScreenOnFully,
-  isInDozingMode, isScreenOff,
+  isInDozingMode, isScreenStateOff,
 } from '../helpers.js';
 import B from 'bluebird';
 import { waitForCondition } from 'asyncbox';
@@ -218,7 +218,7 @@ export async function isScreenLocked () {
     || isCurrentFocusOnKeyguard(windowOutput)
     || !isScreenOnFully(windowOutput)
     || isInDozingMode(powerOutput)
-    || isScreenOff(windowOutput);
+    || isScreenStateOff(windowOutput);
 }
 
 /**

--- a/lib/tools/lockmgmt.js
+++ b/lib/tools/lockmgmt.js
@@ -2,7 +2,7 @@ import { log } from '../logger.js';
 import _ from 'lodash';
 import {
   isShowingLockscreen, isCurrentFocusOnKeyguard, isScreenOnFully,
-  isInDozingMode,
+  isInDozingMode, isScreenOff,
 } from '../helpers.js';
 import B from 'bluebird';
 import { waitForCondition } from 'asyncbox';
@@ -217,7 +217,8 @@ export async function isScreenLocked () {
   return isShowingLockscreen(windowOutput)
     || isCurrentFocusOnKeyguard(windowOutput)
     || !isScreenOnFully(windowOutput)
-    || isInDozingMode(powerOutput);
+    || isInDozingMode(powerOutput)
+    || isScreenOff(windowOutput);
 }
 
 /**

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -3,6 +3,7 @@ import {
   buildStartCmd, isShowingLockscreen, getBuildToolsDirs,
   parseAaptStrings, parseAapt2Strings,
   extractMatchingPermissions, parseLaunchableActivityNames, matchComponentName,
+  isScreenOff,
 } from '../../lib/helpers';
 import { withMocks } from '@appium/test-support';
 import { fs } from '@appium/support';
@@ -57,6 +58,64 @@ describe('helpers', withMocks({fs}, function (mocks) {
         .equal(path.resolve(ANDROID_HOME, 'platforms', 'android-25'));
     });
   });
+
+  describe('isScreenOff', function () {
+    it('should return true if isScreenOff is off', async function () {
+      let dumpsys = `
+    KeyguardServiceDelegate
+      showing=false
+      showingAndNotOccluded=true
+      inputRestricted=false
+      occluded=false
+      secure=false
+      dreaming=false
+      systemIsReady=true
+      deviceHasKeyguard=true
+      enabled=true
+      offReason=OFF_BECAUSE_OF_USER
+      currentUser=-10000
+      bootCompleted=true
+      screenState=SCREEN_STATE_OFF
+      interactiveState=INTERACTIVE_STATE_SLEEP
+      KeyguardStateMonitor
+        mIsShowing=false
+        mSimSecure=false
+        mInputRestricted=false
+        mTrusted=false
+        mCurrentUserId=0
+        ...
+      `;
+      (await isScreenOff(dumpsys)).should.be.true;
+    });
+    it('should return true if isScreenOff is on', async function () {
+      let dumpsys = `
+    KeyguardServiceDelegate
+      showing=false
+      showingAndNotOccluded=true
+      inputRestricted=false
+      occluded=false
+      secure=false
+      dreaming=false
+      systemIsReady=true
+      deviceHasKeyguard=true
+      enabled=true
+      offReason=OFF_BECAUSE_OF_USER
+      currentUser=-10000
+      bootCompleted=true
+      screenState=SCREEN_STATE_ON
+      interactiveState=INTERACTIVE_STATE_AWAKE
+      KeyguardStateMonitor
+        mIsShowing=false
+        mSimSecure=false
+        mInputRestricted=false
+        mTrusted=false
+        mCurrentUserId=0
+        ...
+      `;
+      (await isScreenOff(dumpsys)).should.be.false;
+    });
+  });
+
 
   describe('isShowingLockscreen', function () {
     it('should return true if mShowingLockscreen is true', async function () {

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -3,7 +3,7 @@ import {
   buildStartCmd, isShowingLockscreen, getBuildToolsDirs,
   parseAaptStrings, parseAapt2Strings,
   extractMatchingPermissions, parseLaunchableActivityNames, matchComponentName,
-  isScreenOff,
+  isScreenStateOff,
 } from '../../lib/helpers';
 import { withMocks } from '@appium/test-support';
 import { fs } from '@appium/support';
@@ -59,8 +59,8 @@ describe('helpers', withMocks({fs}, function (mocks) {
     });
   });
 
-  describe('isScreenOff', function () {
-    it('should return true if isScreenOff is off', async function () {
+  describe('isScreenStateOff', function () {
+    it('should return true if isScreenStateOff is off', async function () {
       let dumpsys = `
     KeyguardServiceDelegate
       showing=false
@@ -85,9 +85,9 @@ describe('helpers', withMocks({fs}, function (mocks) {
         mCurrentUserId=0
         ...
       `;
-      (await isScreenOff(dumpsys)).should.be.true;
+      (await isScreenStateOff(dumpsys)).should.be.true;
     });
-    it('should return true if isScreenOff is on', async function () {
+    it('should return true if isScreenStateOff is on', async function () {
       let dumpsys = `
     KeyguardServiceDelegate
       showing=false
@@ -112,7 +112,7 @@ describe('helpers', withMocks({fs}, function (mocks) {
         mCurrentUserId=0
         ...
       `;
-      (await isScreenOff(dumpsys)).should.be.false;
+      (await isScreenStateOff(dumpsys)).should.be.false;
     });
   });
 

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -85,7 +85,7 @@ describe('helpers', withMocks({fs}, function (mocks) {
         mCurrentUserId=0
         ...
       `;
-      (await isScreenStateOff(dumpsys)).should.be.true;
+      isScreenStateOff(dumpsys).should.be.true;
     });
     it('should return true if isScreenStateOff is on', async function () {
       let dumpsys = `
@@ -112,7 +112,7 @@ describe('helpers', withMocks({fs}, function (mocks) {
         mCurrentUserId=0
         ...
       `;
-      (await isScreenStateOff(dumpsys)).should.be.false;
+      isScreenStateOff(dumpsys).should.be.false;
     });
   });
 


### PR DESCRIPTION
To support https://github.com/appium/appium-uiautomator2-driver/issues/859 case.

I confirmed that the current method to detect the lock screen didn't work in the issue's use case. Actually, when the device screen was off while screen recording was working, the existing one didn't match as "locked."

`screenState=SCREEN_STATE_OFF` could help in this case.

This doesn't change current behavior when no screen recording is working, so this could be "fix" I think but this adds a new flag to detect the state so I made this as a "feat."