### PR TITLE
fix: Add activity name for cases the activity fully qualified name is with a different package name

### DIFF
--- a/lib/tools/app-commands.js
+++ b/lib/tools/app-commands.js
@@ -970,6 +970,9 @@ export async function waitForActivityOrNot (pkg, activity, waitForStop, waitMs =
       }
     } else {
       // accept fully qualified activity name.
+      if (oneActivity.includes('/')) {
+        possibleActivityNamesSet.add(oneActivity.split('/')[1]); // Add the activity component after '/' for a case the fully qualified name starts with a different package name
+      }
       possibleActivityNamesSet.add(toFullyQualifiedActivityName(oneActivity, ''));
       const doesIncludePackage = allPackages.some((p) => oneActivity.startsWith(p));
       if (!doesIncludePackage) {


### PR DESCRIPTION
Add the activity name for cases the activity fully qualified name is with a different package name. For example: `com.android.chrome/com.google.android.apps.chrome.Main`.

**Appium log:**
```
[HTTP] --> POST /session {"capabilities":{"alwaysMatch":{"platformName":"Android","appium:automationName":"uiautomator2","appium:appPackage":"com.android.chrome","appium:ensureWebviewsHavePages":true,"appium:nativeWebScreenshot":true,"appium:newCommandTimeout":3600,"appium:connectHardwareKeyboard":true},"firstMatch":[{}]}}
[AppiumDriver@29b2] Calling AppiumDriver.createSession() with args: [{"alwaysMatch":{"platformName":"Android","appium:automationName":"uiautomator2","appium:appPackage":"com.android.chrome","appium:ensureWebviewsHavePages":true,"appium:nativeWebScreenshot":true,"appium:newCommandTimeout":3600,"appium:connectHardwareKeyboard":true},"firstMatch":[{}]},{"alwaysMatch":{"platformName":"Android","appium:automationName":"uiautomator2","appium:appPackage":"com.android.chrome","appium:ensureWebviewsHavePages":true,"appium:nativeWebScreenshot":true,"appium:newCommandTimeout":3600,"appium:connectHardwareKeyboard":true},"firstMatch":[{}]},{"alwaysMatch":{"platformName":"Android","appium:automationName":"uiautomator2","appium:appPackage":"com.android.chrome","appium:ensureWebviewsHavePages":true,"appium:nativeWebScreenshot":true,"appium:newCommandTimeout":3600,"appium:connectHardwareKeyboard":true},"firstMatch":[{}]}]
[AppiumDriver@29b2] Event 'newSessionRequested' logged at 1757254103248 (...)
[Appium] Attempting to find matching driver for automationName 'uiautomator2' and platformName 'Android'
[Appium] The 'uiautomator2' driver was installed and matched caps.
[Appium] Will require it at /Users/dasulin/.appium/node_modules/appium-uiautomator2-driver
[Appium] Requiring driver at /Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/build/index.js
[AppiumDriver@29b2] Appium v3.0.1 creating new AndroidUiautomator2Driver (v5.0.0) session
[AppiumDriver@29b2] Checking BaseDriver versions for Appium and AndroidUiautomator2Driver
[AppiumDriver@29b2] Appium's BaseDriver version is 10.0.0
[AppiumDriver@29b2] AndroidUiautomator2Driver's BaseDriver version is 10.0.0
[AndroidUiautomator2Driver@59f0] 
[AndroidUiautomator2Driver@59f0] Creating session with W3C capabilities: {
  "alwaysMatch": {
    "platformName": "Android",
    "appium:automationName": "uiautomator2",
    "appium:appPackage": "com.android.chrome",
    "appium:ensureWebviewsHavePages": true,
    "appium:nativeWebScreenshot": true,
    "appium:newCommandTimeout": 3600,
    "appium:connectHardwareKeyboard": true
  },
  "firstMatch": [
    {}
  ]
}
[AndroidUiautomator2Driver@59f0] The following provided capabilities were not recognized by this driver:
[AndroidUiautomator2Driver@59f0]   connectHardwareKeyboard
[20c483ef][AndroidUiautomator2Driver@59f0] Session created with session id: 20c483ef-f936-4fb1-91e0-c8c119994215
[20c483ef][ADB] Found 17 'build-tools' folders under '/Users/dasulin/Library/Android/sdk' (newest first):
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/36.1.0-rc1
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/35.0.0
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/35.0.0-rc1
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/34.0.0
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/33.0.2
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/33.0.1
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/32.0.0
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/31.0.0
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/30.0.3
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/30.0.2
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/29.0.3
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/29.0.2
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/29.0.0
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/28.0.3
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/28.0.2
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/28.0.0
[20c483ef][ADB]     /Users/dasulin/Library/Android/sdk/build-tools/27.0.3
[20c483ef][ADB] Using 'adb' from '/Users/dasulin/Library/Android/sdk/platform-tools/adb'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 start-server'
[20c483ef][AndroidUiautomator2Driver@59f0] Retrieving device list
[20c483ef][ADB] Trying to find connected Android devices
[20c483ef][ADB] Getting connected devices
[20c483ef][ADB] Connected devices: [{"udid":"032a52fe","state":"device"}]
[20c483ef][AndroidUiautomator2Driver@59f0] Using device: 032a52fe
[20c483ef][ADB] Using 'adb' from '/Users/dasulin/Library/Android/sdk/platform-tools/adb'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 start-server'
[20c483ef][ADB] Setting device id to 032a52fe
[20c483ef][AndroidUiautomator2Driver@59f0] Starting 'com.android.chrome' directly on the device
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell getprop ro.build.version.sdk'
[20c483ef][ADB] Current device property 'ro.build.version.sdk': 33
[20c483ef][ADB] Getting device platform version
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell getprop ro.build.version.release'
[20c483ef][ADB] Current device property 'ro.build.version.release': 13
[20c483ef][ADB] Device API level: 33
[20c483ef][AndroidUiautomator2Driver@59f0] Relaxing hidden api policy
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell 'settings put global hidden_api_policy_pre_p_apps 1;settings put global hidden_api_policy_p_apps 1;settings put global hidden_api_policy 1''
[20c483ef][AndroidUiautomator2Driver@59f0] Parsing activity from the installed 'com.android.chrome' package manifest
[20c483ef][AndroidUiautomator2Driver@59f0] Pushing settings apk to the device...
[20c483ef][ADB] Getting package info for 'io.appium.settings'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys package io.appium.settings'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell cmd package resolve-activity --brief com.android.chrome'
[20c483ef][AndroidUiautomator2Driver@59f0] Resolved launch package -> activity: com.android.chrome -> com.android.chrome/com.google.android.apps.chrome.Main
[20c483ef][AndroidUiautomator2Driver@59f0] Resolved wait package -> activity: com.android.chrome -> com.android.chrome/com.google.android.apps.chrome.Main
[20c483ef][ADB] Using 'aapt2' from '/Users/dasulin/Library/Android/sdk/build-tools/36.1.0-rc1/aapt2'
[20c483ef][ADB] Reading package manifest: '/Users/dasulin/Library/Android/sdk/build-tools/36.1.0-rc1/aapt2 dump badging /Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/node_modules/io.appium.settings/apks/settings_apk-debug.apk'
[20c483ef][ADB] The version name of the installed 'io.appium.settings' is greater or equal to the application version name ('6.0.0' >= '6.0.0')
[20c483ef][ADB] There is no need to install/upgrade '/Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/node_modules/io.appium.settings/apks/settings_apk-debug.apk'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys activity services io.appium.settings'
[20c483ef][AndroidUiautomator2Driver@59f0] io.appium.settings is already running. There is no need to reset its permissions.
[20c483ef][Logcat] Starting logs capture with command: /Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe logcat -v threadtime
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell appops set io.appium.settings android:mock_location allow'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell "[ -e '/data/local/tmp/mock_apps.json' ] && echo __PASS__"'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell cat /data/local/tmp/mock_apps.json'
[20c483ef][AndroidUiautomator2Driver@59f0] Forwarding UiAutomator2 Server port 6790 to local port 8200
[20c483ef][ADB] Forwarding system: 8200 to device: 6790
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe forward tcp:8200 tcp:6790'
[20c483ef][AndroidUiautomator2Driver@59f0] UIA2Proxy options: {"server":"127.0.0.1","port":8200,"keepAlive":true,"scheme":"http","base":"","reqBasePath":"","sessionId":null,"timeout":240000}
[20c483ef][ADB] Getting package info for 'io.appium.uiautomator2.server'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys package io.appium.uiautomator2.server'
[20c483ef][ADB] Getting install status for io.appium.uiautomator2.server.test
[20c483ef][AndroidUiautomator2Driver@59f0] No app capability. Assuming it is already on the device
[20c483ef][ADB] Getting install status for com.android.chrome
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell cmd package list packages'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell cmd package list packages'
[20c483ef][ADB] Reading package manifest: '/Users/dasulin/Library/Android/sdk/build-tools/36.1.0-rc1/aapt2 dump badging /Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-uiautomator2-server/apks/appium-uiautomator2-server-v8.0.0.apk'
[20c483ef][ADB] 'io.appium.uiautomator2.server.test' is installed
[20c483ef][ADB] 'com.android.chrome' is installed
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell am force-stop com.android.chrome'
[20c483ef][ADB] The version name of the installed 'io.appium.uiautomator2.server' is greater or equal to the application version name ('8.0.0' >= '8.0.0')
[20c483ef][AndroidUiautomator2Driver@59f0] Server packages status: [{"installState":"sameVersionInstalled","appPath":"/Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-uiautomator2-server/apks/appium-uiautomator2-server-v8.0.0.apk","appId":"io.appium.uiautomator2.server"},{"installState":"sameVersionInstalled","appPath":"/Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-uiautomator2-server/apks/appium-uiautomator2-server-debug-androidTest.apk","appId":"io.appium.uiautomator2.server.test"}]
[20c483ef][AndroidUiautomator2Driver@59f0] Server packages are not going to be (re)installed
[20c483ef][AndroidUiautomator2Driver@59f0] Waiting up to 30000ms for services to be available
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell pm list instrumentation'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell pm clear com.android.chrome'
[20c483ef][AndroidUiautomator2Driver@59f0] Instrumentation target 'io.appium.uiautomator2.server.test/androidx.test.runner.AndroidJUnitRunner' is available
[20c483ef][ADB] Adding packages ["io.appium.settings","io.appium.uiautomator2.server","io.appium.uiautomator2.server.test"] to Doze whitelist
[20c483ef][ADB] Got the following command chunks to execute: [["dumpsys","deviceidle","whitelist","+io.appium.settings",";","dumpsys","deviceidle","whitelist","+io.appium.uiautomator2.server",";","dumpsys","deviceidle","whitelist","+io.appium.uiautomator2.server.test",";"]]
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys deviceidle whitelist +io.appium.settings ; dumpsys deviceidle whitelist +io.appium.uiautomator2.server ; dumpsys deviceidle whitelist +io.appium.uiautomator2.server.test ;'
[20c483ef][AndroidUiautomator2Driver@59f0] Performed fast reset on the installed 'com.android.chrome' application (stop and clear)
[20c483ef][AndroidUiautomator2Driver@59f0] Performing shallow cleanup of automation leftovers
[20c483ef][AndroidUiautomator2Driver@59f0] No obsolete sessions have been detected (socket hang up)
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell am force-stop io.appium.uiautomator2.server'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell am force-stop io.appium.uiautomator2.server.test'
[20c483ef][AndroidUiautomator2Driver@59f0] Starting UIAutomator2 server 8.0.0
[20c483ef][AndroidUiautomator2Driver@59f0] Using UIAutomator2 server from '/Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-uiautomator2-server/apks/appium-uiautomator2-server-v8.0.0.apk' and test from '/Users/dasulin/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-uiautomator2-server/apks/appium-uiautomator2-server-debug-androidTest.apk'
[20c483ef][AndroidUiautomator2Driver@59f0] Waiting up to 30000ms for UiAutomator2 to be online...
[20c483ef][ADB] Creating ADB subprocess with args: ["-P","5037","-s","032a52fe","shell","am","instrument","-w","-e","disableAnalytics","true","io.appium.uiautomator2.server.test/androidx.test.runner.AndroidJUnitRunner"]
[20c483ef][AndroidUiautomator2Driver@59f0] Matched '/status' to command name 'getStatus'
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [GET /status] to [GET http://127.0.0.1:8200/status] with no body
[20c483ef][AndroidUiautomator2Driver@59f0] socket hang up
[20c483ef][AndroidUiautomator2Driver@59f0] Matched '/status' to command name 'getStatus'
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [GET /status] to [GET http://127.0.0.1:8200/status] with no body
[20c483ef][AndroidUiautomator2Driver@59f0] socket hang up
[20c483ef][AndroidUiautomator2Driver@59f0] [Instrumentation] 
[20c483ef][AndroidUiautomator2Driver@59f0] Matched '/status' to command name 'getStatus'
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [GET /status] to [GET http://127.0.0.1:8200/status] with no body
[20c483ef][AndroidUiautomator2Driver@59f0] Got response with status 200: {"sessionId":"None","value":{"build":{"version":"8.0.0","versionCode":221},"message":"UiAutomator2 Server is ready to accept commands","ready":true}}
[20c483ef][AndroidUiautomator2Driver@59f0] The initialization of the instrumentation process took 2130ms
[20c483ef][AndroidUiautomator2Driver@59f0] Matched '/session' to command name 'createSession'
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [POST /session] to [POST http://127.0.0.1:8200/session] with body: {"capabilities":{"firstMatch":[{"platformName":"Android","automationName":"uiautomator2","appPackage":"com.android.chrome","ensureWebviewsHavePages":true,"nativeWebScreenshot":true,"newCommandTimeout":3600,"connectHardwareKeyboard":true,"platform":"LINUX","webStorageEnabled":false,"takesScreenshot":true,"javascriptEnabled":true,"databaseEnabled":false,"networkConnectionEnabled":true,"locationContextEnabled":false,"warnings":{},"desired":{"platformName":"Android","automationName":"uiautomator2","appPackage":"com.android.chrome","ensureWebviewsHavePages":true,"nativeWebScreenshot":true,"newCommandTimeout":3600,"connectHardwareKeyboard":true},"deviceName":"032a52fe","deviceUDID":"032a52fe","appActivity":"com.android.chrome/com.google.android.apps.chrome.Main"}],"alwaysMatch":{}}}
[20c483ef][AndroidUiautomator2Driver@59f0] Got response with status 200: {"sessionId":"c23d918d-56f4-4109-bc4a-a3747e91e436","value":{"capabilities":{"firstMatch":[{"platformName":"Android","automationName":"uiautomator2","appPackage":"com.android.chrome","ensureWebviewsHavePages":true,"nativeWebScreenshot":true,"newCommandTimeout":3600,"connectHardwareKeyboard":true,"platform":"LINUX","webStorageEnabled":false,"takesScreenshot":true,"javascriptEnabled":true,"databaseEnabled":false,"networkConnectionEnabled":true,"locationContextEnabled":false,"warnings":{},"desired":{"platformName":"Android","automationName":"uiautomator2","appPackage":"com.android.chrome","ensureWebviewsHavePages":true,"nativeWebScreenshot":true,"newCommandTimeout":3600,"connectHardwareKeyboard":true},"deviceName":"032a52fe","deviceUDID":"032a52fe","appActivity":"com.android.chrome/com.google.android.apps.chrome.Main"}],"alwaysMatch":{}},"sessionId":"c23d918d-56f4-4109-bc4a-a3747e91e436"}}
[20c483ef][AndroidUiautomator2Driver@59f0] Determined the downstream protocol as 'W3C'
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [GET /appium/device/pixel_ratio] to [GET http://127.0.0.1:8200/session/c23d918d-56f4-4109-bc4a-a3747e91e436/appium/device/pixel_ratio] with no body
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [GET /appium/device/system_bars] to [GET http://127.0.0.1:8200/session/c23d918d-56f4-4109-bc4a-a3747e91e436/appium/device/system_bars] with no body
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [GET /window/current/size] to [GET http://127.0.0.1:8200/session/c23d918d-56f4-4109-bc4a-a3747e91e436/window/current/size] with no body
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [GET /appium/device/info] to [GET http://127.0.0.1:8200/session/c23d918d-56f4-4109-bc4a-a3747e91e436/appium/device/info] with no body
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys power'
[20c483ef][AndroidUiautomator2Driver@59f0] Got response with status 200: {"sessionId":"c23d918d-56f4-4109-bc4a-a3747e91e436","value":3}
[20c483ef][AndroidUiautomator2Driver@59f0] Got response with status 200: {"sessionId":"c23d918d-56f4-4109-bc4a-a3747e91e436","value":{"statusBar":93}}
[20c483ef][AndroidUiautomator2Driver@59f0] Got response with status 200: {"sessionId":"c23d918d-56f4-4109-bc4a-a3747e91e436","value":{"height":2376,"width":1080}}
[20c483ef][AndroidUiautomator2Driver@59f0] Got response with status 200: {"sessionId":"c23d918d-56f4-4109-bc4a-a3747e91e436","value":{"androidId":"8114962d2ed3ac5f","apiVersion":"33","bluetooth":{"state":"OFF"},"brand":"OnePlus","carrierName":"","displayDensity":480,"locale":"en_US","manufacturer":"OnePlus","model":"IN2023","networks":[{"capabilities":{"SSID":null,"linkDownBandwidthKbps":41321,"linkUpstreamBandwidthKbps":1805,"networkCapabilities":"NET_CAPABILITY_NOT_METERED,NET_CAPABILITY_INTERNET,NET_CAPABILITY_NOT_RESTRICTED,NET_CAPABILITY_TRUSTED,NET_CAPABILITY_NOT_VPN,NET_CAPABILITY_VALIDATED,NET_CAPABILITY_NOT_ROAMING,NET_CAPABILITY_FOREGROUND,NET_CAPABILITY_NOT_CONGESTED,NET_CAPABILITY_NOT_SUSPENDED","signalStrength":-65,"transportTypes":"TRANSPORT_WIFI"},"detailedState":"CONNECTED","extraInfo":"","isAvailable":true,"isConnected":true,"isFailover":false,"isRoaming":false,"state":"CONNECTED","subtype":-1,"subtypeName":"","type":1,"typeName":"WIFI"}],"platformVersion":"13","realDisplaySize":"1080x2376","timeZone":"Asia/Jerusalem"}}
[20c483ef][AndroidUiautomator2Driver@59f0] Screen is locked, trying to unlock
[20c483ef][AndroidUiautomator2Driver@59f0] Neither 'unlockType' nor 'unlockKey' capability is provided. Assuming the device is locked with a simple lock screen.
[20c483ef][ADB] Waking up the device to dismiss the keyguard
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell input keyevent 26'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell input keyevent 224'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell wm dismiss-keyguard'
[20c483ef][AndroidUiautomator2Driver@59f0] Starting 'com.android.chrome/com.android.chrome/com.google.android.apps.chrome.Main' and waiting for 'com.android.chrome/com.android.chrome/com.google.android.apps.chrome.Main'
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell am start-activity -W -n com.android.chrome/com.google.android.apps.chrome.Main -S -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -f 0x10200000'
[20c483ef][ADB] Expected package names to be focused within 20000ms: 'com.android.chrome'
[20c483ef][ADB] Expected activity name patterns to be focused within 20000ms: '/^com\.android\.chrome\.com\.google\.android\.apps\.chrome\.Main$/'
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: org.chromium.chrome.browser.firstrun.FirstRunActivity
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][ADB] Getting focused package and activity
[20c483ef][ADB] Running '/Users/dasulin/Library/Android/sdk/platform-tools/adb -P 5037 -s 032a52fe shell dumpsys window displays'
[20c483ef][ADB] Focused package: com.android.chrome
[20c483ef][ADB] Focused fully qualified activity name: com.google.android.apps.chrome.Main
[20c483ef][ADB] None of the expected package/activity combinations matched to the currently focused one. Retrying
[20c483ef][AndroidUiautomator2Driver@59f0] Deleting UiAutomator2 session
[20c483ef][AndroidUiautomator2Driver@59f0] Deleting UiAutomator2 server session
[20c483ef][AndroidUiautomator2Driver@59f0] Proxying [DELETE /] to [DELETE http://127.0.0.1:8200/session/c23d918d-56f4-4109-bc4a-a3747e91e436] with no body
```