### PR TITLE
feat: Cleanup deprecated/unused entities and add method overloads

### DIFF
--- a/lib/adb.ts
+++ b/lib/adb.ts
@@ -206,12 +206,11 @@ export class ADB implements ADBOptions {
   killServer = systemCommands.killServer;
   resetTelnetAuthToken = systemCommands.resetTelnetAuthToken;
   adbExecEmu = systemCommands.adbExecEmu;
-  EXEC_OUTPUT_FORMAT = systemCommands.EXEC_OUTPUT_FORMAT;
+  EXEC_OUTPUT_FORMAT: typeof systemCommands.EXEC_OUTPUT_FORMAT = systemCommands.EXEC_OUTPUT_FORMAT;
   adbExec = systemCommands.adbExec;
   shell = systemCommands.shell;
   shellChunks = systemCommands.shellChunks;
   createSubProcess = systemCommands.createSubProcess;
-  getAdbServerPort = systemCommands.getAdbServerPort;
   getEmulatorPort = systemCommands.getEmulatorPort;
   getPortFromEmulatorString = systemCommands.getPortFromEmulatorString;
   getConnectedEmulators = systemCommands.getConnectedEmulators;

--- a/lib/tools/apk-signing.ts
+++ b/lib/tools/apk-signing.ts
@@ -250,14 +250,12 @@ export async function zipAlignApk(this: ADB, apk: string): Promise<boolean> {
  * Check if the app is already signed with the default Appium certificate.
  *
  * @param appPath - The full path to the local .apk(s) file.
- * @param pkg - The name of application package.
  * @param opts - Certificate checking options
  * @returns True if given application is already signed.
  */
 export async function checkApkCert(
   this: ADB,
   appPath: string,
-  pkg: string,
   opts: CertCheckOptions = {},
 ): Promise<boolean> {
   log.debug(`Checking app cert for ${appPath}`);

--- a/lib/tools/device-settings.ts
+++ b/lib/tools/device-settings.ts
@@ -586,9 +586,9 @@ export async function setBluetoothOn(this: ADB, on: boolean): Promise<void> {
  * @throws If there was an error while changing the service state
  */
 export async function setNfcOn(this: ADB, on: boolean): Promise<void> {
-  const {stdout, stderr} = (await this.shell(['svc', 'nfc', on ? 'enable' : 'disable'], {
+  const {stdout, stderr} = await this.shell(['svc', 'nfc', on ? 'enable' : 'disable'], {
     outputFormat: 'full',
-  })) as {stdout: string; stderr: string};
+  });
   const output = stderr || stdout;
   log.debug(output);
   if (output.includes('null NfcAdapter')) {

--- a/lib/tools/system-calls.ts
+++ b/lib/tools/system-calls.ts
@@ -10,14 +10,16 @@ import {DEFAULT_ADB_EXEC_TIMEOUT, cloneDeep, getSdkRootFromEnv, memoize, zip} fr
 import type {
   ConnectedDevicesOptions,
   Device,
+  VerboseDevice,
   AvdLaunchOptions,
   Version,
   RootResult,
   ShellExecOptions,
   SpecialAdbExecOptions,
-  TFullOutputOption,
   ExecResult,
 } from './types';
+
+type AdbExecOptions = ShellExecOptions & SpecialAdbExecOptions;
 
 const DEFAULT_ADB_REBOOT_RETRIES = 90;
 const LINKER_WARNING_REGEXP = /^WARNING: linker.+$/m;
@@ -212,14 +214,29 @@ export async function getBinaryFromPath(this: ADB, binaryName: string): Promise<
 /**
  * Retrieve the list of devices visible to adb.
  *
+ * @param opts - Options with `verbose: true` for long `adb devices -l` output
+ * @returns Array of connected devices with product/model metadata
+ * @throws {Error} If adb devices command fails or returns unexpected output
+ */
+export async function getConnectedDevices(
+  this: ADB,
+  opts: ConnectedDevicesOptions & {verbose: true},
+): Promise<VerboseDevice[]>;
+/**
+ * Retrieve the list of devices visible to adb.
+ *
  * @param opts - Options for device retrieval
  * @returns Array of connected devices
  * @throws {Error} If adb devices command fails or returns unexpected output
  */
 export async function getConnectedDevices(
   this: ADB,
+  opts?: ConnectedDevicesOptions,
+): Promise<Device[]>;
+export async function getConnectedDevices(
+  this: ADB,
   opts: ConnectedDevicesOptions = {},
-): Promise<Device[]> {
+): Promise<Device[] | VerboseDevice[]> {
   log.debug('Getting connected devices');
   const args = [...this.executable.defaultArgs, 'devices'];
   if (opts.verbose) {
@@ -256,15 +273,32 @@ export async function getConnectedDevices(
     .map((line) => {
       // state is "device", afaic
       const [udid, state, ...description] = line.split(/\s+/);
-      const device: Device & Record<string, string> = {udid, state} as Device &
-        Record<string, string>;
-      if (opts.verbose) {
-        for (const entry of description) {
-          if (entry.includes(':')) {
-            // each entry looks like key:value
-            const [key, value] = entry.split(':');
-            device[key] = value;
-          }
+      if (!opts.verbose) {
+        return {udid, state};
+      }
+      const device: VerboseDevice = {
+        udid,
+        state,
+        product: '',
+        model: '',
+        device: '',
+      };
+      for (const entry of description) {
+        if (!entry.includes(':')) {
+          continue;
+        }
+        // each entry looks like key:value
+        const [key, value] = entry.split(':');
+        if (key === 'product') {
+          device.product = value;
+        } else if (key === 'model') {
+          device.model = value;
+        } else if (key === 'device') {
+          device.device = value;
+        } else if (key === 'usb') {
+          device.usb = value;
+        } else if (key === 'transport_id') {
+          device.transport_id = value;
         }
       }
       return device;
@@ -437,23 +471,38 @@ export const EXEC_OUTPUT_FORMAT = {
  * Execute the given adb command.
  *
  * @param cmd - Command string or array of command arguments
- * @param opts - Execution options
- * @returns Command output (string or ExecResult depending on outputFormat)
+ * @param opts - Execution options with `outputFormat: 'full'`
+ * @returns Command stdout and stderr
  * @throws {Error} If command execution fails or timeout is exceeded
  */
-export async function adbExec<
-  TExecOpts extends ShellExecOptions & SpecialAdbExecOptions = ShellExecOptions &
-    SpecialAdbExecOptions,
->(
+export async function adbExec(
   this: ADB,
   cmd: string | string[],
-  opts?: TExecOpts,
-): Promise<TExecOpts extends TFullOutputOption ? ExecResult : string> {
+  opts: AdbExecOptions & {outputFormat: 'full'},
+): Promise<ExecResult>;
+/**
+ * Execute the given adb command.
+ *
+ * @param cmd - Command string or array of command arguments
+ * @param opts - Execution options
+ * @returns Command stdout
+ * @throws {Error} If command execution fails or timeout is exceeded
+ */
+export async function adbExec(
+  this: ADB,
+  cmd: string | string[],
+  opts?: AdbExecOptions,
+): Promise<string>;
+export async function adbExec(
+  this: ADB,
+  cmd: string | string[],
+  opts?: AdbExecOptions,
+): Promise<string | ExecResult> {
   if (!cmd) {
     throw new Error('You need to pass in a command to adbExec()');
   }
 
-  const optsCopy = cloneDeep(opts ?? {}) as TExecOpts;
+  const optsCopy = cloneDeep(opts ?? {}) as AdbExecOptions;
   // setting default timeout for each command to prevent infinite wait.
   optsCopy.timeout = optsCopy.timeout || this.adbExecTimeout || DEFAULT_ADB_EXEC_TIMEOUT;
   optsCopy.timeoutCapName = optsCopy.timeoutCapName || 'adbExecTimeout'; // For error message
@@ -523,7 +572,7 @@ export async function adbExec<
     isExecLocked = true;
   }
   try {
-    return (await execFunc()) as TExecOpts extends TFullOutputOption ? ExecResult : string;
+    return await execFunc();
   } finally {
     if (optsCopy.exclusive) {
       isExecLocked = false;
@@ -535,16 +584,34 @@ export async function adbExec<
  * Execute the given command using _adb shell_ prefix.
  *
  * @param cmd - Command string or array of command arguments
- * @param opts - Execution options
- * @returns Command output (string or ExecResult depending on outputFormat)
+ * @param opts - Execution options with `outputFormat: 'full'`
+ * @returns Command stdout and stderr
  * @throws {Error} If command execution fails
  */
-export async function shell<TShellExecOpts extends ShellExecOptions = ShellExecOptions>(
+export async function shell(
   this: ADB,
   cmd: string | string[],
-  opts?: TShellExecOpts,
-): Promise<TShellExecOpts extends TFullOutputOption ? ExecResult : string> {
-  const {privileged} = opts ?? ({} as TShellExecOpts);
+  opts: ShellExecOptions & {outputFormat: 'full'},
+): Promise<ExecResult>;
+/**
+ * Execute the given command using _adb shell_ prefix.
+ *
+ * @param cmd - Command string or array of command arguments
+ * @param opts - Execution options
+ * @returns Command stdout
+ * @throws {Error} If command execution fails
+ */
+export async function shell(
+  this: ADB,
+  cmd: string | string[],
+  opts?: ShellExecOptions,
+): Promise<string>;
+export async function shell(
+  this: ADB,
+  cmd: string | string[],
+  opts?: ShellExecOptions,
+): Promise<string | ExecResult> {
+  const {privileged} = opts ?? {};
 
   const cmdArr = Array.isArray(cmd) ? cmd : [cmd];
   const fullCmd: string[] = ['shell'];
@@ -573,17 +640,6 @@ export function createSubProcess(this: ADB, args: string[] = []): SubProcess {
   const finalArgs = [...this.executable.defaultArgs, ...args];
   log.debug(`Creating ADB subprocess with args: ${JSON.stringify(finalArgs)}`);
   return new SubProcess(this.getAdbPath(), finalArgs);
-}
-
-/**
- * Retrieve the current adb port.
- * @todo can probably deprecate this now that the logic is just to read this.adbPort
- * @deprecated Use this.adbPort instead
- *
- * @returns The ADB server port number
- */
-export function getAdbServerPort(this: ADB): number {
-  return this.adbPort as number;
 }
 
 /**
@@ -626,18 +682,35 @@ export function getPortFromEmulatorString(this: ADB, emStr: string): number | fa
 /**
  * Retrieve the list of currently connected emulators.
  *
+ * @param opts - Options with `verbose: true` for long `adb devices -l` output
+ * @returns Array of connected emulator devices with product/model metadata
+ * @throws {Error} If error occurs while getting emulators
+ */
+export async function getConnectedEmulators(
+  this: ADB,
+  opts: ConnectedDevicesOptions & {verbose: true},
+): Promise<VerboseDevice[]>;
+/**
+ * Retrieve the list of currently connected emulators.
+ *
  * @param opts - Options for device retrieval
  * @returns Array of connected emulator devices
  * @throws {Error} If error occurs while getting emulators
  */
 export async function getConnectedEmulators(
   this: ADB,
+  opts?: ConnectedDevicesOptions,
+): Promise<Device[]>;
+export async function getConnectedEmulators(
+  this: ADB,
   opts: ConnectedDevicesOptions = {},
-): Promise<Device[]> {
+): Promise<Device[] | VerboseDevice[]> {
   log.debug('Getting connected emulators');
   try {
-    const devices = await this.getConnectedDevices(opts);
-    const emulators: Device[] = [];
+    const devices = opts.verbose
+      ? await this.getConnectedDevices({verbose: true})
+      : await this.getConnectedDevices(opts);
+    const emulators: Array<Device | VerboseDevice> = [];
     for (const device of devices) {
       const port = this.getPortFromEmulatorString(device.udid);
       if (port) {

--- a/lib/tools/types.ts
+++ b/lib/tools/types.ts
@@ -658,8 +658,6 @@ export interface ShellExecOptions {
   outputFormat?: ExecOutputFormat;
 }
 
-export type TFullOutputOption = {outputFormat: 'full'};
-
 export interface AvdLaunchOptions {
   /**
    * Additional emulator command line arguments

--- a/test/functional/apk-signing-e2e-specs.ts
+++ b/test/functional/apk-signing-e2e-specs.ts
@@ -2,7 +2,7 @@ import {ADB} from '../../lib/adb';
 import path from 'node:path';
 import {fs, tempDir} from '@appium/support';
 import {unsignApk} from '../../lib/tools/apk-signing';
-import {APIDEMOS_PKG, getApiDemosPath} from './setup';
+import {getApiDemosPath} from './setup';
 import chai, {expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -36,20 +36,19 @@ describe('Apk-signing', function () {
     const apkCopy = path.resolve(tmpDir, path.basename(apiDemosPath));
     await fs.copyFile(apiDemosPath, apkCopy);
     await unsignApk(apkCopy);
-    expect(await adb.checkApkCert(apkCopy, APIDEMOS_PKG)).to.be.false;
+    expect(await adb.checkApkCert(apkCopy)).to.be.false;
   });
   it('checkApkCert should return true for signed apk', async function () {
     // ApiDemos APK is signed but not with the default Appium certificate
     // So we check with requireDefaultCert: false to verify it's signed
-    expect(await adb.checkApkCert(apiDemosPath, APIDEMOS_PKG, {requireDefaultCert: false})).to.be
-      .true;
+    expect(await adb.checkApkCert(apiDemosPath, {requireDefaultCert: false})).to.be.true;
   });
   it('signWithDefaultCert should sign apk', async function () {
     const apkCopy = path.resolve(tmpDir, path.basename(apiDemosPath));
     await fs.copyFile(apiDemosPath, apkCopy);
     await unsignApk(apkCopy);
     await adb.signWithDefaultCert(apkCopy);
-    expect(await adb.checkApkCert(apkCopy, APIDEMOS_PKG)).to.be.true;
+    expect(await adb.checkApkCert(apkCopy)).to.be.true;
   });
   it('signWithCustomCert should sign apk with custom certificate', async function () {
     const customAdb = await ADB.createADB();
@@ -62,6 +61,6 @@ describe('Apk-signing', function () {
     customAdb.keystorePassword = 'android';
     customAdb.keyPassword = 'android';
     await customAdb.signWithCustomCert(apkCopy);
-    expect(await customAdb.checkApkCert(apkCopy, APIDEMOS_PKG)).to.be.true;
+    expect(await customAdb.checkApkCert(apkCopy)).to.be.true;
   });
 });

--- a/test/unit/apk-signing-specs.ts
+++ b/test/unit/apk-signing-specs.ts
@@ -6,7 +6,6 @@ import {zip} from '@appium/support';
 import type {ZipEntry} from '@appium/support';
 import sinon from 'sinon';
 import * as apkSigningHelpers from '../../lib/tools/apk-signing';
-import {APIDEMOS_PKG} from '../constants';
 import chai, {expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as helpers from '../../lib/utils';
@@ -17,7 +16,6 @@ const defaultKeyPath = path.resolve(__dirname, '..', '..', 'keys', 'testkey.pk8'
 const defaultCertPath = path.resolve(__dirname, '..', '..', 'keys', 'testkey.x509.pem');
 const keyAlias = 'appiumtest';
 const password = 'android';
-const apiDemosPackage = APIDEMOS_PKG;
 const javaDummyPath = 'java_dummy_path';
 const javaHome = 'java_home';
 const apksignerDummyPath = '/path/to/apksigner';
@@ -240,7 +238,7 @@ describe('signing', function () {
   describe('checkApkCert', function () {
     it('should return false for apk not present', async function () {
       mocks.fs.expects('exists').once().withExactArgs('dummyPath').returns(false);
-      expect(await adb.checkApkCert('dummyPath', 'dummyPackage')).to.be.false;
+      expect(await adb.checkApkCert('dummyPath')).to.be.false;
     });
 
     it('should check default signature when not using keystore', async function () {
@@ -272,7 +270,7 @@ describe('signing', function () {
             stderr: '',
           }),
       );
-      expect(await adb.checkApkCert(apiDemosPath, apiDemosPackage)).to.be.true;
+      expect(await adb.checkApkCert(apiDemosPath)).to.be.true;
     });
 
     it('should check non default signature when not using keystore', async function () {
@@ -304,7 +302,7 @@ describe('signing', function () {
             stderr: '',
           }),
       );
-      const result = await adb.checkApkCert(apiDemosPath, apiDemosPackage, {
+      const result = await adb.checkApkCert(apiDemosPath, {
         requireDefaultCert: false,
       });
       expect(result).to.be.true;
@@ -324,7 +322,7 @@ describe('signing', function () {
         .once()
         .withExactArgs('apksigner.jar')
         .throws(new Error('apksigner not found'));
-      await expect(adb.checkApkCert(apiDemosPath, apiDemosPackage)).to.eventually.be.rejected;
+      await expect(adb.checkApkCert(apiDemosPath)).to.eventually.be.rejected;
     });
 
     it('should call getKeystoreHash when using keystore', async function () {
@@ -361,7 +359,7 @@ describe('signing', function () {
             stderr: '',
           }),
       );
-      await expect(adb.checkApkCert(apiDemosPath, apiDemosPackage)).to.eventually.be.true;
+      await expect(adb.checkApkCert(apiDemosPath)).to.eventually.be.true;
     });
   });
 });


### PR DESCRIPTION
### Summary

- Remove unused `pkg` argument from `checkApkCert`
- Remove deprecated `getAdbServerPort` (use `adb.adbPort` instead)
- Replace conditional generic return types on `adbExec` and `shell` with overloads keyed on `outputFormat: 'full'`
- Add overloads on `getConnectedDevices` and `getConnectedEmulators` keyed on `verbose: true` → `VerboseDevice[]`
- Type `EXEC_OUTPUT_FORMAT` on `ADB` so literal `'full'` resolves correctly at call sites
- Remove unused `TFullOutputOption` type

```
BREAKING CHANGE: `checkApkCert(appPath, pkg, opts?)` is now `checkApkCert(appPath, opts?)`. The `pkg` argument was never used.

BREAKING CHANGE: Deprecated `getAdbServerPort()` has been removed. Use `adb.adbPort` instead.

BREAKING CHANGE: `TFullOutputOption` type has been removed
```

### Migration

| Before | After |
|--------|-------|
| `adb.checkApkCert(appPath, pkg)` | `adb.checkApkCert(appPath)` |
| `adb.checkApkCert(appPath, pkg, opts)` | `adb.checkApkCert(appPath, opts)` |
| `adb.getAdbServerPort()` | `adb.adbPort` |

### Type improvements (non-breaking)

- `adbExec(cmd, {outputFormat: 'full'})` → `Promise<ExecResult>`
- `shell(cmd, {outputFormat: 'full'})` → `Promise<ExecResult>`
- `getConnectedDevices({verbose: true})` → `Promise<VerboseDevice[]>`
- `getConnectedEmulators({verbose: true})` → `Promise<VerboseDevice[]>`
