### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-adb",
-  "version": "12.13.0",
+  "version": "12.12.6",
   "description": "Android Debug Bridge interface",
   "main": "./build/index.js",
   "scripts": {
@@ -25,8 +25,8 @@
     "url": "https://github.com/appium/appium-adb/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "bin": {},
   "directories": {
@@ -47,7 +47,7 @@
   ],
   "homepage": "https://github.com/appium/appium-adb",
   "dependencies": {
-    "@appium/support": "^6.0.0",
+    "@appium/support": "^7.0.0-rc.1",
     "async-lock": "^1.0.0",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.4.7",
@@ -56,11 +56,13 @@
     "lru-cache": "^10.0.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.2.0"
+    "teen_process": "^3.0.0"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/test-support": "^3.0.1",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/test-support": "^4.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/async-lock": "^1.4.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10