### PR TITLE
refactor: use an object spread instead of Object.assign

### DIFF
--- a/lib/tools/apk-utils.js
+++ b/lib/tools/apk-utils.js
@@ -373,7 +373,7 @@ export async function installOrUpgrade (appPath, pkg = null, options = {}) {
   switch (appState) {
     case this.APP_INSTALL_STATE.NOT_INSTALLED:
       log.debug(`Installing '${appPath}'`);
-      await this.install(appPath, Object.assign({}, options, {replace: false}));
+      await this.install(appPath, {...options, replace: false});
       return {
         appState,
         wasUninstalled,
@@ -407,11 +407,11 @@ export async function installOrUpgrade (appPath, pkg = null, options = {}) {
   }
 
   try {
-    await this.install(appPath, Object.assign({}, options, {replace: true}));
+    await this.install(appPath, {...options, replace: true});
   } catch (err) {
     log.warn(`Cannot install/upgrade '${pkg}' because of '${err.message}'. Trying full reinstall`);
     await uninstallPackage();
-    await this.install(appPath, Object.assign({}, options, {replace: false}));
+    await this.install(appPath, {...options, replace: false});
   }
   return {
     appState,

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -862,7 +862,7 @@ export async function launchAVD (avdName, opts = {}) {
     log.debug(`Customized emulator environment: ${JSON.stringify(env)}`);
   }
   const proc = new SubProcess(emulatorBinaryPath, launchArgs, {
-    env: Object.assign({}, process.env, env),
+    env: { ...process.env, ...env },
   });
   await proc.start(0);
   for (const streamName of ['stderr', 'stdout']) {


### PR DESCRIPTION
use an object spread instead of Object.assign to make it more concise and readable