### PR TITLE
fix: Update comparison logic for the activity name when there are mutiple active app

### DIFF
--- a/lib/tools/app-commands.js
+++ b/lib/tools/app-commands.js
@@ -909,7 +909,21 @@ export async function getFocusedPackageAndActivity () {
   }
   if (focusedAppCandidates.length > 1 && currentFocusAppCandidates.length > 0) {
     // https://github.com/appium/appium/issues/17106
-    return _.intersectionWith(focusedAppCandidates, currentFocusAppCandidates, _.isEqual)[0]
+    return _.intersectionWith(focusedAppCandidates, currentFocusAppCandidates, (value, other) => {
+      // https://github.com/appium/appium-adb/issues/797
+      if (_.isEqual(value.appPackage, other.appPackage)) {
+        let convertedActivities = [];
+        for (const activity of [value.appActivity, other.appActivity]) {
+          convertedActivities = [
+            ...convertedActivities,
+            activity ? activity.replace(value.appPackage || '', '') : ''
+          ];
+        }
+        return _.isEqual(convertedActivities[0], convertedActivities[1]);
+      } else {
+        return false;
+      }
+    })[0]
       ?? focusedAppCandidates[0];
   }
   if (focusedAppCandidates.length > 0 || currentFocusAppCandidates.length > 0) {

--- a/test/unit/apk-utils-specs.js
+++ b/test/unit/apk-utils-specs.js
@@ -151,6 +151,19 @@ describe('Apk-utils', withMocks({adb, fs, teen_process}, function (mocks) {
       appPackage.should.equal('eu.niko.smart.universal');
       appActivity.should.equal('crc648a3abc16689e594e.MainActivity');
     });
+    it('should return package and activity if the activity name has the package name itself', async function () {
+      mocks.adb.expects('dumpWindows')
+        .once()
+        .returns(`mFocusedApp=null
+        mFocusedApp=ActivityRecord{caf038a u0 com.android.systemui/.subscreen.SubHomeActivity t7}
+        mFocusedApp=ActivityRecord{a646676 u0 com.example.android/.activity.main.MainActivity t285}
+        mCurrentFocus=null
+        mCurrentFocus=null
+        mCurrentFocus=Window{5e9b13b u0 com.example.android/com.example.android.activity.main.MainActivity}}`);
+      const {appPackage, appActivity} = await adb.getFocusedPackageAndActivity();
+      appPackage.should.equal('com.example.android');
+      appActivity.should.equal('.activity.main.MainActivity');
+    });
     it('should parse correctly and return package and activity when a comma is present', async function () {
       mocks.adb.expects('dumpWindows')
         .once()


### PR DESCRIPTION
Fix https://github.com/appium/appium-adb/issues/797

## main reason
If the activity name contains the package name itself, the comparison function (_.isEqual) could not recognize it.
And since there are multiple apps active, the function will return the first active app, rather than the intersection of the active and focused apps.

in below case, 
```
mFocusedApp=null
mFocusedApp=ActivityRecord{caf038a u0 com.android.systemui/.subscreen.SubHomeActivity t7}
mFocusedApp=ActivityRecord{a646676 u0 com.example.android/.activity.main.MainActivity t285}
mCurrentFocus=null
mCurrentFocus=null
mCurrentFocus=Window{5e9b13b u0 com.example.android/com.example.android.activity.main.MainActivity}}
```
it comes `com.android.systemui` and `.subscreen.SubHomeActivity` right now.
As a result of this fix, it will come `com.example.android` and `.activity.main.MainActivity`.