### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -203,7 +203,7 @@ export async function readPackageManifest(apkPath) {
   const extractValue = (
     /** @type {string} */ line,
     /** @type {RegExp} */ propPattern,
-    /** @type {((x: string) => any)|undefined} */ valueTransformer
+    /** @type {((x: string) => any)|null} */ valueTransformer
   ) => {
     const match = propPattern.exec(line);
     if (match) {
@@ -213,7 +213,7 @@ export async function readPackageManifest(apkPath) {
   const extractArray = (
     /** @type {string} */ line,
     /** @type {RegExp} */ propPattern,
-    /** @type {((x: string) => any)|undefined} */ valueTransformer
+    /** @type {((x: string) => any)|null} */ valueTransformer
   ) => {
     let match;
     const resultArray = [];
@@ -253,7 +253,7 @@ export async function readPackageManifest(apkPath) {
         const value = extractValue(
           line,
           /** @type {RegExp} */ (pattern),
-          /** @type {((x: string) => any)|undefined} */ (transformer)
+          /** @type {((x: string) => any)|null} */ (transformer)
         );
         if (!_.isUndefined(value)) {
           result[/** @type {string} */ (name)] = value;
@@ -270,7 +270,7 @@ export async function readPackageManifest(apkPath) {
         result.targetSdkVersion = value;
       }
     } else if (line.startsWith('uses-permission:')) {
-      const value = extractValue(line, /name='([^']+)'/);
+      const value = extractValue(line, /name='([^']+)'/, null);
       if (value) {
         result.usesPermissions.push(/** @type {string} */ (value));
       }
@@ -280,15 +280,15 @@ export async function readPackageManifest(apkPath) {
         ['label', /label='([^']+)'/],
         ['icon', /icon='([^']+)'/],
       ]) {
-        const value = extractValue(line, /** @type {RegExp} */ (pattern));
+        const value = extractValue(line, /** @type {RegExp} */ (pattern), null);
         if (value) {
           result.launchableActivity[/** @type {string} */ (name)] = value;
         }
       }
     } else if (line.startsWith('locales:')) {
-      result.locales = /** @type {string[]} */ (extractArray(line, /'([^']+)'/g));
+      result.locales = /** @type {string[]} */ (extractArray(line, /'([^']+)'/g, null));
     } else if (line.startsWith('native-code:')) {
-      result.architectures = /** @type {string[]} */ (extractArray(line, /'([^']+)'/g));
+      result.architectures = /** @type {string[]} */ (extractArray(line, /'([^']+)'/g, null));
     } else if (line.startsWith('densities:')) {
       result.densities = /** @type {number[]} */ (extractArray(line, /'([^']+)'/g, toInt));
     }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/appium/appium-adb/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "bin": {},
   "directories": {
@@ -47,7 +47,7 @@
   ],
   "homepage": "https://github.com/appium/appium-adb",
   "dependencies": {
-    "@appium/support": "^6.0.0",
+    "@appium/support": "^7.0.0-rc.1",
     "async-lock": "^1.0.0",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.4.7",
@@ -56,11 +56,13 @@
     "lru-cache": "^10.0.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.2.0"
+    "teen_process": "^3.0.0"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/test-support": "^3.0.1",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/test-support": "^4.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/async-lock": "^1.4.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10