### PR TITLE
feat!: Migrate the package to ESM

### DIFF
--- a/lib/adb.ts
+++ b/lib/adb.ts
@@ -1,28 +1,28 @@
 import os from 'node:os';
-import {log} from './logger';
-import type {ADBOptions, ADBExecutable} from './types';
-import type {Logcat} from './logcat';
-import type {LogcatOpts, StringRecord} from './tools/types';
+import {log} from './logger.js';
+import type {ADBOptions, ADBExecutable} from './types.js';
+import type {Logcat} from './logcat.js';
+import type {LogcatOpts, StringRecord} from './tools/types.js';
 import type {LRUCache} from 'lru-cache';
 import type {ExecError} from 'teen_process';
 
-import * as generalCommands from './tools/general-commands';
-import * as manifestCommands from './tools/android-manifest';
-import * as systemCommands from './tools/system-calls';
-import * as signingCommands from './tools/apk-signing';
-import * as apkUtilCommands from './tools/apk-utils';
-import * as apksUtilCommands from './tools/apks-utils';
-import * as aabUtilCommands from './tools/aab-utils';
-import * as emuCommands from './tools/emulator-commands';
-import * as emuConstants from './tools/emu-constants';
-import * as lockManagementCommands from './tools/lockmgmt';
-import * as keyboardCommands from './tools/keyboard-commands';
-import * as deviceSettingsCommands from './tools/device-settings';
-import * as fsCommands from './tools/fs-commands';
-import * as appCommands from './tools/app-commands';
-import * as networkCommands from './tools/network-commands';
-import * as logcatCommands from './tools/logcat-commands';
-import * as processCommands from './tools/process-commands';
+import * as generalCommands from './tools/general-commands.js';
+import * as manifestCommands from './tools/android-manifest.js';
+import * as systemCommands from './tools/system-calls.js';
+import * as signingCommands from './tools/apk-signing.js';
+import * as apkUtilCommands from './tools/apk-utils.js';
+import * as apksUtilCommands from './tools/apks-utils.js';
+import * as aabUtilCommands from './tools/aab-utils.js';
+import * as emuCommands from './tools/emulator-commands.js';
+import * as emuConstants from './tools/emu-constants.js';
+import * as lockManagementCommands from './tools/lockmgmt.js';
+import * as keyboardCommands from './tools/keyboard-commands.js';
+import * as deviceSettingsCommands from './tools/device-settings.js';
+import * as fsCommands from './tools/fs-commands.js';
+import * as appCommands from './tools/app-commands.js';
+import * as networkCommands from './tools/network-commands.js';
+import * as logcatCommands from './tools/logcat-commands.js';
+import * as processCommands from './tools/process-commands.js';
 import {
   DEFAULT_ADB_EXEC_TIMEOUT,
   cloneDeep,
@@ -30,7 +30,7 @@ import {
   getSdkRootFromEnv,
   pick,
   requireSdkRoot,
-} from './utils';
+} from './utils/index.js';
 
 export const DEFAULT_ADB_PORT = 5037;
 export const DEFAULT_OPTS = {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,8 +1,8 @@
-export * from './adb';
-export {getAndroidBinaryPath} from './tools/system-calls';
-export {getSdkRootFromEnv} from './utils';
-export type * from './tools/types';
-export type * from './types';
+export * from './adb.js';
+export {getAndroidBinaryPath} from './tools/system-calls.js';
+export {getSdkRootFromEnv} from './utils/index.js';
+export type * from './tools/types.js';
+export type * from './types.js';
 
-import {ADB} from './adb';
+import {ADB} from './adb.js';
 export default ADB;

--- a/lib/logcat.ts
+++ b/lib/logcat.ts
@@ -3,8 +3,8 @@ import {EventEmitter} from 'node:events';
 import {SubProcess, exec} from 'teen_process';
 import {LRUCache} from 'lru-cache';
 import type {ExecError} from 'teen_process';
-import type {ADBExecutable} from './types';
-import type {LogEntry, LogcatOpts as StartCaptureOptions} from './tools/types';
+import type {ADBExecutable} from './types.js';
+import type {LogEntry, LogcatOpts as StartCaptureOptions} from './tools/types.js';
 
 const log = logger.getLogger('Logcat');
 const MAX_BUFFER_SIZE = 10000;

--- a/lib/tools/aab-utils.ts
+++ b/lib/tools/aab-utils.ts
@@ -1,12 +1,12 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import path from 'node:path';
 import {fs, tempDir, util} from '@appium/support';
 import {LRUCache} from 'lru-cache';
 import AsyncLock from 'async-lock';
 import crypto from 'node:crypto';
-import type {ADB} from '../adb';
-import type {ApkCreationOptions, StringRecord} from './types';
-import {unzipFile} from '../utils';
+import type {ADB} from '../adb.js';
+import type {ApkCreationOptions, StringRecord} from './types.js';
+import {unzipFile} from '../utils/index.js';
 
 const AAB_CACHE = new LRUCache<string, string>({
   max: 10,

--- a/lib/tools/android-manifest.ts
+++ b/lib/tools/android-manifest.ts
@@ -1,10 +1,10 @@
 import {exec} from 'teen_process';
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {fs, zip, tempDir, util} from '@appium/support';
 import path from 'node:path';
-import type {ADB} from '../adb';
-import type {APKInfo, PlatformInfo, StringRecord} from './types';
-import {APKS_EXTENSION, readPackageManifest, unzipFile} from '../utils';
+import type {ADB} from '../adb.js';
+import type {APKInfo, PlatformInfo, StringRecord} from './types.js';
+import {APKS_EXTENSION, readPackageManifest, unzipFile} from '../utils/index.js';
 
 /**
  * Extract package and main activity name from application manifest.

--- a/lib/tools/apk-signing.ts
+++ b/lib/tools/apk-signing.ts
@@ -1,12 +1,12 @@
 import _fs from 'node:fs';
 import {exec, type ExecError} from 'teen_process';
 import path from 'node:path';
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {tempDir, system, mkdirp, fs, util, zip} from '@appium/support';
 import {LRUCache} from 'lru-cache';
-import type {ADB} from '../adb';
-import type {StringRecord, SignedAppCacheValue, CertCheckOptions, KeystoreHash} from './types';
-import {APKS_EXTENSION, getJavaForOs, getJavaHome, getResourcePath} from '../utils';
+import type {ADB} from '../adb.js';
+import type {StringRecord, SignedAppCacheValue, CertCheckOptions, KeystoreHash} from './types.js';
+import {APKS_EXTENSION, getJavaForOs, getJavaHome, getResourcePath} from '../utils/index.js';
 
 const DEFAULT_PRIVATE_KEY = path.join('keys', 'testkey.pk8');
 const DEFAULT_CERTIFICATE = path.join('keys', 'testkey.x509.pem');

--- a/lib/tools/apk-utils.ts
+++ b/lib/tools/apk-utils.ts
@@ -1,11 +1,11 @@
 import {exec, type ExecError} from 'teen_process';
-import {log} from '../logger';
+import {log} from '../logger.js';
 import path from 'node:path';
 import {fs, util, mkdirp, timing} from '@appium/support';
 import * as semver from 'semver';
 import os from 'node:os';
 import {LRUCache} from 'lru-cache';
-import type {ADB} from '../adb';
+import type {ADB} from '../adb.js';
 import {
   APKS_EXTENSION,
   APK_INSTALL_TIMEOUT,
@@ -14,7 +14,7 @@ import {
   cloneDeep,
   defaults,
   readPackageManifest,
-} from '../utils';
+} from '../utils/index.js';
 import type {
   UninstallOptions,
   ShellExecOptions,
@@ -26,7 +26,7 @@ import type {
   AppInfo,
   InstallState,
   StringRecord,
-} from './types';
+} from './types.js';
 
 export const REMOTE_CACHE_ROOT = '/data/local/tmp/appium_cache';
 

--- a/lib/tools/apks-utils.ts
+++ b/lib/tools/apks-utils.ts
@@ -1,12 +1,12 @@
 import {exec} from 'teen_process';
-import {log} from '../logger';
+import {log} from '../logger.js';
 import path from 'node:path';
 import {fs, tempDir, util} from '@appium/support';
 import {LRUCache} from 'lru-cache';
 import AsyncLock from 'async-lock';
-import type {ADB} from '../adb';
-import type {InstallMultipleApksOptions, InstallApksOptions, StringRecord} from './types';
-import {APK_INSTALL_TIMEOUT, buildInstallArgs, getJavaForOs, unzipFile} from '../utils';
+import type {ADB} from '../adb.js';
+import type {InstallMultipleApksOptions, InstallApksOptions, StringRecord} from './types.js';
+import {APK_INSTALL_TIMEOUT, buildInstallArgs, getJavaForOs, unzipFile} from '../utils/index.js';
 
 const BASE_APK = 'base-master.apk';
 const LANGUAGE_APK = (lang: string) => `base-${lang}.apk`;

--- a/lib/tools/app-commands.ts
+++ b/lib/tools/app-commands.ts
@@ -1,10 +1,10 @@
 import {fs, tempDir, util, system} from '@appium/support';
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {waitForCondition} from 'asyncbox';
 import path from 'node:path';
-import type {ADB} from '../adb';
+import type {ADB} from '../adb.js';
 import type {ExecError} from 'teen_process';
-import {defaults, intersectionWith} from '../utils';
+import {defaults, intersectionWith} from '../utils/index.js';
 import type {
   StringRecord,
   InstallState,
@@ -16,7 +16,7 @@ import type {
   PackageActivityInfo,
   ListInstalledPackagesOptions,
   ListInstalledPackagesResult,
-} from './types';
+} from './types.js';
 
 // Constants
 export const APP_INSTALL_STATE: StringRecord<InstallState> = {

--- a/lib/tools/device-settings.ts
+++ b/lib/tools/device-settings.ts
@@ -1,8 +1,8 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {retryInterval} from 'asyncbox';
 import {util} from '@appium/support';
-import type {ADB} from '../adb';
-import type {SetPropOpts} from './types';
+import type {ADB} from '../adb.js';
+import type {SetPropOpts} from './types.js';
 import type {ExecError} from 'teen_process';
 
 const ANIMATION_SCALE_KEYS = [

--- a/lib/tools/emulator-commands.ts
+++ b/lib/tools/emulator-commands.ts
@@ -1,9 +1,9 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import net from 'node:net';
 import {util, fs} from '@appium/support';
 import path from 'node:path';
 import * as ini from 'ini';
-import type {ADB} from '../adb';
+import type {ADB} from '../adb.js';
 import type {
   EmuInfo,
   EmuVersionInfo,
@@ -15,7 +15,7 @@ import type {
   GsmVoiceStates,
   NetworkSpeed,
   ExecTelnetOptions,
-} from './types';
+} from './types.js';
 
 /**
  * Check the emulator state.

--- a/lib/tools/fs-commands.ts
+++ b/lib/tools/fs-commands.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type {ADB} from '../adb';
+import type {ADB} from '../adb.js';
 import type {TeenProcessExecOptions} from 'teen_process';
 
 /**

--- a/lib/tools/general-commands.ts
+++ b/lib/tools/general-commands.ts
@@ -1,9 +1,9 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {fs, util} from '@appium/support';
 import {SubProcess, exec, type ExecError} from 'teen_process';
-import type {ADB} from '../adb';
-import type {ScreenrecordOptions, StringRecord} from './types';
-import {memoize} from '../utils';
+import type {ADB} from '../adb.js';
+import type {ScreenrecordOptions, StringRecord} from './types.js';
+import {memoize} from '../utils/index.js';
 
 /**
  * Get the path to adb executable amd assign it

--- a/lib/tools/keyboard-commands.ts
+++ b/lib/tools/keyboard-commands.ts
@@ -1,7 +1,7 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {sleep, waitForCondition} from 'asyncbox';
-import type {ADB} from '../adb';
-import type {KeyboardState} from './types';
+import type {ADB} from '../adb.js';
+import type {KeyboardState} from './types.js';
 
 const KEYCODE_ESC = 111;
 const KEYCODE_BACK = 4;

--- a/lib/tools/lockmgmt.ts
+++ b/lib/tools/lockmgmt.ts
@@ -1,6 +1,6 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {sleep, waitForCondition} from 'asyncbox';
-import type {ADB} from '../adb';
+import type {ADB} from '../adb.js';
 import {util} from '@appium/support';
 
 const CREDENTIAL_CANNOT_BE_NULL_OR_EMPTY_ERROR = `Credential can't be null or empty`;

--- a/lib/tools/logcat-commands.ts
+++ b/lib/tools/logcat-commands.ts
@@ -1,6 +1,6 @@
-import {Logcat} from '../logcat';
-import type {ADB} from '../adb';
-import type {LogcatOpts, LogEntry, LogcatListener} from './types';
+import {Logcat} from '../logcat.js';
+import type {ADB} from '../adb.js';
+import type {LogcatOpts, LogEntry, LogcatListener} from './types.js';
 
 /**
  * Start the logcat process to gather logs.

--- a/lib/tools/network-commands.ts
+++ b/lib/tools/network-commands.ts
@@ -1,7 +1,7 @@
 import {EOL} from 'node:os';
-import {log} from '../logger';
-import type {ADB} from '../adb';
-import type {PortFamily, PortInfo} from './types';
+import {log} from '../logger.js';
+import type {ADB} from '../adb.js';
+import type {PortFamily, PortInfo} from './types.js';
 
 /**
  * Get TCP port forwarding with adb on the device under test.

--- a/lib/tools/process-commands.ts
+++ b/lib/tools/process-commands.ts
@@ -1,7 +1,7 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {util} from '@appium/support';
 import type {ExecError} from 'teen_process';
-import type {ADB} from '../adb';
+import type {ADB} from '../adb.js';
 
 const PID_COLUMN_TITLE: string = 'PID';
 const PROCESS_NAME_COLUMN_TITLE: string = 'NAME';

--- a/lib/tools/system-calls.ts
+++ b/lib/tools/system-calls.ts
@@ -1,12 +1,18 @@
 import path from 'node:path';
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {system, fs, util, tempDir, timing} from '@appium/support';
 import {exec, SubProcess} from 'teen_process';
 import type {ExecError, TeenProcessExecResult} from 'teen_process';
 import {asyncmap, retry, retryInterval, sleep, waitForCondition} from 'asyncbox';
 import * as semver from 'semver';
-import type {ADB} from '../adb';
-import {DEFAULT_ADB_EXEC_TIMEOUT, cloneDeep, getSdkRootFromEnv, memoize, zip} from '../utils';
+import type {ADB} from '../adb.js';
+import {
+  DEFAULT_ADB_EXEC_TIMEOUT,
+  cloneDeep,
+  getSdkRootFromEnv,
+  memoize,
+  zip,
+} from '../utils/index.js';
 import type {
   ConnectedDevicesOptions,
   Device,
@@ -17,7 +23,7 @@ import type {
   ShellExecOptions,
   SpecialAdbExecOptions,
   ExecResult,
-} from './types';
+} from './types.js';
 
 type AdbExecOptions = ShellExecOptions & SpecialAdbExecOptions;
 

--- a/lib/tools/types.ts
+++ b/lib/tools/types.ts
@@ -1,4 +1,4 @@
-import type * as emuConstants from './emu-constants';
+import type * as emuConstants from './emu-constants.js';
 
 export type StringRecord<T = any> = Record<string, T>;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
-import type {Logcat} from './logcat';
-import type {StringRecord} from './tools/types';
+import type {Logcat} from './logcat.js';
+import type {StringRecord} from './tools/types.js';
 
 export interface ADBOptions {
   sdkRoot?: string;

--- a/lib/utils/helpers/index.ts
+++ b/lib/utils/helpers/index.ts
@@ -3,8 +3,8 @@ export {
   APK_EXTENSION,
   APK_INSTALL_TIMEOUT,
   DEFAULT_ADB_EXEC_TIMEOUT,
-} from './constants';
-export {buildInstallArgs, type BuildInstallArgsOptions} from './install';
-export {readPackageManifest} from './manifest';
-export {getResourcePath, unzipFile} from './resource';
-export {getSdkRootFromEnv, requireSdkRoot, getJavaHome, getJavaForOs} from './sdk';
+} from './constants.js';
+export {buildInstallArgs, type BuildInstallArgsOptions} from './install.js';
+export {readPackageManifest} from './manifest.js';
+export {getResourcePath, unzipFile} from './resource.js';
+export {getSdkRootFromEnv, requireSdkRoot, getJavaHome, getJavaForOs} from './sdk.js';

--- a/lib/utils/helpers/install.ts
+++ b/lib/utils/helpers/install.ts
@@ -1,5 +1,5 @@
 import {util} from '@appium/support';
-import {log} from '../../logger';
+import {log} from '../../logger.js';
 
 export interface BuildInstallArgsOptions {
   replace?: boolean;

--- a/lib/utils/helpers/manifest.ts
+++ b/lib/utils/helpers/manifest.ts
@@ -1,8 +1,8 @@
 import {util} from '@appium/support';
 import {exec, type ExecError} from 'teen_process';
-import {log} from '../../logger';
-import type {ADB} from '../../adb';
-import type {ApkManifest} from '../../tools/types';
+import {log} from '../../logger.js';
+import type {ADB} from '../../adb.js';
+import type {ApkManifest} from '../../tools/types.js';
 
 /**
  * Reads and parses Android manifest metadata from an APK via `aapt2`.

--- a/lib/utils/helpers/resource.ts
+++ b/lib/utils/helpers/resource.ts
@@ -1,10 +1,8 @@
 import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {fs, zip, util} from '@appium/support';
-import {log} from '../../logger';
-import {MODULE_NAME} from './constants';
-
-// Declare __filename for CommonJS compatibility
-declare const __filename: string;
+import {log} from '../../logger.js';
+import {MODULE_NAME} from './constants.js';
 
 export const getResourcePath = util.memoize(async function getResourcePath(
   relPath: string,
@@ -37,7 +35,7 @@ export async function unzipFile(
 }
 
 const getModuleRoot = util.memoize(async function getModuleRoot(): Promise<string> {
-  let moduleRoot = path.dirname(path.resolve(__filename));
+  let moduleRoot = path.dirname(fileURLToPath(import.meta.url));
   let isAtFsRoot = false;
   while (!isAtFsRoot) {
     const manifestPath = path.join(moduleRoot, 'package.json');

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,5 +1,5 @@
-import * as helpers from './helpers';
-import * as lodash from './lodash';
+import * as helpers from './helpers/index.js';
+import * as lodash from './lodash/index.js';
 import {util} from '@appium/support';
 
 export const APKS_EXTENSION = helpers.APKS_EXTENSION;
@@ -22,4 +22,4 @@ export const zip = lodash.zip;
 export const pick = lodash.pick;
 export const defaultsDeep = lodash.defaultsDeep;
 
-export type {BuildInstallArgsOptions} from './helpers';
+export type {BuildInstallArgsOptions} from './helpers/index.js';

--- a/lib/utils/lodash/index.ts
+++ b/lib/utils/lodash/index.ts
@@ -1,1 +1,1 @@
-export * from './core';
+export * from './core.js';

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "rebuild": "npm run clean && npm run build",
     "format": "prettier -w ./lib ./test",
     "format:check": "prettier --check ./lib ./test",
-    "test": "node --test --test-force-exit --test-timeout=60000 \"./build/test/unit/**/*.spec.js\"",
-    "e2e-test": "node --test --test-force-exit --test-concurrency=1 --test-timeout=300000 \"./build/test/functional/**/*.spec.js\""
+    "test": "node --enable-source-maps --test --test-force-exit --test-timeout=60000 \"./build/test/unit/**/*.spec.js\"",
+    "e2e-test": "node --enable-source-maps --test --test-force-exit --test-concurrency=1 --test-timeout=300000 \"./build/test/functional/**/*.spec.js\""
   },
   "repository": {
     "type": "git",
@@ -70,10 +70,19 @@
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.3.1",
+    "esmock": "^2.7.6",
     "prettier": "^3.0.0",
     "semantic-release": "^25.0.2",
     "sinon": "^22.0.0",
     "typescript": "^6.0.2"
   },
-  "types": "./build/lib/index.d.ts"
+  "types": "./build/lib/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  }
 }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {node} from '@appium/support';
 
 /**
@@ -9,5 +10,5 @@ export const APIDEMOS_PKG = 'io.appium.android.apis';
 export const APIDEMOS_ACTIVITY = 'io.appium.android.apis.ApiDemos';
 export const APIDEMOS_ACTIVITY_SHORT = '.ApiDemos';
 
-export const MODULE_ROOT = node.getModuleRootSync('appium-adb', __filename)!;
+export const MODULE_ROOT = node.getModuleRootSync('appium-adb', fileURLToPath(import.meta.url))!;
 export const FIXTURES_ROOT = path.join(MODULE_ROOT, 'test', 'fixtures');

--- a/test/functional/adb-e2e.spec.ts
+++ b/test/functional/adb-e2e.spec.ts
@@ -1,11 +1,11 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import {fs} from '@appium/support';
 import path from 'node:path';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('ADB', function () {
   it('should correctly return adb if present', async function () {

--- a/test/functional/android-manifest-e2e.spec.ts
+++ b/test/functional/android-manifest-e2e.spec.ts
@@ -1,14 +1,14 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import path from 'node:path';
 import {fs, tempDir} from '@appium/support';
-import {APIDEMOS_PKG, APIDEMOS_ACTIVITY_SHORT, getApiDemosPath} from './setup';
-import {getAndroidPlatformAndPath} from '../../lib/tools/android-manifest';
-import chai, {expect} from 'chai';
+import {APIDEMOS_PKG, APIDEMOS_ACTIVITY_SHORT, getApiDemosPath} from './setup.js';
+import {getAndroidPlatformAndPath} from '../../lib/tools/android-manifest.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {readPackageManifest, requireSdkRoot} from '../../lib/utils';
+import {readPackageManifest, requireSdkRoot} from '../../lib/utils/index.js';
 import {describe, it, before, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('Android-manifest', function () {
   let adb: ADB;

--- a/test/functional/apk-signing-e2e.spec.ts
+++ b/test/functional/apk-signing-e2e.spec.ts
@@ -1,14 +1,14 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import path from 'node:path';
 import {fs, tempDir} from '@appium/support';
-import {unsignApk} from '../../lib/tools/apk-signing';
-import {getApiDemosPath} from './setup';
-import {FIXTURES_ROOT} from '../constants';
-import chai, {expect} from 'chai';
+import {unsignApk} from '../../lib/tools/apk-signing.js';
+import {getApiDemosPath} from './setup.js';
+import {FIXTURES_ROOT} from '../constants.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, before, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const keystorePath = path.resolve(FIXTURES_ROOT, 'appiumtest.keystore');
 const keyAlias = 'appiumtest';

--- a/test/functional/apk-utils-e2e.spec.ts
+++ b/test/functional/apk-utils-e2e.spec.ts
@@ -1,6 +1,6 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import {retryInterval} from 'asyncbox';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {
   E2E_TIMEOUT,
@@ -9,10 +9,10 @@ import {
   APIDEMOS_ACTIVITY,
   APIDEMOS_ACTIVITY_SHORT,
   getApiDemosPath,
-} from './setup';
+} from './setup.js';
 import {describe, it, before, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const START_APP_WAIT_DURATION = 60000;
 const START_APP_WAIT_DURATION_FAIL = process.env.CI ? 20000 : 10000;

--- a/test/functional/app-commands-e2e.spec.ts
+++ b/test/functional/app-commands-e2e.spec.ts
@@ -1,11 +1,11 @@
-import {ADB} from '../../lib/adb';
-import {E2E_TIMEOUT, APIDEMOS_PKG, APIDEMOS_ACTIVITY, getApiDemosPath} from './setup';
+import {ADB} from '../../lib/adb.js';
+import {E2E_TIMEOUT, APIDEMOS_PKG, APIDEMOS_ACTIVITY, getApiDemosPath} from './setup.js';
 import {waitForCondition} from 'asyncbox';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, before, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('app commands', {timeout: E2E_TIMEOUT}, function () {
   let adb: ADB;

--- a/test/functional/emulator-commands-e2e.spec.ts
+++ b/test/functional/emulator-commands-e2e.spec.ts
@@ -1,9 +1,9 @@
-import {ADB} from '../../lib/adb';
-import chai, {expect} from 'chai';
+import {ADB} from '../../lib/adb.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, before, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('emulator commands', function () {
   let adb: ADB;

--- a/test/functional/general-commands-e2e.spec.ts
+++ b/test/functional/general-commands-e2e.spec.ts
@@ -1,14 +1,14 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import path from 'node:path';
 import {randomUUID} from 'node:crypto';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {E2E_TIMEOUT, APIDEMOS_PKG, getApiDemosPath} from './setup';
+import {E2E_TIMEOUT, APIDEMOS_PKG, getApiDemosPath} from './setup.js';
 import {fs, tempDir} from '@appium/support';
 import {waitForCondition} from 'asyncbox';
 import {describe, it, before, after, afterEach, beforeEach, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('general commands', {timeout: E2E_TIMEOUT}, function () {
   let adb: ADB;

--- a/test/functional/lock-mgmt-e2e.spec.ts
+++ b/test/functional/lock-mgmt-e2e.spec.ts
@@ -1,9 +1,9 @@
-import {ADB} from '../../lib/adb';
-import chai, {expect} from 'chai';
+import {ADB} from '../../lib/adb.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, before, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('Lock Management', function () {
   let adb: ADB;

--- a/test/functional/logcat-commands-e2e.spec.ts
+++ b/test/functional/logcat-commands-e2e.spec.ts
@@ -1,11 +1,11 @@
-import {ADB} from '../../lib/adb';
-import {Logcat} from '../../lib/logcat';
-import {E2E_TIMEOUT} from './setup';
-import chai, {expect} from 'chai';
+import {ADB} from '../../lib/adb.js';
+import {Logcat} from '../../lib/logcat.js';
+import {E2E_TIMEOUT} from './setup.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, before, afterEach, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('logcat commands', {timeout: E2E_TIMEOUT}, function () {
   async function runClearDeviceLogTest(adb: ADB, logcat: Logcat, clear = true) {

--- a/test/functional/process-commands-e2e.spec.ts
+++ b/test/functional/process-commands-e2e.spec.ts
@@ -1,17 +1,17 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import {
   E2E_TIMEOUT,
   APIDEMOS_PKG,
   APIDEMOS_ACTIVITY,
   getApiDemosPath,
   ensureRootAccess,
-} from './setup';
+} from './setup.js';
 import {waitForCondition} from 'asyncbox';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, before, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('process commands', {timeout: E2E_TIMEOUT}, function () {
   let adb: ADB;

--- a/test/functional/setup.ts
+++ b/test/functional/setup.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
 import {fs, net} from '@appium/support';
-import type {ADB} from '../../lib/adb';
-import {FIXTURES_ROOT} from '../constants';
+import type {ADB} from '../../lib/adb.js';
+import {FIXTURES_ROOT} from '../constants.js';
 export const E2E_TIMEOUT = process.env.CI ? 240000 : 60000;
 export const E2E_LONG_TIMEOUT = E2E_TIMEOUT * 10;
 
 // Re-export ApiDemos constants from common constants file
-export {APIDEMOS_PKG, APIDEMOS_ACTIVITY, APIDEMOS_ACTIVITY_SHORT} from '../constants';
+export {APIDEMOS_PKG, APIDEMOS_ACTIVITY, APIDEMOS_ACTIVITY_SHORT} from '../constants.js';
 
 const APIDEMOS_URL =
   'https://github.com/appium/android-apidemos/releases/download/v6.0.0/ApiDemos-debug.apk';

--- a/test/functional/system-calls-e2e.spec.ts
+++ b/test/functional/system-calls-e2e.spec.ts
@@ -1,13 +1,13 @@
-import {ADB} from '../../lib/adb';
-import {E2E_TIMEOUT, E2E_LONG_TIMEOUT} from './setup';
+import {ADB} from '../../lib/adb.js';
+import {E2E_TIMEOUT, E2E_LONG_TIMEOUT} from './setup.js';
 import path from 'node:path';
 import {fs} from '@appium/support';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {getResourcePath} from '../../lib/utils';
+import {getResourcePath} from '../../lib/utils/index.js';
 import {describe, it, before, type TestContext} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const DEFAULT_CERTIFICATE = path.join('keys', 'testkey.x509.pem');
 const avdName = process.env.ANDROID_AVD || 'Android Emulator';

--- a/test/unit/adb.spec.ts
+++ b/test/unit/adb.spec.ts
@@ -1,9 +1,9 @@
-import {ADB, DEFAULT_ADB_PORT} from '../../lib/adb';
-import chai, {expect} from 'chai';
+import {ADB, DEFAULT_ADB_PORT} from '../../lib/adb.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('ADB', function () {
   describe('clone', function () {

--- a/test/unit/android-manifest.spec.ts
+++ b/test/unit/android-manifest.spec.ts
@@ -1,12 +1,12 @@
-import {getAndroidPlatformAndPath} from '../../lib/tools/android-manifest';
+import {getAndroidPlatformAndPath} from '../../lib/tools/android-manifest.js';
 import sinon from 'sinon';
 import {fs} from '@appium/support';
 import path from 'node:path';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('android manifest', function () {
   let sandbox: sinon.SinonSandbox;

--- a/test/unit/apk-signing.spec.ts
+++ b/test/unit/apk-signing.spec.ts
@@ -1,18 +1,15 @@
-import {ADB} from '../../lib/adb';
 import path from 'node:path';
-import * as teen_process from 'teen_process';
+import esmock from 'esmock';
 import * as appiumSupport from '@appium/support';
 import {zip} from '@appium/support';
 import type {ZipEntry} from '@appium/support';
 import sinon from 'sinon';
-import * as apkSigningHelpers from '../../lib/tools/apk-signing';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import * as helpers from '../../lib/utils';
 import {describe, it, beforeEach, afterEach} from 'node:test';
-import {FIXTURES_ROOT, MODULE_ROOT} from '../constants';
+import {FIXTURES_ROOT, MODULE_ROOT} from '../constants.js';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const keystorePath = path.resolve(FIXTURES_ROOT, 'appiumtest.keystore');
 const keysRoot = path.resolve(MODULE_ROOT, 'keys');
@@ -26,6 +23,27 @@ const apksignerDummyPath = '/path/to/apksigner';
 const tempDir = appiumSupport.tempDir;
 const fs = appiumSupport.fs;
 
+let currentExec: (...args: any[]) => any = async () => ({stdout: '', stderr: ''});
+let currentGetResourcePath: (...args: any[]) => any = async () => '';
+let currentGetJavaForOs: (...args: any[]) => any = async () => javaDummyPath;
+let currentGetJavaHome: (...args: any[]) => any = async () => javaHome;
+
+const {ADB} = await esmock(
+  '../../lib/adb.js',
+  import.meta.url,
+  {},
+  {
+    teen_process: {
+      exec: (...args: any[]) => currentExec(...args),
+    },
+    '../../lib/utils/index.js': {
+      getResourcePath: (...args: any[]) => currentGetResourcePath(...args),
+      getJavaForOs: (...args: any[]) => currentGetJavaForOs(...args),
+      getJavaHome: (...args: any[]) => currentGetJavaHome(...args),
+    },
+  },
+);
+
 const adb = new ADB();
 adb.keystorePath = keystorePath;
 adb.keyAlias = keyAlias;
@@ -35,26 +53,20 @@ adb.keyPassword = password;
 describe('signing', function () {
   let sandbox: sinon.SinonSandbox;
   let mocks: {
-    teen_process: any;
-    helpers: any;
     adb: any;
     appiumSupport: any;
     fs: any;
     tempDir: any;
-    apkSigningHelpers: any;
   };
-  const apiDemosPath = path.resolve(__dirname, '..', 'fixtures', 'ApiDemos-debug.apk');
+  const apiDemosPath = path.resolve(FIXTURES_ROOT, 'ApiDemos-debug.apk');
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
     mocks = {
-      teen_process: sandbox.mock(teen_process),
-      helpers: sandbox.mock(helpers),
       adb: sandbox.mock(adb),
       appiumSupport: sandbox.mock(appiumSupport),
       fs: sandbox.mock(fs),
       tempDir: sandbox.mock(tempDir),
-      apkSigningHelpers: sandbox.mock(apkSigningHelpers),
     };
   });
 
@@ -66,61 +78,41 @@ describe('signing', function () {
   describe('signWithDefaultCert', function () {
     it('should call exec with correct args', async function () {
       mocks.fs.expects('exists').once().withExactArgs(apiDemosPath).returns(true);
-      mocks.helpers
-        .expects('getResourcePath')
-        .once()
-        .withExactArgs(path.join('keys', 'testkey.pk8'))
-        .returns(defaultKeyPath);
-      mocks.helpers
-        .expects('getResourcePath')
-        .once()
-        .withExactArgs(path.join('keys', 'testkey.x509.pem'))
-        .returns(defaultCertPath);
+      const getResourcePathStub = sandbox.stub();
+      getResourcePathStub.withArgs(path.join('keys', 'testkey.pk8')).returns(defaultKeyPath);
+      getResourcePathStub.withArgs(path.join('keys', 'testkey.x509.pem')).returns(defaultCertPath);
+      currentGetResourcePath = getResourcePathStub;
       mocks.adb
         .expects('getBinaryFromSdkRoot')
         .once()
         .withExactArgs('apksigner.jar')
         .returns(apksignerDummyPath);
-      mocks.helpers.expects('getJavaForOs').once().returns(javaDummyPath);
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(javaDummyPath, sinon.match.array)
-            .onFirstCall()
-            .returns({stdout: '', stderr: ''}),
-        );
+      currentGetJavaForOs = sandbox.stub().returns(javaDummyPath);
+      currentExec = sandbox
+        .stub()
+        .withArgs(javaDummyPath, sinon.match.array)
+        .onFirstCall()
+        .returns({stdout: '', stderr: ''});
       await adb.signWithDefaultCert(apiDemosPath);
     });
 
     it('should fail if apksigner fails', async function () {
       mocks.fs.expects('exists').once().withExactArgs(apiDemosPath).returns(true);
-      mocks.helpers
-        .expects('getResourcePath')
-        .once()
-        .withExactArgs(path.join('keys', 'testkey.pk8'))
-        .returns(defaultKeyPath);
-      mocks.helpers
-        .expects('getResourcePath')
-        .once()
-        .withExactArgs(path.join('keys', 'testkey.x509.pem'))
-        .returns(defaultCertPath);
+      const getResourcePathStub = sandbox.stub();
+      getResourcePathStub.withArgs(path.join('keys', 'testkey.pk8')).returns(defaultKeyPath);
+      getResourcePathStub.withArgs(path.join('keys', 'testkey.x509.pem')).returns(defaultCertPath);
+      currentGetResourcePath = getResourcePathStub;
       mocks.adb
         .expects('getBinaryFromSdkRoot')
         .once()
         .withExactArgs('apksigner.jar')
         .returns(apksignerDummyPath);
-      mocks.helpers.expects('getJavaForOs').once().returns(javaDummyPath);
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(javaDummyPath, sinon.match.array)
-            .onFirstCall()
-            .throws(new Error('apksigner failed')),
-        );
+      currentGetJavaForOs = sandbox.stub().returns(javaDummyPath);
+      currentExec = sandbox
+        .stub()
+        .withArgs(javaDummyPath, sinon.match.array)
+        .onFirstCall()
+        .throws(new Error('apksigner failed'));
       await expect(adb.signWithDefaultCert(apiDemosPath)).to.eventually.be.rejected;
     });
 
@@ -142,16 +134,12 @@ describe('signing', function () {
         .once()
         .withExactArgs('apksigner.jar')
         .returns(apksignerDummyPath);
-      mocks.helpers.expects('getJavaForOs').once().returns(javaDummyPath);
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(javaDummyPath, sinon.match.array)
-            .onFirstCall()
-            .returns({stdout: '', stderr: ''}),
-        );
+      currentGetJavaForOs = sandbox.stub().returns(javaDummyPath);
+      currentExec = sandbox
+        .stub()
+        .withArgs(javaDummyPath, sinon.match.array)
+        .onFirstCall()
+        .returns({stdout: '', stderr: ''});
       await adb.signWithCustomCert(apiDemosPath);
     });
 
@@ -169,8 +157,8 @@ describe('signing', function () {
         .once()
         .withExactArgs('apksigner.jar')
         .returns(apksignerDummyPath);
-      mocks.helpers.expects('getJavaForOs').once().returns(javaDummyPath);
-      mocks.helpers.expects('getJavaHome').once().returns(javaHome);
+      currentGetJavaForOs = sandbox.stub().returns(javaDummyPath);
+      currentGetJavaHome = sandbox.stub().returns(javaHome);
       innerExecStub = sandbox.stub();
       innerExecStub.withArgs(javaDummyPath).throws(new Error('apksigner failed'));
       innerExecStub
@@ -189,7 +177,7 @@ describe('signing', function () {
           keyAlias,
         ])
         .returns({});
-      sandbox.stub(teen_process, 'exec').get(() => innerExecStub);
+      currentExec = innerExecStub;
       // Mock zip.readEntries to indicate no META-INF (so unsignApk returns false)
       /* eslint-disable promise/prefer-await-to-callbacks -- zip.readEntries is callback-based */
       sandbox.stub(zip, 'readEntries').callsFake(async (apkPath, callback) => {
@@ -221,15 +209,11 @@ describe('signing', function () {
         .once()
         .withExactArgs(path.dirname(alignedApk))
         .returns({});
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(adb.binaries!.zipalign, ['-f', '4', apiDemosPath, alignedApk])
-            .onFirstCall()
-            .returns({}),
-        );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.binaries!.zipalign, ['-f', '4', apiDemosPath, alignedApk])
+        .onFirstCall()
+        .returns({});
       mocks.fs
         .expects('mv')
         .once()
@@ -259,21 +243,19 @@ describe('signing', function () {
         .twice()
         .withExactArgs('apksigner.jar')
         .returns(apksignerDummyPath);
-      mocks.helpers.expects('getJavaForOs').once().returns(javaDummyPath);
-      sandbox.stub(teen_process, 'exec').get(() =>
-        sandbox
-          .stub()
-          .withArgs(javaDummyPath, sinon.match.array)
-          .onFirstCall()
-          .returns({
-            stdout: `
+      currentGetJavaForOs = sandbox.stub().returns(javaDummyPath);
+      currentExec = sandbox
+        .stub()
+        .withArgs(javaDummyPath, sinon.match.array)
+        .onFirstCall()
+        .returns({
+          stdout: `
       Signer #1 certificate DN: EMAILADDRESS=android@android.com, CN=Android, OU=Android, O=Android, L=Mountain View, ST=California, C=US
       Signer #1 certificate SHA-256 digest: a40da80a59d170caa950cf15c18c454d47a39b26989d8b640ecd745ba71bf5dc
       Signer #1 certificate SHA-1 digest: 61ed377e85d386a8dfee6b864bd85b0bfaa5af81
       Signer #1 certificate MD5 digest: e89b158e4bcf988ebd09eb83f5378e87`,
-            stderr: '',
-          }),
-      );
+          stderr: '',
+        });
       expect(await adb.checkApkCert(apiDemosPath)).to.be.true;
     });
 
@@ -291,21 +273,19 @@ describe('signing', function () {
         .twice()
         .withExactArgs('apksigner.jar')
         .returns(apksignerDummyPath);
-      mocks.helpers.expects('getJavaForOs').once().returns(javaDummyPath);
-      sandbox.stub(teen_process, 'exec').get(() =>
-        sandbox
-          .stub()
-          .withArgs(javaDummyPath, sinon.match.array)
-          .onFirstCall()
-          .returns({
-            stdout: `
+      currentGetJavaForOs = sandbox.stub().returns(javaDummyPath);
+      currentExec = sandbox
+        .stub()
+        .withArgs(javaDummyPath, sinon.match.array)
+        .onFirstCall()
+        .returns({
+          stdout: `
       Signer #1 certificate DN: EMAILADDRESS=android@android.com, CN=Android, OU=Android, O=Android, L=Mountain View, ST=California, C=US
       Signer #1 certificate SHA-256 digest: a40da80a59d170caa950cf15cccccc4d47a39b26989d8b640ecd745ba71bf5dc
       Signer #1 certificate SHA-1 digest: 61ed377e85d386a8dfee6b864bdcccccfaa5af81
       Signer #1 certificate MD5 digest: e89b158e4bcf988ebd09eb83f53ccccc`,
-            stderr: '',
-          }),
-      );
+          stderr: '',
+        });
       const result = await adb.checkApkCert(apiDemosPath, {
         requireDefaultCert: false,
       });
@@ -348,21 +328,19 @@ describe('signing', function () {
         .twice()
         .withExactArgs('apksigner.jar')
         .returns(apksignerDummyPath);
-      mocks.helpers.expects('getJavaForOs').once().returns(javaDummyPath);
-      sandbox.stub(teen_process, 'exec').get(() =>
-        sandbox
-          .stub()
-          .withArgs(javaDummyPath, sinon.match.array)
-          .onFirstCall()
-          .returns({
-            stdout: `
+      currentGetJavaForOs = sandbox.stub().returns(javaDummyPath);
+      currentExec = sandbox
+        .stub()
+        .withArgs(javaDummyPath, sinon.match.array)
+        .onFirstCall()
+        .returns({
+          stdout: `
       Signer #1 certificate DN: EMAILADDRESS=android@android.com, CN=Android, OU=Android, O=Android, L=Mountain View, ST=California, C=US
       Signer #1 certificate SHA-256 digest: a40da80a59d170caa950cf15cccccc4d47a39b26989d8b640ecd745ba71bf5dc
       Signer #1 certificate SHA-1 digest: 61ed377e85d386a8dfee6b864bdcccccfaa5af81
       Signer #1 certificate MD5 digest: e89b158e4bcf988ebd09eb83f53ccccc`,
-            stderr: '',
-          }),
-      );
+          stderr: '',
+        });
       await expect(adb.checkApkCert(apiDemosPath)).to.eventually.be.true;
     });
   });

--- a/test/unit/apk-utils.spec.ts
+++ b/test/unit/apk-utils.spec.ts
@@ -1,14 +1,14 @@
 import * as teen_process from 'teen_process';
 import {fs} from '@appium/support';
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import sinon from 'sinon';
-import {REMOTE_CACHE_ROOT} from '../../lib/tools/apk-utils';
-import * as apksUtilsMethods from '../../lib/tools/apks-utils';
-import chai, {expect} from 'chai';
+import {REMOTE_CACHE_ROOT} from '../../lib/tools/apk-utils.js';
+import * as apksUtilsMethods from '../../lib/tools/apks-utils.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const pkg = 'com.example.android.contactmanager',
   uri = 'content://contacts/people/1',

--- a/test/unit/app-commands.spec.ts
+++ b/test/unit/app-commands.spec.ts
@@ -1,6 +1,6 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import net from 'node:net';
-import {Logcat} from '../../lib/logcat';
+import {Logcat} from '../../lib/logcat.js';
 import * as teen_process from 'teen_process';
 import sinon from 'sinon';
 import {
@@ -9,16 +9,16 @@ import {
   buildStartCmd,
   extractMatchingPermissions,
   assertSafeComponentName,
-} from '../../lib/tools/app-commands';
-import {getBuildToolsDirs} from '../../lib/tools/system-calls';
-import {parseAapt2Strings, parseAaptStrings} from '../../lib/tools/apk-utils';
+} from '../../lib/tools/app-commands.js';
+import {getBuildToolsDirs} from '../../lib/tools/system-calls.js';
+import {parseAapt2Strings, parseAaptStrings} from '../../lib/tools/apk-utils.js';
 import {fs} from '@appium/support';
-import {APIDEMOS_PKG, APIDEMOS_ACTIVITY_SHORT} from '../constants';
-import chai, {expect} from 'chai';
+import {APIDEMOS_PKG, APIDEMOS_ACTIVITY_SHORT} from '../constants.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const apiDemosPackage = APIDEMOS_PKG;
 

--- a/test/unit/emulator-commands.spec.ts
+++ b/test/unit/emulator-commands.spec.ts
@@ -1,10 +1,10 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import sinon from 'sinon';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const emulators = [
   {udid: 'emulator-5554', state: 'device', port: 5554},

--- a/test/unit/general-commands.spec.ts
+++ b/test/unit/general-commands.spec.ts
@@ -1,15 +1,15 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import net from 'node:net';
-import {Logcat} from '../../lib/logcat';
+import {Logcat} from '../../lib/logcat.js';
 import * as teen_process from 'teen_process';
 import sinon from 'sinon';
 import {EOL} from 'node:os';
-import {APIDEMOS_PKG} from '../constants';
-import chai, {expect} from 'chai';
+import {APIDEMOS_PKG} from '../constants.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const apiLevel = 21,
   platformVersion = '4.4.4',

--- a/test/unit/lockmgmt.spec.ts
+++ b/test/unit/lockmgmt.spec.ts
@@ -1,10 +1,10 @@
-import {isShowingLockscreen, isScreenStateOff} from '../../lib/tools/lockmgmt';
+import {isShowingLockscreen, isScreenStateOff} from '../../lib/tools/lockmgmt.js';
 import sinon from 'sinon';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('lock management', function () {
   let sandbox: sinon.SinonSandbox;

--- a/test/unit/logcat-commands.spec.ts
+++ b/test/unit/logcat-commands.spec.ts
@@ -1,12 +1,26 @@
-import * as teen_process from 'teen_process';
 import events from 'node:events';
-import {Logcat} from '../../lib/logcat';
+import esmock from 'esmock';
 import sinon from 'sinon';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
+
+let currentExec: (...args: any[]) => any = async () => ({stdout: '', stderr: ''});
+let currentSubProcess: (...args: any[]) => any = () => ({});
+
+// Must remain a real `function` (not a method/arrow) since logcat.ts invokes it with `new`.
+function SubProcessMock(...args: any[]) {
+  return currentSubProcess(...args);
+}
+
+const {Logcat} = await esmock('../../lib/logcat.js', import.meta.url, {
+  teen_process: {
+    exec: (...args: any[]) => currentExec(...args),
+    SubProcess: SubProcessMock,
+  },
+});
 
 describe('logcat commands', function () {
   let sandbox: sinon.SinonSandbox;
@@ -26,15 +40,11 @@ describe('logcat commands', function () {
     it('should correctly call subprocess and should resolve promise', async function () {
       const conn = new events.EventEmitter();
       (conn as any).start = () => {};
-      sandbox
-        .stub(teen_process, 'SubProcess')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs('dummyPath', ['logcat', '-v', 'brief', 'yolo2:d', '*:v'])
-            .onFirstCall()
-            .returns(conn),
-        );
+      currentSubProcess = sandbox
+        .stub()
+        .withArgs('dummyPath', ['logcat', '-v', 'brief', 'yolo2:d', '*:v'])
+        .onFirstCall()
+        .returns(conn);
       setTimeout(function () {
         conn.emit('line-stdout', '- beginning of system\r');
       }, 0);
@@ -48,15 +58,11 @@ describe('logcat commands', function () {
     it('should correctly call subprocess and should reject promise', async function () {
       const conn = new events.EventEmitter();
       (conn as any).start = () => {};
-      sandbox
-        .stub(teen_process, 'SubProcess')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs('dummyPath', ['logcat', '-v', 'threadtime'])
-            .onFirstCall()
-            .returns(conn),
-        );
+      currentSubProcess = sandbox
+        .stub()
+        .withArgs('dummyPath', ['logcat', '-v', 'threadtime'])
+        .onFirstCall()
+        .returns(conn);
       setTimeout(function () {
         conn.emit('line-stderr', 'execvp()');
       }, 0);
@@ -65,15 +71,11 @@ describe('logcat commands', function () {
     it('should correctly call subprocess and should resolve promise if it fails on startup', async function () {
       const conn = new events.EventEmitter();
       (conn as any).start = () => {};
-      sandbox
-        .stub(teen_process, 'SubProcess')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs('dummyPath', ['logcat', '-v', 'threadtime'])
-            .onFirstCall()
-            .returns(conn),
-        );
+      currentSubProcess = sandbox
+        .stub()
+        .withArgs('dummyPath', ['logcat', '-v', 'threadtime'])
+        .onFirstCall()
+        .returns(conn);
       setTimeout(function () {
         conn.emit('line-stderr', 'something');
       }, 0);
@@ -83,22 +85,18 @@ describe('logcat commands', function () {
 
   describe('clear', function () {
     it('should call logcat clear', async function () {
-      sandbox.stub(teen_process, 'exec').get(() =>
-        sandbox
-          .stub()
-          .withArgs(adb.path, [...adb.defaultArgs, 'logcat', '-c'])
-          .onFirstCall(),
-      );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.path, [...adb.defaultArgs, 'logcat', '-c'])
+        .onFirstCall();
       await logcat.clear();
     });
     it('should not fail if logcat clear fails', async function () {
-      sandbox.stub(teen_process, 'exec').get(() =>
-        sandbox
-          .stub()
-          .withArgs(adb.path, [...adb.defaultArgs, 'logcat', '-c'])
-          .onFirstCall()
-          .throws('Failed to clear'),
-      );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.path, [...adb.defaultArgs, 'logcat', '-c'])
+        .onFirstCall()
+        .throws('Failed to clear');
       await expect(logcat.clear()).to.eventually.not.be.rejected;
     });
   });

--- a/test/unit/process-commands.spec.ts
+++ b/test/unit/process-commands.spec.ts
@@ -1,14 +1,14 @@
-import {ADB} from '../../lib/adb';
+import {ADB} from '../../lib/adb.js';
 import net from 'node:net';
-import {Logcat} from '../../lib/logcat';
+import {Logcat} from '../../lib/logcat.js';
 import * as teen_process from 'teen_process';
 import sinon from 'sinon';
-import {APIDEMOS_PKG} from '../constants';
-import chai, {expect} from 'chai';
+import {APIDEMOS_PKG} from '../constants.js';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const apiDemosPackage = APIDEMOS_PKG;
 

--- a/test/unit/system-calls.spec.ts
+++ b/test/unit/system-calls.spec.ts
@@ -1,12 +1,34 @@
-import {ADB} from '../../lib/adb';
 import * as teen_process from 'teen_process';
+import esmock from 'esmock';
 import sinon from 'sinon';
-import chai, {expect} from 'chai';
+import {use, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import * as asyncbox from 'asyncbox';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
+
+let currentExec: (...args: any[]) => any = async () => ({stdout: '', stderr: '', code: 0});
+let currentSleep: (...args: any[]) => any = async () => {};
+let currentRetryInterval: (...args: any[]) => any = async (
+  _retries: number,
+  _interval: number,
+  fn: () => any,
+) => fn();
+
+const {ADB} = await esmock(
+  '../../lib/adb.js',
+  import.meta.url,
+  {},
+  {
+    teen_process: {
+      exec: (...args: any[]) => currentExec(...args),
+    },
+    asyncbox: {
+      sleep: (...args: any[]) => currentSleep(...args),
+      retryInterval: (...args: any[]) => currentRetryInterval(...args),
+    },
+  },
+);
 
 const adb = new ADB();
 adb.executable.path = 'adb_path';
@@ -26,15 +48,11 @@ describe('system calls', function () {
 
   describe('getConnectedDevices', function () {
     it('should get all connected devices', async function () {
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
-            .onFirstCall()
-            .returns({stdout: 'List of devices attached \n emulator-5554	device'}),
-        );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
+        .onFirstCall()
+        .returns({stdout: 'List of devices attached \n emulator-5554	device'});
       const devices = await adb.getConnectedDevices();
       expect(devices).to.have.length.above(0);
       expect(devices).to.deep.equal([{udid: 'emulator-5554', state: 'device'}]);
@@ -45,43 +63,33 @@ describe('system calls', function () {
         "adb server version (32) doesn't match this client (36); killing...\n" +
         '* daemon started successfully *\n' +
         'emulator-5554	device';
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
-            .onFirstCall()
-            .returns({stdout: stdoutValue}),
-        );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
+        .onFirstCall()
+        .returns({stdout: stdoutValue});
       const devices = await adb.getConnectedDevices();
       expect(devices).to.have.length.above(0);
     });
     it('should fail when adb devices returns unexpected output', async function () {
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
-            .onFirstCall()
-            .returns({stdout: 'foobar'}),
-        );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
+        .onFirstCall()
+        .returns({stdout: 'foobar'});
       await expect(adb.getConnectedDevices()).to.eventually.be.rejectedWith(
         'Unexpected output while trying to get devices',
       );
     });
     it('should get all connected devices with verbose output', async function () {
-      sandbox.stub(teen_process, 'exec').get(() =>
-        sandbox
-          .stub()
-          .withArgs(adb.executable.path, ['-P', '5037', 'devices', '-l'])
-          .onFirstCall()
-          .returns({
-            stdout:
-              'List of devices attached \nemulator-5556 device product:sdk_google_phone_x86_64 model:Android_SDK_built_for_x86_64 device:generic_x86_64\n0a388e93      device usb:1-1 product:razor model:Nexus_7 device:flo',
-          }),
-      );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.executable.path, ['-P', '5037', 'devices', '-l'])
+        .onFirstCall()
+        .returns({
+          stdout:
+            'List of devices attached \nemulator-5556 device product:sdk_google_phone_x86_64 model:Android_SDK_built_for_x86_64 device:generic_x86_64\n0a388e93      device usb:1-1 product:razor model:Nexus_7 device:flo',
+        });
       const devices = await adb.getConnectedDevices({verbose: true});
       expect(devices).to.have.length.above(0);
       expect(devices).to.deep.equal([
@@ -117,17 +125,17 @@ describe('system calls', function () {
       const innerStubThree = execStub
         .withArgs(adb.executable.path, ['-P', '5037', 'kill-server'], sinon.match.object)
         .resolves();
-      sandbox.stub(teen_process, 'exec').get(() => {
+      currentExec = (...args: any[]) => {
         if (stubCurrent === 0) {
           stubCurrent++;
-          return innerStubOne;
+          return innerStubOne(...args);
         } else if (stubCurrent === 1) {
           stubCurrent++;
-          return innerStubTwo;
+          return innerStubTwo(...args);
         }
         stubCurrent = 0;
-        return innerStubThree;
-      });
+        return innerStubThree(...args);
+      };
       await expect(adb.getDevicesWithRetry(1000)).to.eventually.be.rejectedWith(
         /Could not find a connected Android device/,
       );
@@ -148,17 +156,17 @@ describe('system calls', function () {
       const innerStubThree = execStub
         .withArgs(adb.executable.path, ['-P', '5037', 'kill-server'], sinon.match.object)
         .resolves();
-      sandbox.stub(teen_process, 'exec').get(() => {
+      currentExec = (...args: any[]) => {
         if (stubCurrent === 0) {
           stubCurrent++;
-          return innerStubOne;
+          return innerStubOne(...args);
         } else if (stubCurrent === 1) {
           stubCurrent++;
-          return innerStubTwo;
+          return innerStubTwo(...args);
         }
         stubCurrent = 0;
-        return innerStubThree;
-      });
+        return innerStubThree(...args);
+      };
       await expect(adb.getDevicesWithRetry(1000)).to.eventually.be.rejectedWith(
         /Could not find a connected Android device/,
       );
@@ -167,15 +175,11 @@ describe('system calls', function () {
       expect(innerStubThree.callCount).to.be.at.least(2);
     });
     it('should get all connected devices', async function () {
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox
-            .stub()
-            .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
-            .onFirstCall()
-            .returns({stdout: 'List of devices attached \n emulator-5554	device'}),
-        );
+      currentExec = sandbox
+        .stub()
+        .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
+        .onFirstCall()
+        .returns({stdout: 'List of devices attached \n emulator-5554	device'});
       const devices = await adb.getDevicesWithRetry(1000);
       expect(devices).to.have.length.above(0);
     });
@@ -197,20 +201,20 @@ describe('system calls', function () {
       const innerStubFour = execStub
         .withArgs(adb.executable.path, ['-P', '5037', 'devices'])
         .resolves({stdout: 'List of devices attached \n emulator-5554	device', stderr: '', code: 0});
-      sandbox.stub(teen_process, 'exec').get(() => {
+      currentExec = (...args: any[]) => {
         if (stubCurrent === 0) {
           stubCurrent++;
-          return innerStubOne;
+          return innerStubOne(...args);
         } else if (stubCurrent === 1) {
           stubCurrent++;
-          return innerStubTwo;
+          return innerStubTwo(...args);
         } else if (stubCurrent === 2) {
           stubCurrent++;
-          return innerStubThree;
+          return innerStubThree(...args);
         }
         stubCurrent = 3;
-        return innerStubFour;
-      });
+        return innerStubFour(...args);
+      };
       const devices = await adb.getDevicesWithRetry(2000);
       expect(devices).to.have.length.above(0);
       // '.withArgs(adb.executable.path, ['-P', '5037', 'devices'])' was called twice in total
@@ -221,7 +225,7 @@ describe('system calls', function () {
     });
     it('should fail when exec throws an error', async function () {
       const innerStub = sandbox.stub().throws(new Error('Error foobar'));
-      sandbox.stub(teen_process, 'exec').get(() => innerStub);
+      currentExec = (...args: any[]) => innerStub(...args);
 
       await expect(adb.getDevicesWithRetry(1000)).to.eventually.be.rejectedWith(
         /Could not find a connected Android device/,
@@ -258,16 +262,16 @@ describe('system calls', function () {
 
 describe('System calls 2', function () {
   let sandbox: sinon.SinonSandbox;
-  let mocks: {adb: any; teen_process: any};
+  let mocks: {adb: any};
   let sleepStub: sinon.SinonStub;
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
-    sandbox.stub(asyncbox, 'retryInterval').callsFake(async (retries, interval, fn) => fn());
-    sleepStub = sandbox.stub(asyncbox, 'sleep').resolves();
+    currentRetryInterval = sandbox.stub().callsFake(async (retries, interval, fn) => fn());
+    sleepStub = sandbox.stub().resolves();
+    currentSleep = sleepStub;
     mocks = {
       adb: sandbox.mock(adb),
-      teen_process: sandbox.mock(teen_process),
     };
   });
 
@@ -311,11 +315,10 @@ describe('System calls 2', function () {
   });
   describe('shell outputFormat option', function () {
     beforeEach(function () {
-      sandbox
-        .stub(teen_process, 'exec')
-        .get(() =>
-          sandbox.stub().onFirstCall().returns({stdout: 'a value', stderr: 'an error', code: 0}),
-        );
+      currentExec = sandbox
+        .stub()
+        .onFirstCall()
+        .returns({stdout: 'a value', stderr: 'an error', code: 0});
     });
     it('should default to stdout', async function () {
       const output = await adb.shell(['command']);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "checkJs": true,
     "esModuleInterop": true,
     "types": ["node"],
-    "strict": true
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": ["lib", "test"]
 }


### PR DESCRIPTION
## Summary

- Add "type": "module" and an exports map to package.json; keep main/types for compatibility.
- Explicitly set "module": "NodeNext" / "moduleResolution": "NodeNext" in tsconfig.json.
- Add .js extensions to all relative imports across lib/ and test/ (required by Node ESM resolution); fix directory-style imports (./utils → ./utils/index.js, etc.).
- Replace __filename/__dirname usage with fileURLToPath(import.meta.url).
- Update chai usage for v6's real-ESM, no-default-export shape (import chai from 'chai' → import {use} from 'chai').
- Add esmock as a dev dependency and rework the three unit test files that stubbed local/CJS namespace imports via Sinon (system-calls.spec.ts, apk-signing.spec.ts, logcat-commands.spec.ts), since real ES module namespaces can't be mutated directly.
- Add --enable-source-maps to the test/e2e-test scripts.

BREAKING CHANGE: Consumers using require('appium-adb') must switch to import/dynamic import() — the package no longer ships a CommonJS entry point.
