### PR TITLE
fix: Windows APK signature verification when Java/SDK paths contain spaces

### DIFF
--- a/lib/tools/apk-signing.ts
+++ b/lib/tools/apk-signing.ts
@@ -40,8 +40,6 @@ export async function executeApksigner(this: ADB, args: string[]): Promise<strin
   // It is necessary to specify CWD explicitly; see https://github.com/appium/appium/issues/14724#issuecomment-737446715
   const {stdout, stderr} = await exec(fullCmd[0], fullCmd.slice(1), {
     cwd: path.dirname(apkSignerJar),
-    // @ts-ignore This works
-    windowsVerbatimArguments: system.isWindows(),
   });
   for (const [name, stream] of [
     ['stdout', stdout],
@@ -157,10 +155,7 @@ export async function signWithCustomCert(this: ADB, apk: string): Promise<void> 
         this.keyAlias as string,
       ];
       log.debug(`Starting jarsigner: ${util.quote(fullCmd)}`);
-      await exec(fullCmd[0], fullCmd.slice(1), {
-        // @ts-ignore This works
-        windowsVerbatimArguments: system.isWindows(),
-      });
+      await exec(fullCmd[0], fullCmd.slice(1));
     } catch (e) {
       const execErr = e as ExecError;
       throw new Error(
@@ -378,10 +373,7 @@ export async function getKeystoreHash(this: ADB): Promise<KeystoreHash> {
   ];
   log.info(`Running '${keytool}' with arguments: ${util.quote(args)}`);
   try {
-    const {stdout} = await exec(keytool, args, {
-      // @ts-ignore This property is ok
-      windowsVerbatimArguments: system.isWindows(),
-    });
+    const {stdout} = await exec(keytool, args);
     const result: KeystoreHash = {};
     for (const hashName of [SHA512, SHA256, SHA1, MD5]) {
       const hashRe = new RegExp(`^\\s*${hashName}:\\s*([a-f0-9:]+)`, 'mi');

--- a/test/unit/apk-signing-specs.ts
+++ b/test/unit/apk-signing-specs.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import * as teen_process from 'teen_process';
 import * as appiumSupport from '@appium/support';
 import {zip} from '@appium/support';
+import type {ZipEntry} from '@appium/support';
 import sinon from 'sinon';
 import * as apkSigningHelpers from '../../lib/tools/apk-signing';
 import {APIDEMOS_PKG} from '../constants';
@@ -191,7 +192,10 @@ describe('signing', function () {
       /* eslint-disable promise/prefer-await-to-callbacks -- zip.readEntries is callback-based */
       sandbox.stub(zip, 'readEntries').callsFake(async (apkPath, callback) => {
         // Call callback with a non-META-INF entry so hasMetaInf stays false
-        callback({entry: {fileName: 'AndroidManifest.xml'}});
+        callback({
+          entry: {fileName: 'AndroidManifest.xml'},
+          extractEntryTo: async () => {},
+        } as ZipEntry);
       });
       /* eslint-enable promise/prefer-await-to-callbacks */
       await adb.signWithCustomCert(apiDemosPath);

--- a/test/unit/apk-signing-specs.ts
+++ b/test/unit/apk-signing-specs.ts
@@ -171,41 +171,30 @@ describe('signing', function () {
       innerExecStub = sandbox.stub();
       innerExecStub.withArgs(javaDummyPath).throws(new Error('apksigner failed'));
       innerExecStub
-        .withArgs(
-          jarsigner,
-          [
-            '-sigalg',
-            'MD5withRSA',
-            '-digestalg',
-            'SHA1',
-            '-keystore',
-            keystorePath,
-            '-storepass',
-            password,
-            '-keypass',
-            password,
-            apiDemosPath,
-            keyAlias,
-          ],
-          {windowsVerbatimArguments: appiumSupport.system.isWindows()},
-        )
+        .withArgs(jarsigner, [
+          '-sigalg',
+          'MD5withRSA',
+          '-digestalg',
+          'SHA1',
+          '-keystore',
+          keystorePath,
+          '-storepass',
+          password,
+          '-keypass',
+          password,
+          apiDemosPath,
+          keyAlias,
+        ])
         .returns({});
       sandbox.stub(teen_process, 'exec').get(() => innerExecStub);
       // Mock zip.readEntries to indicate no META-INF (so unsignApk returns false)
-      // We need to stub the actual zip object since it's imported as a named import
-      const originalReadEntries = zip.readEntries;
-      // eslint-disable-next-line promise/prefer-await-to-callbacks
-      zip.readEntries = async (apkPath, callback) => {
+      /* eslint-disable promise/prefer-await-to-callbacks -- zip.readEntries is callback-based */
+      sandbox.stub(zip, 'readEntries').callsFake(async (apkPath, callback) => {
         // Call callback with a non-META-INF entry so hasMetaInf stays false
-        // eslint-disable-next-line promise/prefer-await-to-callbacks
         callback({entry: {fileName: 'AndroidManifest.xml'}});
-      };
-      try {
-        await adb.signWithCustomCert(apiDemosPath);
-      } finally {
-        // Restore original function
-        zip.readEntries = originalReadEntries;
-      }
+      });
+      /* eslint-enable promise/prefer-await-to-callbacks */
+      await adb.signWithCustomCert(apiDemosPath);
       expect(innerExecStub.callCount).to.eql(2);
     });
   });


### PR DESCRIPTION
### Summary

Removes `windowsVerbatimArguments` from `teen_process.exec` calls in `lib/tools/apk-signing.ts` so Node applies the default Windows quoting for `CreateProcess`. That restores correct behavior when `JAVA_HOME` or other paths include spaces (e.g. `C:\Program Files\Java\...`).

### Problem

On Windows, APK cert checks failed with errors like:

`Could not find or load main class Files\Java\jdk-25.0.2\bin\java.exe`

With `windowsVerbatimArguments: true`, paths with spaces were not handled the same way as in a normal shell invocation, so the JVM saw a truncated or wrong “main class” string. See [appium/appium-adb#867](https://github.com/appium/appium-adb/issues/867).

### Changes

- **`executeApksigner`**: `exec` options now only set `cwd` (same as before for apksigner layout).
- **`signWithCustomCert` (jarsigner fallback)**: `exec` with two arguments only, no verbatim flag.
- **`getKeystoreHash`**: `exec(keytool, args)` with no extra options.

### Tests

- **`test/unit/apk-signing-specs.ts`**: Jarsigner `exec` expectation updated (no third options object). `zip.readEntries` mock uses `sandbox.stub(zip, 'readEntries')` instead of assigning to the imported namespace (satisfies `import/namespace`), with a narrow `eslint-disable` for the callback-shaped mock.

### Notes

`windowsVerbatimArguments` was added in [#591](https://github.com/appium/appium-adb/pull/591) for Windows; current `child_process` / `teen_process` behavior makes it unsafe for these Java invocations when paths contain spaces. Other call sites (e.g. bundletool) already omit this flag.