### PR TITLE
chore: drop rimraf deps from dev deps as no references

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.0.1",
     "prettier": "^3.0.0",
-    "rimraf": "^5.0.0",
     "semantic-release": "^24.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.2"


### PR DESCRIPTION
Instead of https://github.com/appium/appium-adb/pull/758